### PR TITLE
feat: add cover page support

### DIFF
--- a/src/integrations/supabase/coverPagesApi.ts
+++ b/src/integrations/supabase/coverPagesApi.ts
@@ -1,0 +1,183 @@
+import { supabase } from "./client";
+import type { Json } from "./types";
+
+export interface CoverPage {
+  id: string;
+  user_id: string;
+  name: string;
+  template_slug: string | null;
+  color_palette_key: string | null;
+  text_content: Json;
+  image_url: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CoverPageAssignment {
+  id: string;
+  user_id: string;
+  report_type: string;
+  cover_page_id: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export async function getCoverPages(userId: string): Promise<CoverPage[]> {
+  const { data, error } = await supabase
+    .from("cover_pages")
+    .select("*")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    console.error("Error fetching cover pages:", error);
+    throw error;
+  }
+
+  return (data || []) as CoverPage[];
+}
+
+export async function createCoverPage(
+  userId: string,
+  payload: {
+    name: string;
+    template_slug?: string | null;
+    color_palette_key?: string | null;
+    text_content?: Json;
+    image_url?: string | null;
+  }
+): Promise<CoverPage> {
+  const { data, error } = await supabase
+    .from("cover_pages")
+    .insert({
+      user_id: userId,
+      name: payload.name,
+      template_slug: payload.template_slug ?? null,
+      color_palette_key: payload.color_palette_key ?? null,
+      text_content: payload.text_content ?? {},
+      image_url: payload.image_url ?? null,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Error creating cover page:", error);
+    throw error;
+  }
+
+  return data as CoverPage;
+}
+
+export async function updateCoverPage(
+  id: string,
+  updates: Partial<
+    Pick<
+      CoverPage,
+      "name" | "template_slug" | "color_palette_key" | "text_content" | "image_url"
+    >
+  >
+): Promise<CoverPage> {
+  const { data, error } = await supabase
+    .from("cover_pages")
+    .update(updates)
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Error updating cover page:", error);
+    throw error;
+  }
+
+  return data as CoverPage;
+}
+
+export async function deleteCoverPage(id: string): Promise<void> {
+  const { error } = await supabase.from("cover_pages").delete().eq("id", id);
+
+  if (error) {
+    console.error("Error deleting cover page:", error);
+    throw error;
+  }
+}
+
+export async function getCoverPageAssignments(
+  userId: string
+): Promise<CoverPageAssignment[]> {
+  const { data, error } = await supabase
+    .from("cover_page_assignments")
+    .select("*")
+    .eq("user_id", userId);
+
+  if (error) {
+    console.error("Error fetching cover page assignments:", error);
+    throw error;
+  }
+
+  return (data || []) as CoverPageAssignment[];
+}
+
+export async function createCoverPageAssignment(
+  userId: string,
+  reportType: string,
+  coverPageId: string
+): Promise<CoverPageAssignment> {
+  const { data, error } = await supabase
+    .from("cover_page_assignments")
+    .insert({
+      user_id: userId,
+      report_type: reportType,
+      cover_page_id: coverPageId,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Error creating cover page assignment:", error);
+    throw error;
+  }
+
+  return data as CoverPageAssignment;
+}
+
+export async function updateCoverPageAssignment(
+  id: string,
+  updates: Partial<Pick<CoverPageAssignment, "report_type" | "cover_page_id">>
+): Promise<CoverPageAssignment> {
+  const { data, error } = await supabase
+    .from("cover_page_assignments")
+    .update(updates)
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Error updating cover page assignment:", error);
+    throw error;
+  }
+
+  return data as CoverPageAssignment;
+}
+
+export async function deleteCoverPageAssignment(id: string): Promise<void> {
+  const { error } = await supabase
+    .from("cover_page_assignments")
+    .delete()
+    .eq("id", id);
+
+  if (error) {
+    console.error("Error deleting cover page assignment:", error);
+    throw error;
+  }
+}
+
+export const coverPagesApi = {
+  getCoverPages,
+  createCoverPage,
+  updateCoverPage,
+  deleteCoverPage,
+  getCoverPageAssignments,
+  createCoverPageAssignment,
+  updateCoverPageAssignment,
+  deleteCoverPageAssignment,
+};

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -265,6 +265,77 @@ export type Database = {
         }
         Relationships: []
       }
