### PR TITLE
Handle opening protection checkbox mapping dynamically

### DIFF
--- a/src/lib/windMitigationFieldMap.ts
+++ b/src/lib/windMitigationFieldMap.ts
@@ -61,8 +61,6 @@ export const WIND_MITIGATION_FIELD_MAP: Record<string, string> = {
     // --- Secondary Water Resistance (Q6) ---
 
     // --- Opening Protection (Q7) ---
-    "reportData.7_opening_protection.glazedOverall": "oplA",
-    "reportData.7_opening_protection.nonGlazedSubclass": "oplB",
     // Opening Protection Levels per Opening Type
     "reportData.7_opening_protection.openingProtection.windows_or_entry_doors_glazed.NA": "windowDoorNA",
     "reportData.7_opening_protection.openingProtection.windows_or_entry_doors_glazed.A": "windowDoorA",


### PR DESCRIPTION
## Summary
- remove hardcoded mappings for opening protection overall and subclass fields
- mark opening protection values as manually handled and implement custom checkbox logic

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: eslint errors in unrelated files)*
- `npx tsx testFill2.ts B B.1 >/tmp/outB.log 2>&1 && tail -n 1 /tmp/outB.log`
- `npx tsx testFill2.ts C N.3 >/tmp/outC.log 2>&1 && tail -n 1 /tmp/outC.log`


------
https://chatgpt.com/codex/tasks/task_e_68a683f9eb5483338a4c574fe25ee2e5