### PR TITLE
Handle roof geometry dynamically

### DIFF
--- a/src/lib/windMitigationFieldMap.ts
+++ b/src/lib/windMitigationFieldMap.ts
@@ -58,12 +58,6 @@ export const WIND_MITIGATION_FIELD_MAP: Record<string, string> = {
     "reportData.2_roof_covering.coverings.other.year_of_original_install_or_replacement": "otherInstallReplaceDate",
     "reportData.2_roof_covering.coverings.other.no_information_provided_for_compliance": "otherNoCompliance",
     "reportData.2_roof_covering.coverings.other.description": "otherRoofCoveringType",
-
-    // --- Roof Geometry (Q5) ---
-    "reportData.5_roof_geometry.selectedOption": "roofGeometryA",
-    "reportData.5_roof_geometry.fields.total_roof_system_perimeter_ft": "roofGeometryB",
-    "reportData.5_roof_geometry.fields.non_hip_feature_total_length_ft": "roofGeometryC",
-
     // --- Secondary Water Resistance (Q6) ---
     "reportData.6_secondary_water_resistance.selectedOption": "swrA",
 


### PR DESCRIPTION
## Summary
- remove roof geometry entries from wind mitigation field map
- add roof geometry to manual key prefixes and map roof geometry options programmatically

## Testing
- `npx tsx temp-debug.ts` *(debugFieldMapping output, no Q5 warnings)*
- `npx tsx temp-fill.ts` *(roof geometry options A–C populate correct fields)*
- `npm run lint` *(fails: Unexpected any, forbidden require imports)*


------
https://chatgpt.com/codex/tasks/task_e_68a67c0996a08333a99cbd98c03a3117