### PR TITLE
feat: add design JSON to cover pages

### DIFF
--- a/src/integrations/supabase/coverPagesApi.ts
+++ b/src/integrations/supabase/coverPagesApi.ts
@@ -8,6 +8,7 @@ export interface CoverPage {
   template_slug: string | null;
   color_palette_key: string | null;
   text_content: Json;
+  design_json: Json;
   image_url: string | null;
   created_at: string;
   updated_at: string;
@@ -41,6 +42,7 @@ export async function createCoverPage(
     template_slug?: string | null;
     color_palette_key?: string | null;
     text_content?: Json;
+    design_json?: Json;
     image_url?: string | null;
   }
 ): Promise<CoverPage> {
@@ -52,6 +54,7 @@ export async function createCoverPage(
       template_slug: payload.template_slug ?? null,
       color_palette_key: payload.color_palette_key ?? null,
       text_content: payload.text_content ?? {},
+      design_json: payload.design_json ?? {},
       image_url: payload.image_url ?? null,
     })
     .select()
@@ -70,7 +73,7 @@ export async function updateCoverPage(
   updates: Partial<
     Pick<
       CoverPage,
-      "name" | "template_slug" | "color_palette_key" | "text_content" | "image_url"
+      "name" | "template_slug" | "color_palette_key" | "text_content" | "design_json" | "image_url"
     >
   >
 ): Promise<CoverPage> {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -309,6 +309,7 @@ export type Database = {
           name: string
           template_slug: string | null
           text_content: Json
+          design_json: Json
           updated_at: string
           user_id: string
         }
@@ -320,6 +321,7 @@ export type Database = {
           name: string
           template_slug?: string | null
           text_content?: Json
+          design_json?: Json
           updated_at?: string
           user_id: string
         }
@@ -331,6 +333,7 @@ export type Database = {
           name?: string
           template_slug?: string | null
           text_content?: Json
+          design_json?: Json
           updated_at?: string
           user_id?: string
         }

--- a/supabase/migrations/20250825120000_add_design_json_to_cover_pages.sql
+++ b/supabase/migrations/20250825120000_add_design_json_to_cover_pages.sql
@@ -1,0 +1,3 @@
+-- Add design_json column to cover_pages table
+ALTER TABLE public.cover_pages
+  ADD COLUMN IF NOT EXISTS design_json jsonb NOT NULL DEFAULT '{}'::jsonb;


### PR DESCRIPTION
## Summary
- add `design_json` JSONB column to `cover_pages`
- allow creating and updating cover pages with `design_json`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 182 problems (165 errors, 17 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a85471dda483339e2bad189f9fe653