### PR TITLE
Add cover page selection and persistence

### DIFF
--- a/src/hooks/useLocalDraft.ts
+++ b/src/hooks/useLocalDraft.ts
@@ -61,6 +61,7 @@ export function createReport(meta: {
   address: string;
   inspectionDate: string;
   reportType?: "home_inspection" | "wind_mitigation";
+  coverPageId?: string;
 }): Report {
   const id = crypto.randomUUID();
   const reportType = meta.reportType || "home_inspection";
@@ -84,6 +85,7 @@ export function createReport(meta: {
       status: "Draft",
       finalComments: "",
       coverImage: "",
+      coverPageId: meta.coverPageId || "",
       previewTemplate: "classic",
       reportType: "home_inspection",
       sections,
@@ -98,6 +100,7 @@ export function createReport(meta: {
       status: "Draft",
       finalComments: "",
       coverImage: "",
+      coverPageId: meta.coverPageId || "",
       previewTemplate: "classic",
       reportType: "wind_mitigation",
       reportData: {

--- a/src/integrations/supabase/reportsApi.ts
+++ b/src/integrations/supabase/reportsApi.ts
@@ -23,6 +23,7 @@ function toDbPayload(report: Report) {
     status: report.status,
     final_comments: report.finalComments || null,
     cover_image: report.coverImage || null,
+    cover_page_id: report.coverPageId || null,
     preview_template: report.previewTemplate || 'classic',
     report_type: report.reportType,
     report_data: report.reportType === "wind_mitigation" ? report.reportData : null,
@@ -51,6 +52,7 @@ function fromDbRow(row: any): Report {
     status: row.status,
     finalComments: row.final_comments || "",
     coverImage: row.cover_image || "",
+    coverPageId: row.cover_page_id || "",
     previewTemplate: row.preview_template || "classic",
     reportData: row.report_data ?? {},
     reportType,
@@ -166,6 +168,7 @@ export async function dbCreateReport(meta: {
   insuranceCompany?: string;
   policyNumber?: string;
   email?: string;
+  coverPageId?: string;
 }, userId: string, organizationId?: string): Promise<Report> {
   const id = crypto.randomUUID();
 
@@ -190,6 +193,7 @@ export async function dbCreateReport(meta: {
       status: "Draft",
       finalComments: "",
       coverImage: "",
+      coverPageId: meta.coverPageId || "",
       previewTemplate: "classic",
       reportType: "home_inspection",
       sections,
@@ -207,6 +211,7 @@ export async function dbCreateReport(meta: {
       status: "Draft",
       finalComments: "",
       coverImage: "",
+      coverPageId: meta.coverPageId || "",
       previewTemplate: "classic",
       reportType: "wind_mitigation",
       phoneHome: meta.phoneHome || "",

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -568,6 +568,7 @@ export type Database = {
           client_name: string
           contact_id: string | null
           cover_image: string | null
+          cover_page_id: string | null
           created_at: string
           email: string | null
           final_comments: string | null
@@ -594,6 +595,7 @@ export type Database = {
           client_name: string
           contact_id?: string | null
           cover_image?: string | null
+          cover_page_id?: string | null
           created_at?: string
           email?: string | null
           final_comments?: string | null
@@ -620,6 +622,7 @@ export type Database = {
           client_name?: string
           contact_id?: string | null
           cover_image?: string | null
+          cover_page_id?: string | null
           created_at?: string
           email?: string | null
           final_comments?: string | null
@@ -646,6 +649,13 @@ export type Database = {
             columns: ["contact_id"]
             isOneToOne: false
             referencedRelation: "contacts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "reports_cover_page_id_fkey"
+            columns: ["cover_page_id"]
+            isOneToOne: false
+            referencedRelation: "cover_pages"
             referencedColumns: ["id"]
           },
           {

--- a/src/lib/reportSchemas.ts
+++ b/src/lib/reportSchemas.ts
@@ -52,6 +52,7 @@ export const BaseReportSchema = z.object({
     status: z.enum(["Draft", "Final"]).default("Draft"),
     finalComments: z.string().optional().default(""),
     coverImage: z.string().optional().default(""),
+    coverPageId: z.string().optional().default(""),
     previewTemplate: z.enum(["classic", "modern", "minimal"]).default("classic"),
     reportType: z.enum(["home_inspection", "wind_mitigation"]),
 });

--- a/src/pages/ReportEditor.tsx
+++ b/src/pages/ReportEditor.tsx
@@ -30,6 +30,8 @@ import { cn } from "@/lib/utils";
 import { useCustomSections } from "@/hooks/useCustomSections";
 import { CustomSectionDialog } from "@/components/reports/CustomSectionDialog";
 import { Plus } from "lucide-react";
+import useCoverPages from "@/hooks/useCoverPages";
+import { Label } from "@/components/ui/label";
 
 // Lazy load wind mitigation editor at module level
 const WindMitigationEditor = React.lazy(() => import("@/components/reports/WindMitigationEditor"));
@@ -78,9 +80,10 @@ const ReportEditor: React.FC = () => {
   const [currentFindingId, setCurrentFindingId] = React.useState<string | null>(null);
   const [selectedContactId, setSelectedContactId] = React.useState<string>("");
   const [customSectionDialogOpen, setCustomSectionDialogOpen] = React.useState(false);
-  
+
   // Custom sections hook
   const { customSections, loadCustomSections } = useCustomSections();
+  const { coverPages, assignments } = useCoverPages();
 
   // Handle contact change to update address automatically
   const handleContactChange = React.useCallback((contact: any) => {
@@ -168,6 +171,15 @@ const ReportEditor: React.FC = () => {
       } : prev);
     }
   }, [customSections, report?.id]);
+
+  React.useEffect(() => {
+    if (!report) return;
+    if (report.coverPageId) return;
+    const assigned = assignments.find(a => a.report_type === report.reportType);
+    if (assigned) {
+      setReport(prev => prev ? { ...prev, coverPageId: assigned.cover_page_id } : prev);
+    }
+  }, [assignments, report?.reportType, report?.id]);
 
   useAutosave({
     value: report,
@@ -1034,6 +1046,27 @@ const ReportEditor: React.FC = () => {
               ) : (
                 <p className="text-sm text-muted-foreground">No report details fields configured.</p>
               )}
+              <div className="space-y-2">
+                <Label>Cover Page</Label>
+                <Select
+                  value={report.coverPageId || ""}
+                  onValueChange={(val) =>
+                    setReport((prev) => (prev ? { ...prev, coverPageId: val } : prev))
+                  }
+                >
+                  <SelectTrigger className="w-[250px]">
+                    <SelectValue placeholder="Select cover page" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="">None</SelectItem>
+                    {coverPages.map((cp) => (
+                      <SelectItem key={cp.id} value={cp.id}>
+                        {cp.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
             </section>
           )}
 

--- a/supabase/migrations/20250822120000_add_cover_page_id_to_reports.sql
+++ b/supabase/migrations/20250822120000_add_cover_page_id_to_reports.sql
@@ -1,0 +1,5 @@
+-- Add cover_page_id column to reports table
+ALTER TABLE reports
+  ADD COLUMN IF NOT EXISTS cover_page_id uuid REFERENCES cover_pages(id);
+
+CREATE INDEX IF NOT EXISTS idx_reports_cover_page_id ON reports(cover_page_id);


### PR DESCRIPTION
## Summary
- allow selecting cover pages when creating or editing reports
- default new reports to their assigned cover page
- store selected coverPageId on reports and database

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 187 problems (169 errors, 18 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a7580f03248333be58a0bdea15ebaf