### PR TITLE
Scale cover page canvas and show zoom level

### DIFF
--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -98,6 +98,7 @@ interface FormValues {
 
 export default function CoverPageEditorPage() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const [canvas, setCanvas] = useState<FabricCanvas | null>(null);
   const [selected, setSelected] = useState<CanvasObject | null>(null);
   const [zoom, setZoom] = useState(1);
@@ -695,6 +696,22 @@ export default function CoverPageEditorPage() {
     canvas.setZoom(zoom);
   }, [zoom, canvas]);
 
+  useEffect(() => {
+    const updateScale = () => {
+      const wrapper = wrapperRef.current;
+      if (!wrapper) return;
+      const scale = Math.min(
+        (wrapper.clientWidth - 32) / 816,
+        (wrapper.clientHeight - 32) / 1056,
+        1
+      );
+      setZoom(scale);
+    };
+    updateScale();
+    window.addEventListener("resize", updateScale);
+    return () => window.removeEventListener("resize", updateScale);
+  }, []);
+
   return (
     <div className="flex h-full">
       <div className="w-[22rem] p-2 border-r space-y-2">
@@ -1089,24 +1106,27 @@ export default function CoverPageEditorPage() {
         </Accordion>
       </div>
 
-      <div className="flex-1 relative flex items-center justify-center">
+      <div
+        ref={wrapperRef}
+        className="flex-1 relative flex items-center justify-center overflow-auto p-8"
+      >
         <div
-          className="relative border-2 border-blue-500"
+          className="relative border-2 border-blue-500 box-border"
           style={{
             width: 816,
             height: 1056,
             transform: `scale(${zoom})`,
-            transformOrigin: "0 0",
+            transformOrigin: "top left",
           }}
         >
-          <canvas ref={canvasRef} />
+          <canvas ref={canvasRef} className="block" />
           <span className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-full rotate-90">
             11"
           </span>
           <span className="absolute bottom-0 left-1/2 translate-y-full -translate-x-1/2">
             8.5"
           </span>
-          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex gap-2">
+          <div className="absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-2 bg-white/80 rounded-md px-2 py-1">
             <Button onClick={undo} variant="outline" size="icon" aria-label="Undo">
               <Undo2 className="h-4 w-4" />
             </Button>
@@ -1116,6 +1136,7 @@ export default function CoverPageEditorPage() {
             <Button onClick={zoomOut} variant="outline" size="icon" aria-label="Zoom Out">
               <ZoomOut className="h-4 w-4" />
             </Button>
+            <span className="text-sm w-12 text-center">{Math.round(zoom * 100)}%</span>
             <Button onClick={zoomIn} variant="outline" size="icon" aria-label="Zoom In">
               <ZoomIn className="h-4 w-4" />
             </Button>


### PR DESCRIPTION
## Summary
- Auto-scale cover page canvas to fit available space and keep blue frame visible
- Display current zoom percentage in bottom toolbar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 208 errors, 18 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_68a74c524d748333bb6d5e7e9c943838