### PR TITLE
fix: normalize opening protection data

### DIFF
--- a/src/integrations/supabase/reportsApi.ts
+++ b/src/integrations/supabase/reportsApi.ts
@@ -75,6 +75,27 @@ function fromDbRow(row: any): Report {
       "6_secondary_water_resistance": {},
       "7_opening_protection": {},
     };
+
+    // Normalize opening protection data - older reports may store single string values
+    const openingProtection =
+      base.reportData?.["7_opening_protection"]?.openingProtection;
+    if (openingProtection && typeof openingProtection === "object") {
+      for (const key of Object.keys(openingProtection)) {
+        const value = openingProtection[key];
+        if (typeof value === "string") {
+          openingProtection[key] = {
+            NA: false,
+            A: false,
+            B: false,
+            C: false,
+            D: false,
+            N: false,
+            X: false,
+            [value]: true,
+          };
+        }
+      }
+    }
   }
   
   const parsed = ReportSchema.safeParse(base);


### PR DESCRIPTION
## Summary
- normalize wind mitigation opening protection data from legacy string values

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5fb32cf7c8333a53656c8a940a429