### PR TITLE
feat: add cover page manager

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,7 @@ const App = () => (
               <Route path="/tasks" element={lazyLoad(() => import("./pages/Tasks"))} />
               <Route path="/defects-admin" element={lazyLoad(() => import("./pages/DefectsAdmin"))} />
               <Route path="/section-manager" element={lazyLoad(() => import("./pages/SectionManager"))} />
+              <Route path="/cover-page-manager" element={lazyLoad(() => import("./pages/CoverPageManager"))} />
               <Route path="/profile" element={lazyLoad(() => import("./pages/Profile"))} />
               {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
               <Route path="*" element={<NotFound />} />

--- a/src/components/cover-pages/CoverPageEditor.tsx
+++ b/src/components/cover-pages/CoverPageEditor.tsx
@@ -1,0 +1,169 @@
+import React, { useEffect, useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { CoverPagePreview } from "./CoverPagePreview";
+import type { CoverPage } from "@/integrations/supabase/coverPagesApi";
+
+const TEMPLATES = [
+  { value: "default", label: "Default" },
+  { value: "modern", label: "Modern" },
+];
+
+const REPORT_TYPES = [
+  { value: "home_inspection", label: "Home Inspection" },
+  { value: "wind_mitigation", label: "Wind Mitigation" },
+];
+
+interface CoverPageEditorProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (data: {
+    name: string;
+    templateSlug?: string;
+    colorPaletteKey?: string;
+    textContent?: string;
+    imageUrl?: string;
+    reportTypes: string[];
+  }) => Promise<void>;
+  coverPage?: CoverPage;
+  initialReportTypes?: string[];
+}
+
+export function CoverPageEditor({
+  open,
+  onOpenChange,
+  onSave,
+  coverPage,
+  initialReportTypes = [],
+}: CoverPageEditorProps) {
+  const [name, setName] = useState("");
+  const [template, setTemplate] = useState("default");
+  const [color, setColor] = useState("#000000");
+  const [text, setText] = useState("");
+  const [imageUrl, setImageUrl] = useState("");
+  const [reportTypes, setReportTypes] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (open) {
+      setName(coverPage?.name || "");
+      setTemplate(coverPage?.template_slug || "default");
+      setColor(coverPage?.color_palette_key || "#000000");
+      setText((coverPage?.text_content as string) || "");
+      setImageUrl(coverPage?.image_url || "");
+      setReportTypes(initialReportTypes);
+    }
+  }, [open, coverPage, initialReportTypes]);
+
+  const toggleReportType = (rt: string) => {
+    setReportTypes((prev) =>
+      prev.includes(rt) ? prev.filter((t) => t !== rt) : [...prev, rt]
+    );
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await onSave({
+      name,
+      templateSlug: template,
+      colorPaletteKey: color,
+      textContent: text,
+      imageUrl,
+      reportTypes,
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{coverPage ? "Edit Cover Page" : "New Cover Page"}</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="space-y-4">
+            <div>
+              <Label htmlFor="name">Name</Label>
+              <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+            </div>
+            <div>
+              <Label>Template</Label>
+              <Select value={template} onValueChange={setTemplate}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {TEMPLATES.map((t) => (
+                    <SelectItem key={t.value} value={t.value}>
+                      {t.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label htmlFor="text">Text</Label>
+              <Textarea
+                id="text"
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label htmlFor="color">Color</Label>
+              <Input
+                id="color"
+                type="color"
+                value={color}
+                onChange={(e) => setColor(e.target.value)}
+              />
+            </div>
+            <div>
+              <Label htmlFor="imageUrl">Image URL</Label>
+              <Input
+                id="imageUrl"
+                value={imageUrl}
+                onChange={(e) => setImageUrl(e.target.value)}
+                placeholder="https://"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Report Types</Label>
+              {REPORT_TYPES.map((rt) => (
+                <div key={rt.value} className="flex items-center space-x-2">
+                  <Checkbox
+                    id={`rt-${rt.value}`}
+                    checked={reportTypes.includes(rt.value)}
+                    onCheckedChange={() => toggleReportType(rt.value)}
+                  />
+                  <label htmlFor={`rt-${rt.value}`} className="text-sm">
+                    {rt.label}
+                  </label>
+                </div>
+              ))}
+            </div>
+            <div className="flex gap-2">
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button type="submit">{coverPage ? "Save" : "Create"}</Button>
+            </div>
+          </div>
+          <div className="flex items-start justify-center">
+            <CoverPagePreview
+              title={name}
+              text={text}
+              color={color}
+              imageUrl={imageUrl}
+            />
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default CoverPageEditor;

--- a/src/components/cover-pages/CoverPageList.tsx
+++ b/src/components/cover-pages/CoverPageList.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import type { CoverPage } from "@/integrations/supabase/coverPagesApi";
+import { Button } from "@/components/ui/button";
+
+interface CoverPageListProps {
+  coverPages: CoverPage[];
+  onEdit: (cp: CoverPage) => void;
+  onCreate: () => void;
+}
+
+export function CoverPageList({ coverPages, onEdit, onCreate }: CoverPageListProps) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-bold">Cover Pages</h2>
+        <Button onClick={onCreate}>New Cover Page</Button>
+      </div>
+      <ul className="space-y-2">
+        {coverPages.map((cp) => (
+          <li
+            key={cp.id}
+            className="border rounded p-4 flex items-center justify-between"
+          >
+            <span>{cp.name}</span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onEdit(cp)}
+            >
+              Edit
+            </Button>
+          </li>
+        ))}
+        {coverPages.length === 0 && (
+          <li className="text-sm text-muted-foreground">No cover pages yet.</li>
+        )}
+      </ul>
+    </div>
+  );
+}
+
+export default CoverPageList;

--- a/src/components/cover-pages/CoverPagePreview.tsx
+++ b/src/components/cover-pages/CoverPagePreview.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+interface CoverPagePreviewProps {
+  title: string;
+  text?: string;
+  color: string;
+  imageUrl?: string | null;
+}
+
+export function CoverPagePreview({ title, text, color, imageUrl }: CoverPagePreviewProps) {
+  return (
+    <div className="border rounded overflow-hidden w-full max-w-sm">
+      <div
+        className="h-40 flex items-center justify-center bg-muted"
+        style={{ backgroundColor: color }}
+      >
+        {imageUrl ? (
+          <img src={imageUrl} alt="cover" className="max-h-full" />
+        ) : (
+          <span className="text-sm text-muted-foreground">No image</span>
+        )}
+      </div>
+      <div className="p-4 text-center">
+        <h2 className="font-bold text-xl">{title || "Untitled"}</h2>
+        {text && <p className="mt-2 text-sm whitespace-pre-wrap">{text}</p>}
+      </div>
+    </div>
+  );
+}
+
+export default CoverPagePreview;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -60,6 +60,9 @@ const Header: React.FC = () => {
               <Link to="/section-manager" className="transition-colors hover:text-primary">
                 Section Manager
               </Link>
+              <Link to="/cover-page-manager" className="transition-colors hover:text-primary">
+                Cover Pages
+              </Link>
             </>
           ) : (
             <>
@@ -112,6 +115,9 @@ const Header: React.FC = () => {
                   </DropdownMenuItem>
                   <DropdownMenuItem asChild>
                     <Link to="/section-manager">Section Manager</Link>
+                  </DropdownMenuItem>
+                  <DropdownMenuItem asChild>
+                    <Link to="/cover-page-manager">Cover Page Manager</Link>
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem

--- a/src/pages/CoverPageManager.tsx
+++ b/src/pages/CoverPageManager.tsx
@@ -1,0 +1,145 @@
+import { useState } from "react";
+import Seo from "@/components/Seo";
+import { CoverPageList } from "@/components/cover-pages/CoverPageList";
+import { CoverPageEditor } from "@/components/cover-pages/CoverPageEditor";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import useCoverPages from "@/hooks/useCoverPages";
+import type { CoverPage } from "@/integrations/supabase/coverPagesApi";
+
+const REPORT_TYPES = [
+  { value: "home_inspection", label: "Home Inspection" },
+  { value: "wind_mitigation", label: "Wind Mitigation" },
+];
+
+export default function CoverPageManager() {
+  const {
+    coverPages,
+    assignments,
+    createCoverPage,
+    updateCoverPage,
+    assignCoverPageToReportType,
+    removeAssignmentFromReportType,
+  } = useCoverPages();
+
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editing, setEditing] = useState<CoverPage | undefined>();
+  const [initialReportTypes, setInitialReportTypes] = useState<string[]>([]);
+
+  const handleCreate = () => {
+    setEditing(undefined);
+    setInitialReportTypes([]);
+    setEditorOpen(true);
+  };
+
+  const handleEdit = (cp: CoverPage) => {
+    setEditing(cp);
+    const assigned = assignments
+      .filter((a) => a.cover_page_id === cp.id)
+      .map((a) => a.report_type);
+    setInitialReportTypes(assigned);
+    setEditorOpen(true);
+  };
+
+  const handleSave = async (data: {
+    name: string;
+    templateSlug?: string;
+    colorPaletteKey?: string;
+    textContent?: string;
+    imageUrl?: string;
+    reportTypes: string[];
+  }) => {
+    if (editing) {
+      await updateCoverPage(editing.id, {
+        name: data.name,
+        template_slug: data.templateSlug,
+        color_palette_key: data.colorPaletteKey,
+        text_content: data.textContent,
+        image_url: data.imageUrl,
+      });
+      const current = assignments
+        .filter((a) => a.cover_page_id === editing.id)
+        .map((a) => a.report_type);
+      for (const rt of current) {
+        if (!data.reportTypes.includes(rt)) {
+          await removeAssignmentFromReportType(rt);
+        }
+      }
+      for (const rt of data.reportTypes) {
+        await assignCoverPageToReportType(rt, editing.id);
+      }
+    } else {
+      const newCp = await createCoverPage({
+        name: data.name,
+        template_slug: data.templateSlug,
+        color_palette_key: data.colorPaletteKey,
+        text_content: data.textContent,
+        image_url: data.imageUrl,
+      });
+      for (const rt of data.reportTypes) {
+        await assignCoverPageToReportType(rt, newCp.id);
+      }
+    }
+    setEditorOpen(false);
+  };
+
+  const currentAssignment = (rt: string) =>
+    assignments.find((a) => a.report_type === rt)?.cover_page_id || "";
+
+  const handleReportTypeChange = async (rt: string, coverPageId: string) => {
+    if (!coverPageId) {
+      await removeAssignmentFromReportType(rt);
+    } else {
+      await assignCoverPageToReportType(rt, coverPageId);
+    }
+  };
+
+  return (
+    <>
+      <Seo
+        title="Cover Page Manager - Home Inspection Platform"
+        description="Manage custom cover pages for your reports"
+      />
+      <div className="max-w-4xl mx-auto p-4 space-y-8">
+        <CoverPageList
+          coverPages={coverPages}
+          onEdit={handleEdit}
+          onCreate={handleCreate}
+        />
+
+        <div className="space-y-4">
+          <h2 className="text-xl font-bold">Report Type Assignments</h2>
+          {REPORT_TYPES.map((rt) => (
+            <div key={rt.value} className="flex items-center gap-2">
+              <Label className="w-40">{rt.label}</Label>
+              <Select
+                value={currentAssignment(rt.value)}
+                onValueChange={(value) => handleReportTypeChange(rt.value, value)}
+              >
+                <SelectTrigger className="w-[250px]">
+                  <SelectValue placeholder="Select cover page" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="">None</SelectItem>
+                  {coverPages.map((cp) => (
+                    <SelectItem key={cp.id} value={cp.id}>
+                      {cp.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ))}
+        </div>
+
+        <CoverPageEditor
+          open={editorOpen}
+          onOpenChange={setEditorOpen}
+          coverPage={editing}
+          initialReportTypes={initialReportTypes}
+          onSave={handleSave}
+        />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add cover page manager page with list, editor and assignments
- implement cover page preview component
- expose cover page manager route and navigation links

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type, Unexpected lexical declaration in case block, Unexpected any, A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a75691c0588333a66796cc81672c1c