### PR TITLE
Remove inspector comments from wind mitigation reports

### DIFF
--- a/src/components/reports/WindMitigationEditor.tsx
+++ b/src/components/reports/WindMitigationEditor.tsx
@@ -30,7 +30,6 @@ const WindMitigationEditor: React.FC<WindMitigationEditorProps> = ({report, onUp
             "5_roof_geometry": {},
             "6_secondary_water_resistance": {},
             "7_opening_protection": {},
-            inspectorComments: ""
         },
     });
 

--- a/src/hooks/useLocalDraft.ts
+++ b/src/hooks/useLocalDraft.ts
@@ -108,7 +108,6 @@ export function createReport(meta: {
         "5_roof_geometry": {},
         "6_secondary_water_resistance": {},
         "7_opening_protection": {},
-        inspectorComments: "",
       },
     };
   }

--- a/src/integrations/supabase/reportsApi.ts
+++ b/src/integrations/supabase/reportsApi.ts
@@ -74,7 +74,6 @@ function fromDbRow(row: any): Report {
       "5_roof_geometry": {},
       "6_secondary_water_resistance": {},
       "7_opening_protection": {},
-      inspectorComments: "",
     };
   }
   
@@ -168,7 +167,6 @@ export async function dbCreateReport(meta: {
         "5_roof_geometry": {},
         "6_secondary_water_resistance": {},
         "7_opening_protection": {},
-        inspectorComments: "",
       },
     };
   }

--- a/src/lib/reportSchemas.ts
+++ b/src/lib/reportSchemas.ts
@@ -107,8 +107,6 @@ export const WindMitigationDataSchema = z.object({
         glazedOverall: z.string().optional(),
         nonGlazedSubclass: z.string().optional()
     }).optional().default({}),
-
-    inspectorComments: z.string().optional().default(""),
 });
 
 // Wind Mitigation Report Schema

--- a/src/lib/windMitigationFieldMap.ts
+++ b/src/lib/windMitigationFieldMap.ts
@@ -60,6 +60,4 @@ export const WIND_MITIGATION_FIELD_MAP: Record<string, string> = {
     "reportData.7_opening_protection.openingProtection.entry_doors_non_glazed": "oplB2",
     "reportData.7_opening_protection.openingProtection.garage_doors_non_glazed": "oplB3",
 
-    // --- Inspector Comments ---
-    "reportData.inspectorComments": "Inspector Comments",
 };


### PR DESCRIPTION
## Summary
- drop `inspectorComments` from wind mitigation field map, schema, and defaults
- update editor, local draft, and Supabase API to stop expecting inspector comments

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 170 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f63b6d708333ab4ab82faf5a8136