### PR TITLE
Enable dynamic roof attachment checkbox selection

### DIFF
--- a/src/lib/windMitigationFieldMap.ts
+++ b/src/lib/windMitigationFieldMap.ts
@@ -58,12 +58,6 @@ export const WIND_MITIGATION_FIELD_MAP: Record<string, string> = {
     "reportData.2_roof_covering.coverings.other.year_of_original_install_or_replacement": "clayTileInstallReplaceDate",
     "reportData.2_roof_covering.coverings.other.no_information_provided_for_compliance": "otherNoCompliance",
 
-    // --- Roof Deck Attachments (Q3) ---
-    "reportData.3_roof_deck_attachment.selectedOption": "roofDeckA",
-
-    // --- Roof to Wall Attachment (Q4) ---
-    "reportData.4_roof_to_wall_attachment.selectedOption": "roofWallA",
-
     // --- Roof Geometry (Q5) ---
     "reportData.5_roof_geometry.selectedOption": "roofGeometryA",
     "reportData.5_roof_geometry.fields.total_roof_system_perimeter_ft": "roofGeometryB",

--- a/src/utils/fillWindMitigationPDF.ts
+++ b/src/utils/fillWindMitigationPDF.ts
@@ -8,6 +8,8 @@ import {WIND_MITIGATION_FIELD_MAP} from "@/lib/windMitigationFieldMap";
 const MANUALLY_HANDLED_KEY_PREFIXES = [
     "reportData.1_building_code",
     "reportData.2_roof_covering.overall_compliance",
+    "reportData.3_roof_deck_attachment.selectedOption",
+    "reportData.4_roof_to_wall_attachment.selectedOption",
 ];
 
 function parseAddress(full: string): {street: string; city: string; state: string; zip: string} {
@@ -189,6 +191,56 @@ export async function fillWindMitigationPDF(report: any): Promise<Blob> {
         } catch (err) {
             console.warn(
                 `⚠️ Could not check roof covering compliance option "${option}"`,
+                err
+            );
+        }
+    }
+
+    // Handle Roof Deck Attachment (Q3)
+    const roofDeckValue = report.reportData?.["3_roof_deck_attachment"]?.selectedOption;
+    if (roofDeckValue) {
+        const option = String(roofDeckValue).toUpperCase();
+        try {
+            const checkbox = form.getCheckBox(`roofDeck${option}` as never);
+            checkbox.check();
+            ["A", "B", "C", "D", "E", "F", "G"].forEach((letter) => {
+                if (letter !== option) {
+                    try {
+                        form.getCheckBox(`roofDeck${letter}` as never).uncheck();
+                    } catch (err) {
+                        // Ignore missing checkboxes
+                    }
+                }
+            });
+            console.log(`✅ Checked roof deck attachment option "${option}"`);
+        } catch (err) {
+            console.warn(
+                `⚠️ Could not check roof deck attachment option "${option}"`,
+                err
+            );
+        }
+    }
+
+    // Handle Roof to Wall Attachment (Q4)
+    const roofWallValue = report.reportData?.["4_roof_to_wall_attachment"]?.selectedOption;
+    if (roofWallValue) {
+        const option = String(roofWallValue).toUpperCase();
+        try {
+            const checkbox = form.getCheckBox(`roofWall${option}` as never);
+            checkbox.check();
+            ["A", "B", "C", "D", "E", "F", "G", "H"].forEach((letter) => {
+                if (letter !== option) {
+                    try {
+                        form.getCheckBox(`roofWall${letter}` as never).uncheck();
+                    } catch (err) {
+                        // Ignore missing checkboxes
+                    }
+                }
+            });
+            console.log(`✅ Checked roof to wall attachment option "${option}"`);
+        } catch (err) {
+            console.warn(
+                `⚠️ Could not check roof to wall attachment option "${option}"`,
                 err
             );
         }


### PR DESCRIPTION
## Summary
- remove hardcoded roof deck and roof-to-wall checkbox mappings
- mark roof attachment options as manually handled
- dynamically select appropriate roof deck and roof-to-wall checkboxes based on report data

## Testing
- `npx -y tsx verify.ts` (removed)
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 166 errors, 17 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a674680f1483339d45992e767cd29d