### PR TITLE
Surface field mapping mismatches after PDF form load

### DIFF
--- a/src/utils/fillWindMitigationPDF.ts
+++ b/src/utils/fillWindMitigationPDF.ts
@@ -60,6 +60,9 @@ export async function fillWindMitigationPDF(report: any): Promise<Blob> {
     const form = pdfDoc.getForm();
     console.log("📄 Available PDF fields:", form.getFields().map((f: any) => f.getName()));
 
+    // Surface mapping/debug information as soon as the form is loaded
+    debugFieldMapping(report, form);
+
     // console.log("📋 All PDF fields and current values:");
     // form.getFields().forEach((field) => {
     //     const name = field.getName();
@@ -92,8 +95,6 @@ export async function fillWindMitigationPDF(report: any): Promise<Blob> {
 
     console.log("🔑 Data to map:", dataToMap);
     console.log("🔑 Flattened data keys:", Object.keys(dataToMap));
-
-    debugFieldMapping(dataToMap, form);
 
     // 🔎 Debug: show what's being flattened vs mapped
     const unmappedKeys = Object.keys(dataToMap).filter(


### PR DESCRIPTION
## Summary
- call `debugFieldMapping` in `fillWindMitigationPDF` immediately after loading the form to surface data and mapping inconsistencies

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a61c2a5a18833382a9971bff95e37d