### PR TITLE
refactor: inline roof-to-wall option fields

### DIFF
--- a/src/components/reports/windmitigation/RoofToWallQuestion.tsx
+++ b/src/components/reports/windmitigation/RoofToWallQuestion.tsx
@@ -15,34 +15,14 @@ interface RoofToWallQuestionProps {
 export const RoofToWallQuestion: React.FC<RoofToWallQuestionProps> = ({ control, watch }) => {
   const question = WIND_MITIGATION_QUESTIONS.questions[3];
   const selectedOption = watch("4_roof_to_wall_attachment.selectedOption");
-  const selectedOptionData = question.options.find((opt: any) => opt.code === selectedOption);
 
   return (
     <Card>
       <CardHeader>
         <CardTitle className="text-lg">4. Roof-to-Wall Attachment</CardTitle>
         <p className="text-sm text-muted-foreground">{question.prompt}</p>
-        {question.minimal_conditions_for_B_C_D && (
-          <div className="text-xs text-muted-foreground mt-2 p-3 bg-muted/30 rounded-md">
-            <strong>Minimal conditions for B, C, D:</strong> {question.minimal_conditions_for_B_C_D}
-          </div>
-        )}
       </CardHeader>
       <CardContent className="space-y-6">
-        {question.fields && (
-          <div className="space-y-3 p-4 bg-muted/50 rounded-lg">
-            {question.fields.map((field) => (
-              <WindMitigationQuestionField
-                key={field.name}
-                field={field}
-                control={control}
-                questionId="4_roof_to_wall_attachment"
-                optionCode="minimal"
-                watch={watch}
-              />
-            ))}
-          </div>
-        )}
 
         <FormField
           control={control}
@@ -53,20 +33,58 @@ export const RoofToWallQuestion: React.FC<RoofToWallQuestionProps> = ({ control,
                 <RadioGroup
                   onValueChange={field.onChange}
                   value={field.value}
-                  className="flex flex-col space-y-2"
+                  className="flex flex-col space-y-4"
                 >
                   {question.options.map((option) => (
-                    <FormItem
-                      key={option.code}
-                      className="flex items-start space-x-3 space-y-0"
-                    >
-                      <FormControl>
-                        <RadioGroupItem value={option.code} className="mt-1" />
-                      </FormControl>
-                      <FormLabel className="text-sm font-normal leading-relaxed">
-                        <span className="font-medium">{option.code}.</span> {option.label}
-                      </FormLabel>
-                    </FormItem>
+                    <div key={option.code} className="space-y-3">
+                      <FormItem className="flex items-start space-x-3 space-y-0">
+                        <FormControl>
+                          <RadioGroupItem value={option.code} className="mt-1" />
+                        </FormControl>
+                        <FormLabel className="text-sm font-normal leading-relaxed">
+                          <span className="font-medium">{option.code}.</span> {option.label}
+                        </FormLabel>
+                      </FormItem>
+
+                      {selectedOption === option.code && option.fields && (
+                        <div className="ml-6 space-y-3">
+                          {option.fields.map((optField: any) => (
+                            <WindMitigationQuestionField
+                              key={optField.name}
+                              field={optField}
+                              control={control}
+                              questionId="4_roof_to_wall_attachment"
+                              optionCode={option.code}
+                              watch={watch}
+                            />
+                          ))}
+                        </div>
+                      )}
+
+                      {selectedOption === option.code && option.code === "A" && (
+                        <>
+                          {question.minimal_conditions_for_B_C_D && (
+                            <div className="ml-6 text-xs text-muted-foreground mt-2">
+                              <strong>Minimal conditions for B, C, D:</strong> {question.minimal_conditions_for_B_C_D}
+                            </div>
+                          )}
+                          {question.fields && (
+                            <div className="ml-6 mt-2 space-y-3">
+                              {question.fields.map((minField) => (
+                                <WindMitigationQuestionField
+                                  key={minField.name}
+                                  field={minField}
+                                  control={control}
+                                  questionId="4_roof_to_wall_attachment"
+                                  optionCode="minimal"
+                                  watch={watch}
+                                />
+                              ))}
+                            </div>
+                          )}
+                        </>
+                      )}
+                    </div>
                   ))}
                 </RadioGroup>
               </FormControl>
@@ -74,21 +92,6 @@ export const RoofToWallQuestion: React.FC<RoofToWallQuestionProps> = ({ control,
             </FormItem>
           )}
         />
-
-        {selectedOptionData?.fields && (
-          <div className="ml-6 space-y-3 p-4 bg-muted/50 rounded-lg">
-            {selectedOptionData.fields.map((field: any) => (
-              <WindMitigationQuestionField
-                key={field.name}
-                field={field}
-                control={control}
-                questionId="4_roof_to_wall_attachment"
-                optionCode={selectedOption}
-                watch={watch}
-              />
-            ))}
-          </div>
-        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- render roof-to-wall option fields inline within each radio option
- show minimal condition checkboxes under option A

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 168 errors)


------
https://chatgpt.com/codex/tasks/task_e_68a723bdf6f88333a9c614d36b08c64f