+      cover_page_assignments: {
+        Row: {
+          cover_page_id: string
+          created_at: string
+          id: string
+          report_type: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          cover_page_id: string
+          created_at?: string
+          id?: string
+          report_type: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          cover_page_id?: string
+          created_at?: string
+          id?: string
+          report_type?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "fk_cover_page_assignments_cover_page"
+            columns: ["cover_page_id"]
+            isOneToOne: false
+            referencedRelation: "cover_pages"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      cover_pages: {
+        Row: {
+          color_palette_key: string | null
+          created_at: string
+          id: string
+          image_url: string | null
+          name: string
+          template_slug: string | null
+          text_content: Json
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          color_palette_key?: string | null
+          created_at?: string
+          id?: string
+          image_url?: string | null
+          name: string
+          template_slug?: string | null
+          text_content?: Json
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          color_palette_key?: string | null
+          created_at?: string
+          id?: string
+          image_url?: string | null
+          name?: string
+          template_slug?: string | null
+          text_content?: Json
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       defects: {
         Row: {
           created_at: string

--- a/supabase/migrations/20250821170515_ac16a105-42ed-4590-a2f8-4ba820d4a836.sql
+++ b/supabase/migrations/20250821170515_ac16a105-42ed-4590-a2f8-4ba820d4a836.sql
@@ -1,0 +1,80 @@
+-- Create cover_pages and cover_page_assignments tables
+
+-- Create cover_pages table
+CREATE TABLE public.cover_pages (
+  id uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id uuid NOT NULL,
+  name text NOT NULL,
+  template_slug text,
+  color_palette_key text,
+  text_content jsonb NOT NULL DEFAULT '{}'::jsonb,
+  image_url text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT fk_cover_pages_user FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE
+);
+
+-- Create cover_page_assignments table
+CREATE TABLE public.cover_page_assignments (
+  id uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id uuid NOT NULL,
+  report_type text NOT NULL,
+  cover_page_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, report_type),
+  CONSTRAINT fk_cover_page_assignments_user FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE,
+  CONSTRAINT fk_cover_page_assignments_cover_page FOREIGN KEY (cover_page_id) REFERENCES public.cover_pages(id) ON DELETE CASCADE
+);
+
+-- Enable Row Level Security
+ALTER TABLE public.cover_pages ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.cover_page_assignments ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies for cover_pages
+CREATE POLICY "Users can view their own cover pages"
+ON public.cover_pages FOR SELECT
+USING (user_id = auth.uid());
+
+CREATE POLICY "Users can insert their own cover pages"
+ON public.cover_pages FOR INSERT
+WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "Users can update their own cover pages"
+ON public.cover_pages FOR UPDATE
+USING (user_id = auth.uid());
+
+CREATE POLICY "Users can delete their own cover pages"
+ON public.cover_pages FOR DELETE
+USING (user_id = auth.uid());
+
+-- RLS Policies for cover_page_assignments
+CREATE POLICY "Users can view their own cover page assignments"
+ON public.cover_page_assignments FOR SELECT
+USING (user_id = auth.uid());
+
+CREATE POLICY "Users can insert their own cover page assignments"
+ON public.cover_page_assignments FOR INSERT
+WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "Users can update their own cover page assignments"
+ON public.cover_page_assignments FOR UPDATE
+USING (user_id = auth.uid());
+
+CREATE POLICY "Users can delete their own cover page assignments"
+ON public.cover_page_assignments FOR DELETE
+USING (user_id = auth.uid());
+
+-- Trigger for updated_at
+CREATE TRIGGER update_cover_pages_updated_at
+BEFORE UPDATE ON public.cover_pages
+FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TRIGGER update_cover_page_assignments_updated_at
+BEFORE UPDATE ON public.cover_page_assignments
+FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- Indexes
+CREATE INDEX idx_cover_pages_user_id ON public.cover_pages(user_id);
+CREATE INDEX idx_cover_page_assignments_user_id ON public.cover_page_assignments(user_id);
+CREATE INDEX idx_cover_page_assignments_cover_page_id ON public.cover_page_assignments(cover_page_id);


### PR DESCRIPTION
## Summary
- add `cover_pages` and `cover_page_assignments` tables with policies and indexes
- extend Supabase types for new tables
- implement CRUD helpers for cover pages and assignments

## Testing
- `npm run lint` *(fails: 188 problems)*
- `npx eslint src/integrations/supabase/coverPagesApi.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a75142a15c8333ae648a31ef6acb51