### PR TITLE
Fix runtime error from openmoji in cover page editor

### DIFF
--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -51,7 +51,6 @@ import {
 } from "lucide-react";
 import * as LucideIcons from "lucide-react";
 import { icons as lucideIcons } from "lucide";
-import { openmojis } from "openmoji";
 
 
 const TEMPLATES: Record<string, string> = {
@@ -103,6 +102,16 @@ export default function CoverPageEditorPage() {
   const { images, uploadImage, deleteImage } = useImageLibrary();
   const [iconSearch, setIconSearch] = useState("");
   const [clipartSearch, setClipartSearch] = useState("");
+  const [openmojis, setOpenmojis] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetch(
+      "https://cdn.jsdelivr.net/npm/openmoji@16.0.0/data/openmoji.json"
+    )
+      .then((res) => res.json())
+      .then(setOpenmojis)
+      .catch(() => setOpenmojis([]));
+  }, []);
 
 
   const pushHistory = () => {


### PR DESCRIPTION
## Summary
- Fetch OpenMoji metadata from CDN instead of importing Node-only package
- Remove OpenMoji package import in cover page editor

## Testing
- `npm run lint` *(fails: Unexpected any, no-case-declarations, etc.)*
- `npm run build` *(fails: Rollup failed to resolve import "lucide" from CoverPageEditorPage.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68a8867a52848333bf1d3677424d6f8f