### PR TITLE
feat: capture wind mitigation contact details

### DIFF
--- a/src/components/contacts/ContactLookup.tsx
+++ b/src/components/contacts/ContactLookup.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { contactsApi } from "@/integrations/supabase/crmApi";
+import { useAuth } from "@/contexts/AuthContext";
+
+interface ContactLookupProps {
+  value?: string;
+  onChange: (id: string, contact?: any) => void;
+}
+
+export const ContactLookup: React.FC<ContactLookupProps> = ({ value, onChange }) => {
+  const { user } = useAuth();
+  const nav = useNavigate();
+
+  const { data: contacts = [] } = useQuery({
+    queryKey: ["contacts", user?.id],
+    queryFn: () => contactsApi.list(user!.id),
+    enabled: !!user,
+  });
+
+  return (
+    <Select
+      value={value}
+      onValueChange={(contactId) => {
+        if (contactId === "add-new") {
+          nav("/contacts/new");
+          return;
+        }
+        const selectedContact = contacts.find((c: any) => c.id === contactId);
+        onChange(contactId, selectedContact);
+      }}
+    >
+      <SelectTrigger>
+        <SelectValue placeholder="Select a contact or add new...">
+          {value && contacts.length > 0 ? (() => {
+            const contact = contacts.find((c: any) => c.id === value);
+            return contact ? `${contact.first_name} ${contact.last_name}` : value;
+          })() : "Select a contact or add new..."}
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="add-new" className="font-medium text-primary">
+          + Add New Contact
+        </SelectItem>
+        {contacts.map((contact: any) => (
+          <SelectItem key={contact.id} value={contact.id}>
+            {contact.first_name} {contact.last_name}
+            {contact.email && (
+              <span className="text-muted-foreground ml-2">({contact.email})</span>
+            )}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+};
+
+export default ContactLookup;

--- a/src/integrations/supabase/reportsApi.ts
+++ b/src/integrations/supabase/reportsApi.ts
@@ -25,7 +25,14 @@ function toDbPayload(report: Report) {
     cover_image: report.coverImage || null,
     preview_template: report.previewTemplate || 'classic',
     report_type: report.reportType,
-    report_data: report.reportType === "wind_mitigation" ? report.reportData : null,  };
+    report_data: report.reportType === "wind_mitigation" ? report.reportData : null,
+    phone_home: (report as any).phoneHome || null,
+    phone_work: (report as any).phoneWork || null,
+    phone_cell: (report as any).phoneCell || null,
+    insurance_company: (report as any).insuranceCompany || null,
+    policy_number: (report as any).policyNumber || null,
+    email: (report as any).email || null,
+  };
 }
 
 function fromDbRow(row: any): Report {
@@ -43,6 +50,12 @@ function fromDbRow(row: any): Report {
     previewTemplate: row.preview_template || "classic",
     reportData: row.report_data ?? {},
     reportType,
+    phoneHome: row.phone_home || "",
+    phoneWork: row.phone_work || "",
+    phoneCell: row.phone_cell || "",
+    insuranceCompany: row.insurance_company || "",
+    policyNumber: row.policy_number || "",
+    email: row.email || "",
   };
 
   if (reportType === "home_inspection") {
@@ -141,6 +154,12 @@ export async function dbCreateReport(meta: {
   inspectionDate: string; // 'YYYY-MM-DD' or ISO
   contact_id?: string;
   reportType: "home_inspection" | "wind_mitigation";
+  phoneHome?: string;
+  phoneWork?: string;
+  phoneCell?: string;
+  insuranceCompany?: string;
+  policyNumber?: string;
+  email?: string;
 }, userId: string, organizationId?: string): Promise<Report> {
   const id = crypto.randomUUID();
 
@@ -180,6 +199,12 @@ export async function dbCreateReport(meta: {
       coverImage: "",
       previewTemplate: "classic",
       reportType: "wind_mitigation",
+      phoneHome: meta.phoneHome || "",
+      phoneWork: meta.phoneWork || "",
+      phoneCell: meta.phoneCell || "",
+      insuranceCompany: meta.insuranceCompany || "",
+      policyNumber: meta.policyNumber || "",
+      email: meta.email || "",
       reportData: {
         "1_building_code": {},
         "2_roof_covering": {},

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -503,6 +503,12 @@ export type Database = {
           inspection_date: string
           organization_id: string | null
           preview_template: string
+          phone_home: string | null
+          phone_work: string | null
+          phone_cell: string | null
+          insurance_company: string | null
+          policy_number: string | null
+          email: string | null
           report_data: Json | null
           report_type: string | null
           sections: Json | null
@@ -523,6 +529,12 @@ export type Database = {
           inspection_date: string
           organization_id?: string | null
           preview_template?: string
+          phone_home?: string | null
+          phone_work?: string | null
+          phone_cell?: string | null
+          insurance_company?: string | null
+          policy_number?: string | null
+          email?: string | null
           report_data?: Json | null
           report_type?: string | null
           sections?: Json | null
@@ -543,6 +555,12 @@ export type Database = {
           inspection_date?: string
           organization_id?: string | null
           preview_template?: string
+          phone_home?: string | null
+          phone_work?: string | null
+          phone_cell?: string | null
+          insurance_company?: string | null
+          policy_number?: string | null
+          email?: string | null
           report_data?: Json | null
           report_type?: string | null
           sections?: Json | null

--- a/src/lib/reportSchemas.ts
+++ b/src/lib/reportSchemas.ts
@@ -130,6 +130,12 @@ export const WindMitigationDataSchema = z.object({
 export const WindMitigationReportSchema = BaseReportSchema.extend({
     reportType: z.literal("wind_mitigation"),
     reportData: WindMitigationDataSchema,
+    phoneHome: z.string().optional(),
+    phoneWork: z.string().optional(),
+    phoneCell: z.string().optional(),
+    insuranceCompany: z.string().optional(),
+    policyNumber: z.string().optional(),
+    email: z.string().optional(),
 });
 
 // Union type for all report types

--- a/src/utils/fillWindMitigationPDF.ts
+++ b/src/utils/fillWindMitigationPDF.ts
@@ -110,6 +110,12 @@ export async function fillWindMitigationPDF(report: any): Promise<Blob> {
         street,
         city,
         zip,
+        phoneHome: report.phoneHome,
+        phoneWork: report.phoneWork,
+        phoneCell: report.phoneCell,
+        email: report.email,
+        insuranceCompany: report.insuranceCompany,
+        policyNumber: report.policyNumber,
         inspectionDate: report.inspectionDate
             ? new Date(report.inspectionDate).toLocaleDateString()
             : '',

--- a/supabase/migrations/20250821000000_add_report_contact_fields.sql
+++ b/supabase/migrations/20250821000000_add_report_contact_fields.sql
@@ -1,0 +1,8 @@
+-- Add contact and insurance fields to reports table
+ALTER TABLE reports
+    ADD COLUMN IF NOT EXISTS phone_home TEXT,
+    ADD COLUMN IF NOT EXISTS phone_work TEXT,
+    ADD COLUMN IF NOT EXISTS phone_cell TEXT,
+    ADD COLUMN IF NOT EXISTS insurance_company TEXT,
+    ADD COLUMN IF NOT EXISTS policy_number TEXT,
+    ADD COLUMN IF NOT EXISTS email TEXT;


### PR DESCRIPTION
## Summary
- extend wind mitigation report schema with contact and insurance fields
- persist new fields in Supabase and expose via API
- add contact lookup and new fields to wind mitigation report creation
- map new contact fields into PDF generation

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68a6642fa8cc833384648e5afec438ad