### PR TITLE
Remove fixed canvas wrapper dimensions

### DIFF
--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -1242,13 +1242,10 @@ export default function CoverPageEditorPage() {
       >
         <div
           className="relative border-2 border-blue-500 box-border"
-        style={{
-          width: 816,
-          height: 1056,
-          transform: `scale(${fitScale * zoom})`,
-          transformOrigin: "top left",
-        }}
-      >
+          style={{
+            transform: `scale(${fitScale * zoom})`,
+          }}
+        >
           <canvas ref={canvasRef} className="block" />
           <span className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-full rotate-90">
             11"


### PR DESCRIPTION
## Summary
- Avoid inlining width/height/transform-origin on the canvas wrapper so only the scale transform is applied

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8aa2291d08333bd39336ecb7d666d