### PR TITLE
Add default cover page selection per report type

### DIFF
--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -52,9 +52,9 @@ export default function CoverPageEditorPage() {
 
   useEffect(() => {
     if (coverPage) {
-      const assigned = assignments
-        .filter((a) => a.cover_page_id === coverPage.id)
-        .map((a) => a.report_type);
+      const assigned = Object.entries(assignments)
+        .filter(([_, id]) => id === coverPage.id)
+        .map(([rt]) => rt);
       reset({
         name: coverPage.name || "",
         template: coverPage.template_slug || "default",
@@ -75,9 +75,9 @@ export default function CoverPageEditorPage() {
         text_content: data.text,
         image_url: data.imageUrl,
       });
-      const current = assignments
-        .filter((a) => a.cover_page_id === coverPage.id)
-        .map((a) => a.report_type);
+      const current = Object.entries(assignments)
+        .filter(([_, id]) => id === coverPage.id)
+        .map(([rt]) => rt);
       for (const rt of current) {
         if (!data.reportTypes.includes(rt)) {
           await removeAssignmentFromReportType(rt);

--- a/src/pages/CoverPageManager.tsx
+++ b/src/pages/CoverPageManager.tsx
@@ -1,7 +1,6 @@
+import { Link } from "react-router-dom";
 import Seo from "@/components/Seo";
-import { CoverPageList } from "@/components/cover-pages/CoverPageList";
-import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
 import useCoverPages from "@/hooks/useCoverPages";
 
 const REPORT_TYPES = [
@@ -17,14 +16,13 @@ export default function CoverPageManager() {
     removeAssignmentFromReportType,
   } = useCoverPages();
 
-  const currentAssignment = (rt: string) =>
-    assignments.find((a) => a.report_type === rt)?.cover_page_id || "none";
+  const isAssigned = (rt: string, id: string) => assignments[rt] === id;
 
-  const handleReportTypeChange = async (rt: string, coverPageId: string) => {
-    if (coverPageId === "none") {
+  const handleToggle = async (rt: string, id: string) => {
+    if (isAssigned(rt, id)) {
       await removeAssignmentFromReportType(rt);
     } else {
-      await assignCoverPageToReportType(rt, coverPageId);
+      await assignCoverPageToReportType(rt, id);
     }
   };
 
@@ -35,33 +33,44 @@ export default function CoverPageManager() {
         description="Manage custom cover pages for your reports"
       />
       <div className="max-w-4xl mx-auto p-4 space-y-8">
-        <CoverPageList coverPages={coverPages} />
-
         <div className="space-y-4">
-          <h2 className="text-xl font-bold">Report Type Assignments</h2>
-          {REPORT_TYPES.map((rt) => (
-            <div key={rt.value} className="flex items-center gap-2">
-              <Label className="w-40">{rt.label}</Label>
-              <Select
-                value={currentAssignment(rt.value)}
-                onValueChange={(value) => handleReportTypeChange(rt.value, value)}
+          <div className="flex items-center justify-between">
+            <h2 className="text-xl font-bold">Cover Pages</h2>
+            <Button asChild>
+              <Link to="/cover-page-manager/new">Create New Cover Page</Link>
+            </Button>
+          </div>
+          <ul className="space-y-2">
+            {coverPages.map((cp) => (
+              <li
+                key={cp.id}
+                className="border rounded p-4 flex flex-col gap-2"
               >
-                <SelectTrigger className="w-[250px]">
-                  <SelectValue placeholder="Select cover page" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="none">None</SelectItem>
-                  {coverPages.map((cp) => (
-                    <SelectItem key={cp.id} value={cp.id}>
-                      {cp.name}
-                    </SelectItem>
+                <div className="flex items-center justify-between">
+                  <span>{cp.name}</span>
+                  <Button asChild variant="outline" size="sm">
+                    <Link to={`/cover-page-manager/${cp.id}`}>Edit</Link>
+                  </Button>
+                </div>
+                <div className="flex gap-2">
+                  {REPORT_TYPES.map((rt) => (
+                    <Button
+                      key={rt.value}
+                      variant={isAssigned(rt.value, cp.id) ? "default" : "outline"}
+                      size="sm"
+                      onClick={() => handleToggle(rt.value, cp.id)}
+                    >
+                      {rt.label}
+                    </Button>
                   ))}
-                </SelectContent>
-              </Select>
-            </div>
-          ))}
+                </div>
+              </li>
+            ))}
+            {coverPages.length === 0 && (
+              <li className="text-sm text-muted-foreground">No cover pages yet.</li>
+            )}
+          </ul>
         </div>
-
       </div>
     </>
   );

--- a/src/pages/HomeInspectionNew.tsx
+++ b/src/pages/HomeInspectionNew.tsx
@@ -74,9 +74,9 @@ const HomeInspectionNew: React.FC = () => {
   }, [contact, form]);
 
   useEffect(() => {
-    const assigned = assignments.find(a => a.report_type === "home_inspection");
-    if (assigned) {
-      form.setValue("coverPageId", assigned.cover_page_id);
+    const assignedId = assignments["home_inspection"];
+    if (assignedId) {
+      form.setValue("coverPageId", assignedId);
     }
   }, [assignments, form]);
 

--- a/src/pages/ReportEditor.tsx
+++ b/src/pages/ReportEditor.tsx
@@ -175,9 +175,9 @@ const ReportEditor: React.FC = () => {
   React.useEffect(() => {
     if (!report) return;
     if (report.coverPageId) return;
-    const assigned = assignments.find(a => a.report_type === report.reportType);
-    if (assigned) {
-      setReport(prev => prev ? { ...prev, coverPageId: assigned.cover_page_id } : prev);
+    const assignedId = assignments[report.reportType];
+    if (assignedId) {
+      setReport(prev => prev ? { ...prev, coverPageId: assignedId } : prev);
     }
   }, [assignments, report?.reportType, report?.id]);
 

--- a/src/pages/WindMitigationNew.tsx
+++ b/src/pages/WindMitigationNew.tsx
@@ -94,9 +94,9 @@ const WindMitigationNew: React.FC = () => {
   }, [contact, form]);
 
   useEffect(() => {
-    const assigned = assignments.find(a => a.report_type === "wind_mitigation");
-    if (assigned) {
-      form.setValue("coverPageId", assigned.cover_page_id);
+    const assignedId = assignments["wind_mitigation"];
+    if (assignedId) {
+      form.setValue("coverPageId", assignedId);
     }
   }, [assignments, form]);
 

--- a/supabase/migrations/20250824120000_add_unique_constraint_cover_page_assignments.sql
+++ b/supabase/migrations/20250824120000_add_unique_constraint_cover_page_assignments.sql
@@ -1,0 +1,7 @@
+DO $$ BEGIN
+    ALTER TABLE public.cover_page_assignments
+        ADD CONSTRAINT cover_page_assignments_user_id_report_type_key
+        UNIQUE (user_id, report_type);
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;


### PR DESCRIPTION
## Summary
- allow choosing a default cover page for Home Inspection or Wind Mitigation
- fetch and update single cover page assignment per report type
- ensure cover_page_assignments table has unique constraint on `(user_id, report_type)`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 187 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a7cd0631588333917ae8a3273693e1