### PR TITLE
feat: hide footer on cover page manager

### DIFF
--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,16 +1,19 @@
 import React from "react";
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 import Header from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
 
 const RootLayout: React.FC = () => {
+  const location = useLocation();
+  const hideFooter = location.pathname.startsWith("/cover-page-manager");
+
   return (
     <div className="min-h-screen flex flex-col bg-background text-foreground">
       <Header />
       <main id="main-content" className="flex-1">
         <Outlet />
       </main>
-      <Footer />
+      {!hideFooter && <Footer />}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- hide Footer on cover page manager routes using `useLocation`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 208 errors, 18 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b3b83c908333aa214629e8e59598