### PR TITLE
feat: persist cover page design data

### DIFF
--- a/src/hooks/useCoverPages.ts
+++ b/src/hooks/useCoverPages.ts
@@ -4,6 +4,7 @@ import {
   coverPagesApi,
   type CoverPage,
 } from "@/integrations/supabase/coverPagesApi";
+import type { Json } from "@/integrations/supabase/types";
 import { useToast } from "@/hooks/use-toast";
 
 interface CreateCoverPagePayload {
@@ -11,6 +12,7 @@ interface CreateCoverPagePayload {
   template_slug?: string | null;
   color_palette_key?: string | null;
   text_content?: unknown;
+  design_json?: Json;
   image_url?: string | null;
 }
 


### PR DESCRIPTION
## Summary
- include `design_json` in cover page API hook
- allow editing cover page designs with serialization and assignment form

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 182 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68a85ba5f23c8333a9cffa5c3f21752f