### PR TITLE
Add roof-to-wall attachment sub-items and PDF mapping

### DIFF
--- a/src/components/reports/windmitigation/GenericQuestion.tsx
+++ b/src/components/reports/windmitigation/GenericQuestion.tsx
@@ -16,6 +16,7 @@ interface Question {
   id: string;
   prompt: string;
   options?: QuestionOption[];
+  fields?: any[];
   minimal_conditions_for_B_C_D?: string;
 }
 
@@ -54,6 +55,21 @@ export const GenericQuestion: React.FC<GenericQuestionProps> = ({
         )}
       </CardHeader>
       <CardContent className="space-y-4">
+        {question.fields && (
+          <div className="space-y-3 p-4 bg-muted/50 rounded-lg">
+            {question.fields.map((field) => (
+              <WindMitigationQuestionField
+                key={field.name}
+                field={field}
+                control={control}
+                questionId={question.id}
+                optionCode="question"
+                watch={watch}
+              />
+            ))}
+          </div>
+        )}
+
         <FormField
           control={control}
           name={`${question.id}.selectedOption` as any}

--- a/src/components/reports/windmitigation/WindMitigationQuestionField.tsx
+++ b/src/components/reports/windmitigation/WindMitigationQuestionField.tsx
@@ -17,6 +17,7 @@ interface QuestionField {
   type: string;
   format?: string;
   visible_if?: any;
+  label?: string;
 }
 
 interface WindMitigationQuestionFieldProps {
@@ -72,7 +73,7 @@ export const WindMitigationQuestionField: React.FC<WindMitigationQuestionFieldPr
             render={({ field: formField }) => (
               <FormItem className="flex flex-col">
                 <FormLabel className="text-sm font-medium">
-                  {field.name.replace(/_/g, " ").replace(/\b\w/g, l => l.toUpperCase())}
+                  {field.label ?? field.name.replace(/_/g, " ").replace(/\b\w/g, l => l.toUpperCase())}
                 </FormLabel>
                 <Popover>
                   <PopoverTrigger asChild>
@@ -117,7 +118,7 @@ export const WindMitigationQuestionField: React.FC<WindMitigationQuestionFieldPr
             render={({ field: formField }) => (
               <FormItem>
                 <FormLabel className="text-sm font-medium">
-                  {field.name.replace(/_/g, " ").replace(/\b\w/g, l => l.toUpperCase())}
+                  {field.label ?? field.name.replace(/_/g, " ").replace(/\b\w/g, l => l.toUpperCase())}
                 </FormLabel>
                 <FormControl>
                   <Input
@@ -143,8 +144,8 @@ export const WindMitigationQuestionField: React.FC<WindMitigationQuestionFieldPr
             render={({ field: formField }) => (
               <FormItem>
                 <FormLabel className="text-sm font-medium">
-                  {field.name.replace(/_/g, " ").replace(/\b\w/g, l => l.toUpperCase())}
-                </FormLabel>
+                    {field.label ?? field.name.replace(/_/g, " ").replace(/\b\w/g, l => l.toUpperCase())}
+                  </FormLabel>
                 <FormControl>
                   <Input
                     type="number"
@@ -213,8 +214,8 @@ export const WindMitigationQuestionField: React.FC<WindMitigationQuestionFieldPr
                   />
                 </FormControl>
                 <FormLabel className="text-sm font-medium">
-                  {field.name.replace(/_/g, " ").replace(/\b\w/g, l => l.toUpperCase())}
-                </FormLabel>
+                    {field.label ?? field.name.replace(/_/g, " ").replace(/\b\w/g, l => l.toUpperCase())}
+                  </FormLabel>
                 <FormMessage />
               </FormItem>
             )}

--- a/src/constants/windMitigationQuestions.ts
+++ b/src/constants/windMitigationQuestions.ts
@@ -142,14 +142,55 @@ export const WIND_MITIGATION_QUESTIONS = {
       "id": "4_roof_to_wall_attachment",
       "prompt": "Roof to Wall Attachment: What is the WEAKEST roof to wall connection? (Do not include attachment of hip/valley jacks within 5 feet of the inside or outside corner of the roof in determination of WEAKEST type)",
       "minimal_conditions_for_B_C_D": "Minimal conditions to qualify for categories B, C, or D. All visible metal connectors are: Secured to truss/rafter with a minimum of three (3) nails, and Attached to the wall top plate of the wall framing, or embedded in the bond beam, with less than a ½\" gap from the blocking or truss/rafter and blocked no more than 1.5\" of the truss/rafter, and free of visible severe corrosion.",
+      "fields": [
+        {
+          "name": "roof_wall_min_1",
+          "type": "boolean",
+          "label": "Secured to truss/rafter with a minimum of three (3) nails"
+        },
+        {
+          "name": "roof_wall_min_2",
+          "type": "boolean",
+          "label": "Attached to the wall top plate of the wall framing, or embedded in the bond beam, with less than a 1/2\" gap from the blocking or truss/rafter and blocked no more than 1.5\" of the truss/rafter"
+        },
+        {
+          "name": "roof_wall_min_3",
+          "type": "boolean",
+          "label": "Free of visible severe corrosion"
+        }
+      ],
       "options": [
-        { 
-          "code": "A", 
-          "label": "Toe Nails - Truss/rafter anchored to top plate of wall using nails driven at an angle through the truss/rafter and attached to the top plate of the wall, or Metal connectors that do not meet the minimal conditions or requirements of B, C, or D" 
+        {
+          "code": "A",
+          "label": "Toe Nails - Truss/rafter anchored to top plate of wall using nails driven at an angle through the truss/rafter and attached to the top plate of the wall, or Metal connectors that do not meet the minimal conditions or requirements of B, C, or D",
+          "fields": [
+            {
+              "name": "roof_wall_a_1",
+              "type": "boolean",
+              "label": "Truss/rafter anchored to top plate of wall using nails driven at an angle through the truss/rafter and attached to the top plate of the wall"
+            },
+            {
+              "name": "roof_wall_a_2",
+              "type": "boolean",
+              "label": "Metal connectors that do not meet the minimal conditions or requirements of B, C, or D"
+            }
+          ]
         },
         {
           "code": "B",
-          "label": "Clips - Metal connectors that do not wrap over the top of the truss/rafter, or Metal connectors with a minimum of 1 strap that wraps over the top of the truss/rafter and does not meet the nail position requirements of C or D, but is secured with a minimum of 3 nails."
+          "label": "Clips - Metal connectors that do not wrap over the top of the truss/rafter, or Metal connectors with a minimum of 1 strap that wraps over the top of the truss/rafter and does not meet the nail position requirements of C or D, but is secured with a minimum of 3 nails.",
+          "fields": [
+            {
+              "name": "roof_wall_b_1",
+              "type": "boolean",
+              "label": "Metal connectors that do not wrap over the top of the truss/rafter"
+            },
+            {
+              "name": "roof_wall_b_2",
+              "type": "boolean",
+              "label": "Metal connectors with a minimum of 1 strap that wraps over the top of the truss/rafter and does not meet the nail position requirements of C or D, but is secured with a minimum of 3 nails"
+            }
+          ]
         },
         {
           "code": "C",
@@ -157,7 +198,19 @@ export const WIND_MITIGATION_QUESTIONS = {
         },
         {
           "code": "D",
-          "label": "Double Wraps - Metal Connectors consisting of 2 separate straps that are attached to the wall frame, or embedded in the bond beam, on either side of the truss/rafter where each strap wraps over the top of the truss/rafter and is secured with a minimum of 2 nails on the front side, and a minimum of 1 nail on the opposing side, or Metal connectors consisting of a single strap that wraps over the top of the truss/rafter, is secured to the wall on both sides, and is secured to the top plate with a minimum of three nails on each side."
+          "label": "Double Wraps - Metal Connectors consisting of 2 separate straps that are attached to the wall frame, or embedded in the bond beam, on either side of the truss/rafter where each strap wraps over the top of the truss/rafter and is secured with a minimum of 2 nails on the front side, and a minimum of 1 nail on the opposing side, or Metal connectors consisting of a single strap that wraps over the top of the truss/rafter, is secured to the wall on both sides, and is secured to the top plate with a minimum of three nails on each side.",
+          "fields": [
+            {
+              "name": "roof_wall_d_1",
+              "type": "boolean",
+              "label": "Metal connectors consisting of 2 separate straps that are attached to the wall frame, or embedded in the bond beam, on either side of the truss/rafter where each strap wraps over the top of the truss/rafter and is secured with a minimum of 2 nails on the front side, and a minimum of 1 nail on the opposing side"
+            },
+            {
+              "name": "roof_wall_d_2",
+              "type": "boolean",
+              "label": "Metal connectors consisting of a single strap that wraps over the top of the truss/rafter, is secured to the wall on both sides, and is secured to the top plate with a minimum of three nails on each side"
+            }
+          ]
         },
         { "code": "E", "label": "Structural - Anchor bolts structurally connected or reinforced concrete roof." },
         { "code": "F", "label": "Other", "fields": [{ "name": "description", "type": "string" }] },

--- a/src/lib/windMitigationFieldMap.ts
+++ b/src/lib/windMitigationFieldMap.ts
@@ -58,6 +58,18 @@ export const WIND_MITIGATION_FIELD_MAP: Record<string, string> = {
     "reportData.2_roof_covering.coverings.other.year_of_original_install_or_replacement": "otherInstallReplaceDate",
     "reportData.2_roof_covering.coverings.other.no_information_provided_for_compliance": "otherNoCompliance",
     "reportData.2_roof_covering.coverings.other.description": "otherRoofCoveringType",
+
+    // --- Roof to Wall Attachment (Q4) ---
+    "reportData.4_roof_to_wall_attachment.fields.roof_wall_min_1": "roofWallMin1",
+    "reportData.4_roof_to_wall_attachment.fields.roof_wall_min_2": "roofWallMin2",
+    "reportData.4_roof_to_wall_attachment.fields.roof_wall_min_3": "roofWallMin3",
+    "reportData.4_roof_to_wall_attachment.fields.roof_wall_a_1": "roofWallA1",
+    "reportData.4_roof_to_wall_attachment.fields.roof_wall_a_2": "roofWallA2",
+    "reportData.4_roof_to_wall_attachment.fields.roof_wall_b_1": "roofWallB1",
+    "reportData.4_roof_to_wall_attachment.fields.roof_wall_b_2": "roofWallB2",
+    "reportData.4_roof_to_wall_attachment.fields.roof_wall_d_1": "roofWallD1",
+    "reportData.4_roof_to_wall_attachment.fields.roof_wall_d_2": "roofWallD2",
+
     // --- Secondary Water Resistance (Q6) ---
 
     // --- Opening Protection (Q7) ---


### PR DESCRIPTION
## Summary
- support custom labels for wind mitigation question fields
- add roof-to-wall attachment minimal-condition and option sub-item checkboxes
- map new roof-to-wall attachment fields to PDF outputs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 184 problems, 167 errors, 17 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a70c015c8883338249b7b9a446f2e8