### PR TITLE
Handle SWR checkbox dynamically

### DIFF
--- a/src/lib/windMitigationFieldMap.ts
+++ b/src/lib/windMitigationFieldMap.ts
@@ -59,7 +59,6 @@ export const WIND_MITIGATION_FIELD_MAP: Record<string, string> = {
     "reportData.2_roof_covering.coverings.other.no_information_provided_for_compliance": "otherNoCompliance",
     "reportData.2_roof_covering.coverings.other.description": "otherRoofCoveringType",
     // --- Secondary Water Resistance (Q6) ---
-    "reportData.6_secondary_water_resistance.selectedOption": "swrA",
 
     // --- Opening Protection (Q7) ---
     "reportData.7_opening_protection.glazedOverall": "oplA",

--- a/src/utils/fillWindMitigationPDF.ts
+++ b/src/utils/fillWindMitigationPDF.ts
@@ -11,6 +11,7 @@ const MANUALLY_HANDLED_KEY_PREFIXES = [
     "reportData.3_roof_deck_attachment.selectedOption",
     "reportData.4_roof_to_wall_attachment.selectedOption",
     "reportData.5_roof_geometry",
+    "reportData.6_secondary_water_resistance.selectedOption",
 ];
 
 function parseAddress(full: string): {street: string; city: string; state: string; zip: string} {
@@ -309,6 +310,31 @@ export async function fillWindMitigationPDF(report: any): Promise<Blob> {
                     console.warn("⚠️ Could not set total roof area", err);
                 }
             }
+        }
+    }
+
+    // Handle Secondary Water Resistance (Q6)
+    const swrValue = report.reportData?.["6_secondary_water_resistance"]?.selectedOption;
+    if (swrValue) {
+        const option = String(swrValue).toUpperCase();
+        try {
+            const checkbox = form.getCheckBox(`swr${option}` as never);
+            checkbox.check();
+            ["A", "B", "C"].forEach((letter) => {
+                if (letter !== option) {
+                    try {
+                        form.getCheckBox(`swr${letter}` as never).uncheck();
+                    } catch {
+                        // Ignore missing checkboxes
+                    }
+                }
+            });
+            console.log(`✅ Checked secondary water resistance option "${option}"`);
+        } catch (err) {
+            console.warn(
+                `⚠️ Could not check secondary water resistance option "${option}"`,
+                err
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- remove static mapping for secondary water resistance
- treat secondary water resistance as manual key
- set Secondary Water Resistance checkbox dynamically

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `bun test-swr.ts` verifying secondary water resistance checkbox states


------
https://chatgpt.com/codex/tasks/task_e_68a67dc2504c8333b2846c74ceb25443