### PR TITLE
fix: make cover page editor fullscreen

### DIFF
--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -713,7 +713,7 @@ export default function CoverPageEditorPage() {
   }, []);
 
   return (
-    <div className="flex h-full">
+    <div className="fixed inset-0 w-screen h-screen overflow-hidden z-50 bg-gray-900 flex">
       <div className="w-[22rem] p-2 border-r space-y-2">
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
           <div>


### PR DESCRIPTION
## Summary
- ensure cover page editor fills the viewport with fixed wrapper

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 208 errors, 18 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a8aac40fe483339930986a55d361b7