### PR TITLE
feat: parse addresses for wind mitigation PDFs

### DIFF
--- a/src/lib/windMitigationFieldMap.ts
+++ b/src/lib/windMitigationFieldMap.ts
@@ -2,7 +2,9 @@
 export const WIND_MITIGATION_FIELD_MAP: Record<string, string> = {
     // --- Owner Info ---
     clientName: "Owner Name",
-    address: "Address",
+    street: "Address",
+    city: "City",
+    zip: "zipCode",
     phoneHome: "Home Phone",
     phoneWork: "Work Phone",
     phoneCell: "Cell Phone",

--- a/src/utils/fillWindMitigationPDF.ts
+++ b/src/utils/fillWindMitigationPDF.ts
@@ -9,6 +9,13 @@ const MANUALLY_HANDLED_KEY_PREFIXES = [
     "reportData.1_building_code",
 ];
 
+function parseAddress(full: string): {street: string; city: string; state: string; zip: string} {
+    const [street = "", city = "", stateZip = ""] =
+        (full || "").split(",").map((p) => p.trim());
+    const [state = "", zip = ""] = stateZip.split(/\s+/);
+    return {street, city, state, zip};
+}
+
 function flattenObject(obj: any, prefix = ""): Record<string, any> {
     if (!obj || typeof obj !== "object") {
         return {}; // nothing to flatten
@@ -96,10 +103,16 @@ export async function fillWindMitigationPDF(report: any): Promise<Blob> {
     // });
 
     // Create a data object that includes both report properties and flattened reportData
+    const {street, city, zip} = parseAddress(report.address || "");
+
     const dataToMap = {
         clientName: report.clientName,
-        address: report.address,
-        inspectionDate: report.inspectionDate ? new Date(report.inspectionDate).toLocaleDateString() : '',
+        street,
+        city,
+        zip,
+        inspectionDate: report.inspectionDate
+            ? new Date(report.inspectionDate).toLocaleDateString()
+            : '',
 
         ...flattenObject(report.reportData || {}, "reportData")
     };


### PR DESCRIPTION
## Summary
- parse addresses into street, city, state and zip
- include city and zip in wind mitigation PDF mapping

## Testing
- `npm run lint` *(fails: 168 problems (151 errors, 17 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a62902c020833393c3114a501ca498