### PR TITLE
feat: capture county and story count for wind mitigation reports

### DIFF
--- a/src/integrations/supabase/reportsApi.ts
+++ b/src/integrations/supabase/reportsApi.ts
@@ -26,6 +26,8 @@ function toDbPayload(report: Report) {
     preview_template: report.previewTemplate || 'classic',
     report_type: report.reportType,
     report_data: report.reportType === "wind_mitigation" ? report.reportData : null,
+    county: (report as any).county || null,
+    ofStories: (report as any).ofStories || null,
     phone_home: (report as any).phoneHome || null,
     phone_work: (report as any).phoneWork || null,
     phone_cell: (report as any).phoneCell || null,
@@ -43,6 +45,8 @@ function fromDbRow(row: any): Report {
     title: row.title,
     clientName: row.client_name,
     address: row.address,
+    county: row.county || "",
+    ofStories: row.ofStories || "",
     inspectionDate: new Date(`${row.inspection_date}T00:00:00Z`).toISOString(),
     status: row.status,
     finalComments: row.final_comments || "",
@@ -154,6 +158,8 @@ export async function dbCreateReport(meta: {
   inspectionDate: string; // 'YYYY-MM-DD' or ISO
   contact_id?: string;
   reportType: "home_inspection" | "wind_mitigation";
+  county?: string;
+  ofStories?: string;
   phoneHome?: string;
   phoneWork?: string;
   phoneCell?: string;
@@ -178,6 +184,8 @@ export async function dbCreateReport(meta: {
       title: meta.title,
       clientName: meta.clientName,
       address: meta.address,
+      county: meta.county || "",
+      ofStories: meta.ofStories || "",
       inspectionDate: new Date(meta.inspectionDate).toISOString(),
       status: "Draft",
       finalComments: "",
@@ -193,6 +201,8 @@ export async function dbCreateReport(meta: {
       title: meta.title,
       clientName: meta.clientName,
       address: meta.address,
+      county: meta.county || "",
+      ofStories: meta.ofStories || "",
       inspectionDate: new Date(meta.inspectionDate).toISOString(),
       status: "Draft",
       finalComments: "",

--- a/src/lib/reportSchemas.ts
+++ b/src/lib/reportSchemas.ts
@@ -46,6 +46,8 @@ export const BaseReportSchema = z.object({
     title: z.string().min(1, "Report title is required"),
     clientName: z.string().min(1, "Client name is required"),
     address: z.string().min(1, "Address is required"),
+    county: z.string().optional(),
+    ofStories: z.string().optional(),
     inspectionDate: z.string(), // ISO
     status: z.enum(["Draft", "Final"]).default("Draft"),
     finalComments: z.string().optional().default(""),

--- a/src/lib/windMitigationFieldMap.ts
+++ b/src/lib/windMitigationFieldMap.ts
@@ -5,6 +5,8 @@ export const WIND_MITIGATION_FIELD_MAP: Record<string, string> = {
     street: "Address",
     city: "City",
     zip: "zipCode",
+    county: "county",
+    ofStories: "ofStories",
     phoneHome: "Home Phone",
     phoneWork: "Work Phone",
     phoneCell: "Cell Phone",

--- a/src/pages/WindMitigationNew.tsx
+++ b/src/pages/WindMitigationNew.tsx
@@ -20,6 +20,8 @@ const schema = z.object({
   title: z.string().min(1, "Required"),
   clientName: z.string().min(1, "Required"),
   address: z.string().min(1, "Address is required"),
+  county: z.string().optional(),
+  ofStories: z.string().optional(),
   inspectionDate: z.string().min(1, "Required"),
   contactId: z.string().optional(),
   phoneHome: z.string().optional(),
@@ -51,6 +53,8 @@ const WindMitigationNew: React.FC = () => {
       title: "",
       clientName: "",
       address: "",
+      county: "",
+      ofStories: "",
       inspectionDate: new Date().toISOString().slice(0, 10),
       contactId: contactId || "",
       phoneHome: "",
@@ -102,6 +106,8 @@ const WindMitigationNew: React.FC = () => {
             inspectionDate: values.inspectionDate,
             contact_id: values.contactId,
             reportType: "wind_mitigation",
+            county: values.county,
+            ofStories: values.ofStories,
             phoneHome: values.phoneHome,
             phoneWork: values.phoneWork,
             phoneCell: values.phoneCell,
@@ -122,9 +128,10 @@ const WindMitigationNew: React.FC = () => {
         });
         nav('/auth');
       }
-    } catch (e: any) {
+    } catch (e: unknown) {
       console.error(e);
-      toast({ title: "Failed to create report", description: e?.message || "Please try again." });
+      const message = e instanceof Error ? e.message : "Please try again.";
+      toast({ title: "Failed to create report", description: message });
     }
   };
 
@@ -262,6 +269,32 @@ const WindMitigationNew: React.FC = () => {
                   <FormLabel>Policy Number</FormLabel>
                   <FormControl>
                     <Input placeholder="Policy number" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="county"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>County</FormLabel>
+                  <FormControl>
+                    <Input placeholder="County" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="ofStories"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Number of Stories</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Number of stories" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/src/utils/fillWindMitigationPDF.ts
+++ b/src/utils/fillWindMitigationPDF.ts
@@ -117,6 +117,8 @@ export async function fillWindMitigationPDF(report: any): Promise<Blob> {
         street,
         city,
         zip,
+        county: report.county,
+        ofStories: report.ofStories,
         phoneHome: report.phoneHome,
         phoneWork: report.phoneWork,
         phoneCell: report.phoneCell,


### PR DESCRIPTION
## Summary
- add optional county and ofStories fields to report schemas and types
- persist county and story count through Supabase API payloads
- expand wind mitigation creation form, field mapping, and PDF generation to handle county and story count

## Testing
- `npx eslint src/integrations/supabase/reportsApi.ts src/lib/reportSchemas.ts src/lib/windMitigationFieldMap.ts src/pages/WindMitigationNew.tsx src/utils/fillWindMitigationPDF.ts` *(fails: Unexpected any...)*
- `npx tsx test-county.ts` *(fails: PDFDocument has no form field with the name "ofStories")*

------
https://chatgpt.com/codex/tasks/task_e_68a742287ee48333b63912557bc03fff