### PR TITLE
feat: add cover templates and color palettes

### DIFF
--- a/src/constants/colorPalettes.ts
+++ b/src/constants/colorPalettes.ts
@@ -1,0 +1,44 @@
+export const COLOR_PALETTES = [
+  {
+    name: "Classic Blue",
+    primary: "#1e3a8a",
+    secondary: "#3b82f6",
+    accent: "#fcd34d",
+    text: "#1f2937",
+  },
+  {
+    name: "Sunset",
+    primary: "#f97316",
+    secondary: "#fb923c",
+    accent: "#f43f5e",
+    text: "#1c1917",
+  },
+  {
+    name: "Forest",
+    primary: "#166534",
+    secondary: "#22c55e",
+    accent: "#d9f99d",
+    text: "#1f2937",
+  },
+  {
+    name: "Monochrome",
+    primary: "#0f172a",
+    secondary: "#334155",
+    accent: "#64748b",
+    text: "#f1f5f9",
+  },
+  {
+    name: "Lavender",
+    primary: "#7c3aed",
+    secondary: "#c4b5fd",
+    accent: "#f9a8d4",
+    text: "#1f2937",
+  },
+  {
+    name: "Ruby",
+    primary: "#be123c",
+    secondary: "#fda4af",
+    accent: "#f87171",
+    text: "#fafafa",
+  },
+] as const;

--- a/src/constants/coverPageTemplates.ts
+++ b/src/constants/coverPageTemplates.ts
@@ -1,0 +1,62 @@
+export const COVER_PAGE_TEMPLATES = [
+  {
+    id: "centered",
+    container:
+      "flex flex-col items-center justify-center min-h-screen text-center bg-primary text-primary-foreground",
+    text: {
+      title: "text-5xl font-bold text-accent",
+      subtitle: "mt-4 text-xl text-secondary",
+      footer: "mt-auto text-sm text-primary-foreground",
+    },
+  },
+  {
+    id: "left",
+    container:
+      "flex flex-col justify-center min-h-screen pl-20 bg-secondary text-secondary-foreground",
+    text: {
+      title: "text-5xl font-bold text-primary",
+      subtitle: "mt-4 text-lg text-accent",
+      footer: "mt-auto text-sm text-secondary-foreground",
+    },
+  },
+  {
+    id: "right",
+    container:
+      "flex flex-col items-end justify-center min-h-screen pr-20 text-right bg-secondary text-secondary-foreground",
+    text: {
+      title: "text-5xl font-bold text-primary",
+      subtitle: "mt-4 text-lg text-accent",
+      footer: "mt-auto text-sm text-secondary-foreground",
+    },
+  },
+  {
+    id: "banner",
+    container:
+      "flex flex-col justify-between min-h-screen bg-primary text-primary-foreground",
+    text: {
+      title: "mt-20 text-center text-5xl font-bold text-accent",
+      subtitle: "mt-4 text-center text-lg text-secondary",
+      footer: "w-full py-4 text-center bg-accent text-accent-foreground",
+    },
+  },
+  {
+    id: "split",
+    container:
+      "flex flex-col justify-start min-h-screen bg-secondary text-secondary-foreground",
+    text: {
+      title: "mt-20 text-5xl font-bold text-primary",
+      subtitle: "mt-4 text-lg text-accent",
+      footer: "mt-auto text-center text-sm text-secondary-foreground",
+    },
+  },
+  {
+    id: "overlay",
+    container:
+      "relative flex flex-col justify-center min-h-screen bg-primary text-primary-foreground",
+    text: {
+      title: "z-10 text-5xl font-bold text-accent",
+      subtitle: "z-10 mt-4 text-lg text-secondary",
+      footer: "z-10 mt-auto text-sm text-primary-foreground",
+    },
+  },
+] as const;


### PR DESCRIPTION
## Summary
- add reusable color palette definitions
- introduce six cover page templates with palette-aware styling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68a753fc00e8833396ffaddbd3ca1163