### PR TITLE
Remove per-report cover page selection

### DIFF
--- a/src/components/reports/WindMitigationEditor.tsx
+++ b/src/components/reports/WindMitigationEditor.tsx
@@ -4,8 +4,6 @@ import {zodResolver} from "@hookform/resolvers/zod";
 import {WindMitigationData, WindMitigationDataSchema, WindMitigationReport} from "@/lib/reportSchemas";
 import {Form} from "@/components/ui/form";
 import {Button} from "@/components/ui/button";
-import {Label} from "@/components/ui/label";
-import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "@/components/ui/select";
 import {toast} from "@/hooks/use-toast";
 import {WIND_MITIGATION_QUESTIONS} from "@/constants/windMitigationQuestions";
 import {BuildingCodeQuestion} from "./windmitigation/BuildingCodeQuestion";
@@ -14,7 +12,6 @@ import {OpeningProtectionQuestion} from "./windmitigation/OpeningProtectionQuest
 import {GenericQuestion} from "./windmitigation/GenericQuestion";
 import {RoofToWallQuestion} from "./windmitigation/RoofToWallQuestion";
 import {dbUpdateReport} from "@/integrations/supabase/reportsApi.ts";
-import useCoverPages from "@/hooks/useCoverPages";
 
 interface WindMitigationEditorProps {
     report: WindMitigationReport;
@@ -39,7 +36,6 @@ const WindMitigationEditor: React.FC<WindMitigationEditorProps> = ({report, onUp
 
     const {watch, control} = form;
 
-    const {coverPages} = useCoverPages();
 
     const handleSave = async () => {
         try {
@@ -81,27 +77,7 @@ const WindMitigationEditor: React.FC<WindMitigationEditorProps> = ({report, onUp
                     <p className="text-sm text-muted-foreground">Form {WIND_MITIGATION_QUESTIONS.version}</p>
                 </div>
                 <div className="flex items-center gap-2">
-                    <div className="space-y-2">
-                        <Label>Cover Page</Label>
-                        <Select
-                            value={report.coverPageId || "none"}
-                            onValueChange={(val) =>
-                                onUpdate({ ...report, coverPageId: val === "none" ? undefined : val })
-                            }
-                        >
-                            <SelectTrigger className="w-[180px]">
-                                <SelectValue placeholder="Select cover page" />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value="none">None</SelectItem>
-                                {coverPages.map((cp) => (
-                                    <SelectItem key={cp.id} value={cp.id}>
-                                        {cp.name}
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        </Select>
-                    </div>
+                    {/* Cover page selection removed */}
                     <Button onClick={handleSave} className="shrink-0">
                         Save Report
                     </Button>

--- a/src/hooks/useLocalDraft.ts
+++ b/src/hooks/useLocalDraft.ts
@@ -61,7 +61,6 @@ export function createReport(meta: {
   address: string;
   inspectionDate: string;
   reportType?: "home_inspection" | "wind_mitigation";
-  coverPageId?: string;
 }): Report {
   const id = crypto.randomUUID();
   const reportType = meta.reportType || "home_inspection";
@@ -85,7 +84,6 @@ export function createReport(meta: {
       status: "Draft",
       finalComments: "",
       coverImage: "",
-      coverPageId: meta.coverPageId || "",
       previewTemplate: "classic",
       reportType: "home_inspection",
       sections,
@@ -100,7 +98,6 @@ export function createReport(meta: {
       status: "Draft",
       finalComments: "",
       coverImage: "",
-      coverPageId: meta.coverPageId || "",
       previewTemplate: "classic",
       reportType: "wind_mitigation",
       reportData: {

--- a/src/integrations/supabase/reportsApi.ts
+++ b/src/integrations/supabase/reportsApi.ts
@@ -23,7 +23,6 @@ function toDbPayload(report: Report) {
     status: report.status,
     final_comments: report.finalComments || null,
     cover_image: report.coverImage || null,
-    cover_page_id: report.coverPageId || null,
     preview_template: report.previewTemplate || 'classic',
     report_type: report.reportType,
     report_data: report.reportType === "wind_mitigation" ? report.reportData : null,
@@ -52,7 +51,6 @@ function fromDbRow(row: any): Report {
     status: row.status,
     finalComments: row.final_comments || "",
     coverImage: row.cover_image || "",
-    coverPageId: row.cover_page_id || "",
     previewTemplate: row.preview_template || "classic",
     reportData: row.report_data ?? {},
     reportType,
@@ -168,7 +166,6 @@ export async function dbCreateReport(meta: {
   insuranceCompany?: string;
   policyNumber?: string;
   email?: string;
-  coverPageId?: string;
 }, userId: string, organizationId?: string): Promise<Report> {
   const id = crypto.randomUUID();
 
@@ -193,7 +190,6 @@ export async function dbCreateReport(meta: {
       status: "Draft",
       finalComments: "",
       coverImage: "",
-      coverPageId: meta.coverPageId || "",
       previewTemplate: "classic",
       reportType: "home_inspection",
       sections,
@@ -211,7 +207,6 @@ export async function dbCreateReport(meta: {
       status: "Draft",
       finalComments: "",
       coverImage: "",
-      coverPageId: meta.coverPageId || "",
       previewTemplate: "classic",
       reportType: "wind_mitigation",
       phoneHome: meta.phoneHome || "",

--- a/src/lib/reportSchemas.ts
+++ b/src/lib/reportSchemas.ts
@@ -52,7 +52,6 @@ export const BaseReportSchema = z.object({
     status: z.enum(["Draft", "Final"]).default("Draft"),
     finalComments: z.string().optional().default(""),
     coverImage: z.string().optional().default(""),
-    coverPageId: z.string().optional().default(""),
     previewTemplate: z.enum(["classic", "modern", "minimal"]).default("classic"),
     reportType: z.enum(["home_inspection", "wind_mitigation"]),
 });

--- a/src/pages/HomeInspectionNew.tsx
+++ b/src/pages/HomeInspectionNew.tsx
@@ -16,7 +16,6 @@ import { useAuth } from "@/contexts/AuthContext";
 import { dbCreateReport } from "@/integrations/supabase/reportsApi";
 import { contactsApi } from "@/integrations/supabase/crmApi";
 import { supabase } from "@/integrations/supabase/client";
-import useCoverPages from "@/hooks/useCoverPages";
 
 const schema = z.object({
   title: z.string().min(1, "Required"),
@@ -24,7 +23,6 @@ const schema = z.object({
   address: z.string().min(1, "Address is required"),
   inspectionDate: z.string().min(1, "Required"),
   contactId: z.string().optional(),
-  coverPageId: z.string().optional(),
 });
 
 type Values = z.infer<typeof schema>;
@@ -34,7 +32,6 @@ const HomeInspectionNew: React.FC = () => {
   const { user } = useAuth();
   const [searchParams] = useSearchParams();
   const contactId = searchParams.get("contactId");
-  const { coverPages, assignments } = useCoverPages();
 
   // Get all contacts for lookup
   const { data: contacts = [] } = useQuery({
@@ -58,7 +55,6 @@ const HomeInspectionNew: React.FC = () => {
       address: "",
       inspectionDate: new Date().toISOString().slice(0, 10),
       contactId: contactId || "",
-      coverPageId: "none",
     },
   });
 
@@ -73,12 +69,6 @@ const HomeInspectionNew: React.FC = () => {
     }
   }, [contact, form]);
 
-  useEffect(() => {
-    const assignedId = assignments["home_inspection"];
-    if (assignedId) {
-      form.setValue("coverPageId", assignedId);
-    }
-  }, [assignments, form]);
 
   const onSubmit = async (values: Values) => {
     try {
@@ -98,7 +88,6 @@ const HomeInspectionNew: React.FC = () => {
             inspectionDate: values.inspectionDate,
             contact_id: values.contactId,
             reportType: "home_inspection",
-            coverPageId: values.coverPageId === "none" ? undefined : values.coverPageId,
           },
           user.id,
           profile?.organization_id || undefined
@@ -112,7 +101,6 @@ const HomeInspectionNew: React.FC = () => {
           address: values.address,
           inspectionDate: new Date(values.inspectionDate).toISOString(),
           reportType: "home_inspection",
-          coverPageId: values.coverPageId === "none" ? undefined : values.coverPageId,
         });
         toast({ title: "Home inspection report created (local draft)" });
         nav(`/reports/${report.id}`);
@@ -234,29 +222,6 @@ const HomeInspectionNew: React.FC = () => {
                   <FormControl>
                     <Input type="date" {...field} />
                   </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="coverPageId"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Cover Page</FormLabel>
-                  <Select onValueChange={field.onChange} value={field.value || "none"}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select cover page" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="none">None</SelectItem>
-                      {coverPages.map(cp => (
-                        <SelectItem key={cp.id} value={cp.id}>{cp.name}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
                   <FormMessage />
                 </FormItem>
               )}

--- a/src/pages/ReportEditor.tsx
+++ b/src/pages/ReportEditor.tsx
@@ -23,14 +23,12 @@ import { contactsApi } from "@/integrations/supabase/crmApi";
 import AIAnalyzeDialog from "@/components/reports/AIAnalyzeDialog";
 import { CameraCapture } from "@/components/reports/CameraCapture";
 
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Calendar } from "@/components/ui/calendar";
 import { cn } from "@/lib/utils";
 import { useCustomSections } from "@/hooks/useCustomSections";
 import { CustomSectionDialog } from "@/components/reports/CustomSectionDialog";
 import { Plus } from "lucide-react";
-import useCoverPages from "@/hooks/useCoverPages";
 import { Label } from "@/components/ui/label";
 
 // Lazy load wind mitigation editor at module level
@@ -83,7 +81,6 @@ const ReportEditor: React.FC = () => {
 
   // Custom sections hook
   const { customSections, loadCustomSections } = useCustomSections();
-  const { coverPages, assignments } = useCoverPages();
 
   // Handle contact change to update address automatically
   const handleContactChange = React.useCallback((contact: any) => {
@@ -172,14 +169,6 @@ const ReportEditor: React.FC = () => {
     }
   }, [customSections, report?.id]);
 
-  React.useEffect(() => {
-    if (!report) return;
-    if (report.coverPageId) return;
-    const assignedId = assignments[report.reportType];
-    if (assignedId) {
-      setReport(prev => prev ? { ...prev, coverPageId: assignedId } : prev);
-    }
-  }, [assignments, report?.reportType, report?.id]);
 
   useAutosave({
     value: report,
@@ -1046,29 +1035,6 @@ const ReportEditor: React.FC = () => {
               ) : (
                 <p className="text-sm text-muted-foreground">No report details fields configured.</p>
               )}
-              <div className="space-y-2">
-                <Label>Cover Page</Label>
-                <Select
-                  value={report.coverPageId || "none"}
-                  onValueChange={(val) =>
-                    setReport((prev) =>
-                      prev ? { ...prev, coverPageId: val === "none" ? undefined : val } : prev
-                    )
-                  }
-                >
-                  <SelectTrigger className="w-[250px]">
-                    <SelectValue placeholder="Select cover page" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">None</SelectItem>
-                    {coverPages.map((cp) => (
-                      <SelectItem key={cp.id} value={cp.id}>
-                        {cp.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
             </section>
           )}
 

--- a/src/pages/ReportPreview.tsx
+++ b/src/pages/ReportPreview.tsx
@@ -7,8 +7,6 @@ import {useAuth} from "@/contexts/AuthContext";
 import {dbGetReport, dbUpdateReport} from "@/integrations/supabase/reportsApi";
 import {Report} from "@/lib/reportSchemas";
 import {getSignedUrlFromSupabaseUrl, isSupabaseUrl} from "@/integrations/supabase/storage";
-import {coverPagesApi} from "@/integrations/supabase/coverPagesApi";
-import {CoverPagePreview} from "@/components/cover-pages/CoverPagePreview";
 import {Badge} from "@/components/ui/badge";
 import {PREVIEW_TEMPLATES} from "@/constants/previewTemplates";
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "@/components/ui/select";
@@ -85,7 +83,6 @@ const ReportPreview: React.FC = () => {
     const [report, setReport] = React.useState<Report | null>(null);
     const [mediaUrlMap, setMediaUrlMap] = React.useState<Record<string, string>>({});
     const [coverUrl, setCoverUrl] = React.useState<string>("");
-    const [coverPage, setCoverPage] = React.useState<{ color: string; text?: string; imageUrl?: string } | null>(null);
     const [isGeneratingPDF, setIsGeneratingPDF] = React.useState(false);
     const pdfRef = React.useRef<HTMLDivElement>(null);
 
@@ -217,33 +214,7 @@ const ReportPreview: React.FC = () => {
                     if (!cancelled) setCoverUrl(report.coverImage);
                 }
             }
-            // cover page
-            if (report.coverPageId) {
-                try {
-                    const pages = await coverPagesApi.getCoverPages(user.id);
-                    const cp = pages.find((p) => p.id === report.coverPageId);
-                    if (cp) {
-                        let imageUrl = cp.image_url || undefined;
-                        if (imageUrl && isSupabaseUrl(imageUrl)) {
-                            imageUrl = await getSignedUrlFromSupabaseUrl(imageUrl);
-                        }
-                        if (!cancelled) {
-                            setCoverPage({
-                                color: cp.color_palette_key || "#000000",
-                                text: (cp.text_content as string) || "",
-                                imageUrl,
-                            });
-                        }
-                    } else if (!cancelled) {
-                        setCoverPage(null);
-                    }
-                } catch (e) {
-                    console.error(e);
-                    if (!cancelled) setCoverPage(null);
-                }
-            } else if (!cancelled) {
-                setCoverPage(null);
-            }
+            // cover page selection removed
         })();
 
         return () => {
@@ -344,16 +315,7 @@ const ReportPreview: React.FC = () => {
                     {isGeneratingPDF ? 'Generating PDF...' : 'Download PDF'}
                 </Button>
             </div>
-            {coverPage && (
-                <section className="page-break flex justify-center">
-                    <CoverPagePreview
-                        title={report.title}
-                        text={coverPage.text}
-                        color={coverPage.color}
-                        imageUrl={coverPage.imageUrl}
-                    />
-                </section>
-            )}
+            {/* Cover page preview removed */}
             <article className={tpl.container}>
                 {/* Cover Page */}
                 <section className={`${tpl.cover} page-break`}>
@@ -489,12 +451,6 @@ const ReportPreview: React.FC = () => {
                     report={report}
                     mediaUrlMap={mediaUrlMap}
                     coverUrl={coverUrl}
-                    coverPage={coverPage ? {
-                        title: report.title,
-                        text: coverPage.text,
-                        color: coverPage.color,
-                        imageUrl: coverPage.imageUrl
-                    } : undefined}
                 />
             </div>
         </>

--- a/src/pages/WindMitigationNew.tsx
+++ b/src/pages/WindMitigationNew.tsx
@@ -9,14 +9,12 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import ContactLookup from "@/components/contacts/ContactLookup";
 import { toast } from "@/components/ui/use-toast";
 import { useAuth } from "@/contexts/AuthContext";
 import { dbCreateReport } from "@/integrations/supabase/reportsApi";
 import { contactsApi } from "@/integrations/supabase/crmApi";
 import { supabase } from "@/integrations/supabase/client";
-import useCoverPages from "@/hooks/useCoverPages";
 
 const schema = z.object({
   title: z.string().min(1, "Required"),
@@ -32,7 +30,6 @@ const schema = z.object({
   insuranceCompany: z.string().optional(),
   policyNumber: z.string().optional(),
   email: z.string().email().optional().or(z.literal("")),
-  coverPageId: z.string().optional(),
 });
 
 type Values = z.infer<typeof schema>;
@@ -42,7 +39,6 @@ const WindMitigationNew: React.FC = () => {
   const { user } = useAuth();
   const [searchParams] = useSearchParams();
   const contactId = searchParams.get("contactId");
-  const { coverPages, assignments } = useCoverPages();
 
   // Get contact data if contactId is provided
   const { data: contact } = useQuery({
@@ -67,7 +63,6 @@ const WindMitigationNew: React.FC = () => {
       insuranceCompany: "",
       policyNumber: "",
       email: "",
-      coverPageId: "none",
     },
   });
 
@@ -93,12 +88,6 @@ const WindMitigationNew: React.FC = () => {
     }
   }, [contact, form]);
 
-  useEffect(() => {
-    const assignedId = assignments["wind_mitigation"];
-    if (assignedId) {
-      form.setValue("coverPageId", assignedId);
-    }
-  }, [assignments, form]);
 
   const onSubmit = async (values: Values) => {
     try {
@@ -126,7 +115,6 @@ const WindMitigationNew: React.FC = () => {
             insuranceCompany: values.insuranceCompany,
             policyNumber: values.policyNumber,
             email: values.email,
-            coverPageId: values.coverPageId === "none" ? undefined : values.coverPageId,
           },
           user.id,
           profile?.organization_id || undefined
@@ -339,29 +327,6 @@ const WindMitigationNew: React.FC = () => {
                   <FormControl>
                     <Input type="date" {...field} />
                   </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="coverPageId"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Cover Page</FormLabel>
-                  <Select onValueChange={field.onChange} value={field.value || "none"}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select cover page" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      <SelectItem value="none">None</SelectItem>
-                      {coverPages.map(cp => (
-                        <SelectItem key={cp.id} value={cp.id}>{cp.name}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
                   <FormMessage />
                 </FormItem>
               )}


### PR DESCRIPTION
## Summary
- drop `coverPageId` from report schema and Supabase report APIs
- remove cover page selectors from new report pages and editors
- strip cover page handling from report preview and PDF generation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm run build` *(terminated: build process did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ce637ef88333a2023ecc725fec04