### PR TITLE
handle roof covering compliance dynamically

### DIFF
--- a/src/lib/windMitigationFieldMap.ts
+++ b/src/lib/windMitigationFieldMap.ts
@@ -58,9 +58,6 @@ export const WIND_MITIGATION_FIELD_MAP: Record<string, string> = {
     "reportData.2_roof_covering.coverings.other.year_of_original_install_or_replacement": "clayTileInstallReplaceDate",
     "reportData.2_roof_covering.coverings.other.no_information_provided_for_compliance": "otherNoCompliance",
 
-    // --- Roof Covering Methods ---
-    "reportData.2_roof_covering.overall_compliance": "roofCoveringA",
-
     // --- Roof Deck Attachments (Q3) ---
     "reportData.3_roof_deck_attachment.selectedOption": "roofDeckA",
 

--- a/src/utils/fillWindMitigationPDF.ts
+++ b/src/utils/fillWindMitigationPDF.ts
@@ -7,6 +7,7 @@ import {WIND_MITIGATION_FIELD_MAP} from "@/lib/windMitigationFieldMap";
 // data keys.
 const MANUALLY_HANDLED_KEY_PREFIXES = [
     "reportData.1_building_code",
+    "reportData.2_roof_covering.overall_compliance",
 ];
 
 function parseAddress(full: string): {street: string; city: string; state: string; zip: string} {
@@ -164,6 +165,32 @@ export async function fillWindMitigationPDF(report: any): Promise<Blob> {
             } catch (err) {
                 console.warn(`⚠️ Could not set year built for option "${option}"`, err);
             }
+        }
+    }
+
+    // Handle Roof Covering Overall Compliance (Q2)
+    const roofCoveringValue = report.reportData?.["2_roof_covering"]?.overall_compliance;
+    if (roofCoveringValue) {
+        const option = String(roofCoveringValue).toUpperCase();
+        const checkboxName = `roofCovering${option}`;
+        try {
+            const checkbox = form.getCheckBox(checkboxName as never);
+            checkbox.check();
+            ["A", "B", "C", "D"].forEach((letter) => {
+                if (letter !== option) {
+                    try {
+                        form.getCheckBox(`roofCovering${letter}` as never).uncheck();
+                    } catch (err) {
+                        // Ignore missing checkboxes
+                    }
+                }
+            });
+            console.log(`✅ Checked roof covering compliance option "${option}"`);
+        } catch (err) {
+            console.warn(
+                `⚠️ Could not check roof covering compliance option "${option}"`,
+                err
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- remove static mapping for `overall_compliance`
- mark `overall_compliance` as manually handled and set roof covering checkbox dynamically

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 184 problems (167 errors, 17 warnings))*
- `npx tsx testRoofCovering.ts A`
- `npx tsx testRoofCovering.ts B`
- `npx tsx testRoofCovering.ts C`
- `npx tsx testRoofCovering.ts D`


------
https://chatgpt.com/codex/tasks/task_e_68a66fccaca4833397271afeea173f42