### PR TITLE
Use 'none' sentinel for unassigned cover pages

### DIFF
--- a/src/components/reports/WindMitigationEditor.tsx
+++ b/src/components/reports/WindMitigationEditor.tsx
@@ -84,14 +84,16 @@ const WindMitigationEditor: React.FC<WindMitigationEditorProps> = ({report, onUp
                     <div className="space-y-2">
                         <Label>Cover Page</Label>
                         <Select
-                            value={report.coverPageId || ""}
-                            onValueChange={(val) => onUpdate({...report, coverPageId: val})}
+                            value={report.coverPageId || "none"}
+                            onValueChange={(val) =>
+                                onUpdate({ ...report, coverPageId: val === "none" ? undefined : val })
+                            }
                         >
                             <SelectTrigger className="w-[180px]">
                                 <SelectValue placeholder="Select cover page" />
                             </SelectTrigger>
                             <SelectContent>
-                                <SelectItem value="">None</SelectItem>
+                                <SelectItem value="none">None</SelectItem>
                                 {coverPages.map((cp) => (
                                     <SelectItem key={cp.id} value={cp.id}>
                                         {cp.name}

--- a/src/pages/CoverPageManager.tsx
+++ b/src/pages/CoverPageManager.tsx
@@ -84,10 +84,10 @@ export default function CoverPageManager() {
   };
 
   const currentAssignment = (rt: string) =>
-    assignments.find((a) => a.report_type === rt)?.cover_page_id || "";
+    assignments.find((a) => a.report_type === rt)?.cover_page_id || "none";
 
   const handleReportTypeChange = async (rt: string, coverPageId: string) => {
-    if (!coverPageId) {
+    if (coverPageId === "none") {
       await removeAssignmentFromReportType(rt);
     } else {
       await assignCoverPageToReportType(rt, coverPageId);
@@ -120,7 +120,7 @@ export default function CoverPageManager() {
                   <SelectValue placeholder="Select cover page" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="">None</SelectItem>
+                  <SelectItem value="none">None</SelectItem>
                   {coverPages.map((cp) => (
                     <SelectItem key={cp.id} value={cp.id}>
                       {cp.name}

--- a/src/pages/HomeInspectionNew.tsx
+++ b/src/pages/HomeInspectionNew.tsx
@@ -58,7 +58,7 @@ const HomeInspectionNew: React.FC = () => {
       address: "",
       inspectionDate: new Date().toISOString().slice(0, 10),
       contactId: contactId || "",
-      coverPageId: "",
+      coverPageId: "none",
     },
   });
 
@@ -98,7 +98,7 @@ const HomeInspectionNew: React.FC = () => {
             inspectionDate: values.inspectionDate,
             contact_id: values.contactId,
             reportType: "home_inspection",
-            coverPageId: values.coverPageId,
+            coverPageId: values.coverPageId === "none" ? undefined : values.coverPageId,
           },
           user.id,
           profile?.organization_id || undefined
@@ -112,7 +112,7 @@ const HomeInspectionNew: React.FC = () => {
           address: values.address,
           inspectionDate: new Date(values.inspectionDate).toISOString(),
           reportType: "home_inspection",
-          coverPageId: values.coverPageId,
+          coverPageId: values.coverPageId === "none" ? undefined : values.coverPageId,
         });
         toast({ title: "Home inspection report created (local draft)" });
         nav(`/reports/${report.id}`);
@@ -244,14 +244,14 @@ const HomeInspectionNew: React.FC = () => {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Cover Page</FormLabel>
-                  <Select onValueChange={field.onChange} value={field.value}>
+                  <Select onValueChange={field.onChange} value={field.value || "none"}>
                     <FormControl>
                       <SelectTrigger>
                         <SelectValue placeholder="Select cover page" />
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      <SelectItem value="">None</SelectItem>
+                      <SelectItem value="none">None</SelectItem>
                       {coverPages.map(cp => (
                         <SelectItem key={cp.id} value={cp.id}>{cp.name}</SelectItem>
                       ))}

--- a/src/pages/ReportEditor.tsx
+++ b/src/pages/ReportEditor.tsx
@@ -1049,16 +1049,18 @@ const ReportEditor: React.FC = () => {
               <div className="space-y-2">
                 <Label>Cover Page</Label>
                 <Select
-                  value={report.coverPageId || ""}
+                  value={report.coverPageId || "none"}
                   onValueChange={(val) =>
-                    setReport((prev) => (prev ? { ...prev, coverPageId: val } : prev))
+                    setReport((prev) =>
+                      prev ? { ...prev, coverPageId: val === "none" ? undefined : val } : prev
+                    )
                   }
                 >
                   <SelectTrigger className="w-[250px]">
                     <SelectValue placeholder="Select cover page" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="">None</SelectItem>
+                    <SelectItem value="none">None</SelectItem>
                     {coverPages.map((cp) => (
                       <SelectItem key={cp.id} value={cp.id}>
                         {cp.name}

--- a/src/pages/WindMitigationNew.tsx
+++ b/src/pages/WindMitigationNew.tsx
@@ -67,7 +67,7 @@ const WindMitigationNew: React.FC = () => {
       insuranceCompany: "",
       policyNumber: "",
       email: "",
-      coverPageId: "",
+      coverPageId: "none",
     },
   });
 
@@ -126,7 +126,7 @@ const WindMitigationNew: React.FC = () => {
             insuranceCompany: values.insuranceCompany,
             policyNumber: values.policyNumber,
             email: values.email,
-            coverPageId: values.coverPageId,
+            coverPageId: values.coverPageId === "none" ? undefined : values.coverPageId,
           },
           user.id,
           profile?.organization_id || undefined
@@ -349,14 +349,14 @@ const WindMitigationNew: React.FC = () => {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Cover Page</FormLabel>
-                  <Select onValueChange={field.onChange} value={field.value}>
+                  <Select onValueChange={field.onChange} value={field.value || "none"}>
                     <FormControl>
                       <SelectTrigger>
                         <SelectValue placeholder="Select cover page" />
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      <SelectItem value="">None</SelectItem>
+                      <SelectItem value="none">None</SelectItem>
                       {coverPages.map(cp => (
                         <SelectItem key={cp.id} value={cp.id}>{cp.name}</SelectItem>
                       ))}


### PR DESCRIPTION
## Summary
- Replace empty string cover page options with explicit `"none"` value
- Remove cover page assignments when `"none"` is selected
- Default new report forms to `"none"` and translate it to `undefined` on save

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 187 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a760aebc44833387acb6802ee441d3