### PR TITLE
feat: style editor toolbar

### DIFF
--- a/src/components/cover-pages/EditorToolbar.tsx
+++ b/src/components/cover-pages/EditorToolbar.tsx
@@ -64,7 +64,7 @@ export function EditorToolbar({
   const hasMultipleSelection = selectedObjects.length > 1;
 
   return (
-    <div className="flex items-center gap-2 p-3 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+    <div className="flex items-center gap-2 p-3 bg-gray-800/80 text-white shadow-lg rounded-md">
       {/* History Controls */}
       <div className="flex items-center gap-1">
         <Button

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -1257,11 +1257,11 @@ export default function CoverPageEditorPage() {
             8.5"
           </span>
         </div>
-        <div className="absolute top-2 left-1/2 -translate-x-1/2 z-10">
-          <EditorToolbar
-            onUndo={undo}
-            onRedo={redo}
-            canUndo={historyIndex > 0}
+          <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20">
+            <EditorToolbar
+              onUndo={undo}
+              onRedo={redo}
+              canUndo={historyIndex > 0}
             canRedo={historyIndex < history.length - 1}
             onZoomIn={zoomIn}
             onZoomOut={zoomOut}

--- a/src/pages/CoverPageEditorPageNew.tsx
+++ b/src/pages/CoverPageEditorPageNew.tsx
@@ -558,24 +558,26 @@ export default function CoverPageEditorPageNew() {
       </div>
 
       {/* Toolbar */}
-      <EditorToolbar
-        onUndo={handleUndo}
-        onRedo={handleRedo}
-        canUndo={historyIndex > 0}
-        canRedo={historyIndex < history.length - 1}
-        onZoomIn={handleZoomIn}
-        onZoomOut={handleZoomOut}
-        zoom={zoom}
-        onZoomChange={handleZoomChange}
-        showGrid={showGrid}
-        onToggleGrid={() => setShowGrid(!showGrid)}
-        selectedObjects={selectedObjects}
-        onCopy={handleCopy}
-        onDelete={handleDelete}
-        onGroup={handleGroup}
-        onUngroup={handleUngroup}
-        onAlign={handleAlign}
-      />
+      <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20">
+        <EditorToolbar
+          onUndo={handleUndo}
+          onRedo={handleRedo}
+          canUndo={historyIndex > 0}
+          canRedo={historyIndex < history.length - 1}
+          onZoomIn={handleZoomIn}
+          onZoomOut={handleZoomOut}
+          zoom={zoom}
+          onZoomChange={handleZoomChange}
+          showGrid={showGrid}
+          onToggleGrid={() => setShowGrid(!showGrid)}
+          selectedObjects={selectedObjects}
+          onCopy={handleCopy}
+          onDelete={handleDelete}
+          onGroup={handleGroup}
+          onUngroup={handleUngroup}
+          onAlign={handleAlign}
+        />
+      </div>
 
       {/* Main Layout */}
       <div className="flex flex-1 overflow-hidden">


### PR DESCRIPTION
## Summary
- wrap editor toolbar in top-centered overlay to avoid canvas scaling
- add dark semi-transparent styling to editor toolbar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 212 errors, 18 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e1471a9c8333b46d9a7129f6cc02