### PR TITLE
Map boolean PDF text fields to X or blank

### DIFF
--- a/src/utils/fillWindMitigationPDF.ts
+++ b/src/utils/fillWindMitigationPDF.ts
@@ -362,8 +362,15 @@ export async function fillWindMitigationPDF(report: any): Promise<Blob> {
                 }
                 console.log(`✅ Set checkbox "${pdfFieldName}" to ${value}`);
             } else if ("setText" in field) {
-                (field as any).setText(String(value));
-                console.log(`✅ Set text field "${pdfFieldName}" to "${value}"`);
+                if (typeof value === "boolean") {
+                    (field as any).setText(value ? "X" : "");
+                    console.log(
+                        `✅ Set text field "${pdfFieldName}" to "${value ? "X" : ""}"`
+                    );
+                } else {
+                    (field as any).setText(String(value));
+                    console.log(`✅ Set text field "${pdfFieldName}" to "${value}"`);
+                }
             } else {
                 console.warn(`⚠️ Unsupported field type for '${pdfFieldName}'`);
             }


### PR DESCRIPTION
## Summary
- convert boolean values mapped to text fields into "X" or "" in wind mitigation PDF generation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 183 problems)*
- `npx tsx testFill.ts` and inspected PDF fields


------
https://chatgpt.com/codex/tasks/task_e_68a6829b3d448333ad12255ecaaffc9e