### PR TITLE
feat: add rulers toggle

### DIFF
--- a/src/components/cover-pages/CanvasWorkspace.tsx
+++ b/src/components/cover-pages/CanvasWorkspace.tsx
@@ -28,59 +28,56 @@ export function CanvasWorkspace({
 
   return (
     <div className="flex-1 relative bg-muted/50 overflow-auto">
-      <div className="relative p-8">
-        {/* Rulers */}
-        {showRulers && (
-          <>
-            {/* Horizontal Ruler */}
-            <div className="absolute top-0 left-0 right-0 h-8 bg-gray-200 border-b border-gray-300 z-20 pointer-events-none">
-              <div className="relative h-full">
-                {Array.from({ length: 41 }, (_, i) => i * 20).map((mark) => (
-                  <div
-                    key={mark}
-                    className="absolute top-0 h-full border-l border-gray-300/50"
-                    style={{ left: `${mark * zoom}px` }}
-                  >
-                    {mark % 100 === 0 && (
-                      <span className="absolute top-1 left-1 text-xs text-gray-500">
-                        {mark}
-                      </span>
-                    )}
-                  </div>
-                ))}
+      <div className="flex items-center justify-center min-h-full">
+        <div ref={workspaceRef} className="relative m-8">
+          {/* Rulers */}
+          {showRulers && (
+            <>
+              {/* Horizontal Ruler */}
+              <div className="absolute top-0 left-8 right-0 h-8 bg-gray-200 border-b border-gray-300 z-20 pointer-events-none">
+                <div className="relative h-full">
+                  {Array.from({ length: 41 }, (_, i) => i * 20).map((mark) => (
+                    <div
+                      key={mark}
+                      className="absolute top-0 h-full border-l border-gray-300/50"
+                      style={{ left: `${mark * zoom}px` }}
+                    >
+                      {mark % 100 === 0 && (
+                        <span className="absolute top-1 left-1 text-xs text-gray-500">
+                          {mark}
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                </div>
               </div>
-            </div>
 
-            {/* Vertical Ruler */}
-            <div className="absolute top-0 left-0 bottom-0 w-8 bg-gray-200 border-r border-gray-300 z-20 pointer-events-none">
-              <div className="relative w-full h-full">
-                {Array.from({ length: 51 }, (_, i) => i * 20).map((mark) => (
-                  <div
-                    key={mark}
-                    className="absolute left-0 w-full border-t border-gray-300/50"
-                    style={{ top: `${mark * zoom}px` }}
-                  >
-                    {mark % 100 === 0 && (
-                      <span className="absolute top-1 left-1 text-xs text-gray-500 transform -rotate-90 origin-top-left">
-                        {mark}
-                      </span>
-                    )}
-                  </div>
-                ))}
+              {/* Vertical Ruler */}
+              <div className="absolute top-8 left-0 bottom-0 w-8 bg-gray-200 border-r border-gray-300 z-20 pointer-events-none">
+                <div className="relative w-full h-full">
+                  {Array.from({ length: 51 }, (_, i) => i * 20).map((mark) => (
+                    <div
+                      key={mark}
+                      className="absolute left-0 w-full border-t border-gray-300/50"
+                      style={{ top: `${mark * zoom}px` }}
+                    >
+                      {mark % 100 === 0 && (
+                        <span className="absolute top-1 left-1 text-xs text-gray-500 transform -rotate-90 origin-top-left">
+                          {mark}
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                </div>
               </div>
-            </div>
 
-            {/* Corner */}
-            <div className="absolute top-0 left-0 w-8 h-8 bg-gray-200 border-r border-b border-gray-300 z-20 pointer-events-none" />
-          </>
-        )}
+              {/* Corner */}
+              <div className="absolute top-0 left-0 w-8 h-8 bg-gray-200 border-r border-b border-gray-300 z-20 pointer-events-none" />
+            </>
+          )}
 
-        {/* Canvas Container */}
-        <div
-          ref={workspaceRef}
-          className="flex items-center justify-center min-h-full p-8"
-        >
-          <div className="relative">
+          {/* Canvas Container */}
+          <div className={showRulers ? "relative ml-8 mt-8" : "relative"}>
             {/* Grid Background */}
             {showGrid && (
               <div

--- a/src/components/cover-pages/EditorToolbar.tsx
+++ b/src/components/cover-pages/EditorToolbar.tsx
@@ -21,6 +21,7 @@ import {
   AlignVerticalJustifyCenter,
   ArrowUp,
   ArrowDown,
+  Ruler,
 } from "lucide-react";
 
 interface EditorToolbarProps {
@@ -34,6 +35,8 @@ interface EditorToolbarProps {
   onZoomChange: (zoom: number) => void;
   showGrid: boolean;
   onToggleGrid: () => void;
+  showRulers: boolean;
+  onToggleRulers: () => void;
   selectedObjects: any[];
   onCopy: () => void;
   onDelete: () => void;
@@ -53,6 +56,8 @@ export function EditorToolbar({
   onZoomChange,
   showGrid,
   onToggleGrid,
+  showRulers,
+  onToggleRulers,
   selectedObjects,
   onCopy,
   onDelete,
@@ -242,6 +247,14 @@ export function EditorToolbar({
           className="h-8 w-8 p-0"
         >
           <Grid3X3 className="h-4 w-4" />
+        </Button>
+        <Button
+          variant={showRulers ? "default" : "ghost"}
+          size="sm"
+          onClick={onToggleRulers}
+          className="h-8 w-8 p-0"
+        >
+          <Ruler className="h-4 w-4" />
         </Button>
       </div>
     </div>

--- a/src/pages/CoverPageEditorPageNew.tsx
+++ b/src/pages/CoverPageEditorPageNew.tsx
@@ -568,6 +568,8 @@ export default function CoverPageEditorPageNew() {
                 onZoomChange={handleZoomChange}
                 showGrid={showGrid}
                 onToggleGrid={() => setShowGrid(!showGrid)}
+                showRulers={showRulers}
+                onToggleRulers={() => setShowRulers(!showRulers)}
                 selectedObjects={selectedObjects}
                 onCopy={handleCopy}
                 onDelete={handleDelete}
@@ -618,82 +620,3 @@ export default function CoverPageEditorPageNew() {
 
     );
 }
-
-        
-        {/* Save Form */}
-        <form onSubmit={handleSubmit(onSubmit)} className="flex items-center gap-2">
-          <Input
-            {...register("name", { required: true })}
-            placeholder="Cover page name"
-            className="w-48"
-          />
-          <Button type="submit">
-            {id ? "Update" : "Create"}
-          </Button>
-        </form>
-      </div>
-
-      {/* Toolbar */}
-      <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20">
-        <EditorToolbar
-          onUndo={handleUndo}
-          onRedo={handleRedo}
-          canUndo={historyIndex > 0}
-          canRedo={historyIndex < history.length - 1}
-          onZoomIn={handleZoomIn}
-          onZoomOut={handleZoomOut}
-          zoom={zoom}
-          onZoomChange={handleZoomChange}
-          showGrid={showGrid}
-          onToggleGrid={() => setShowGrid(!showGrid)}
-          selectedObjects={selectedObjects}
-          onCopy={handleCopy}
-          onDelete={handleDelete}
-          onGroup={handleGroup}
-          onUngroup={handleUngroup}
-          onAlign={handleAlign}
-        />
-      </div>
-
-      {/* Main Layout */}
-      <div className="flex flex-1 overflow-hidden">
-        {/* Left Sidebar */}
-        <EditorSidebar
-          onAddText={handleAddText}
-          onAddShape={handleAddShape}
-          onAddIcon={handleAddIcon}
-          images={images}
-          onAddImage={handleAddImage}
-          onUploadImage={handleUploadImage}
-          colorPalettes={COLOR_PALETTES}
-          onSelectPalette={setPalette}
-          selectedPalette={palette}
-        />
-
-        {/* Canvas Workspace */}
-        <CanvasWorkspace
-          canvasRef={canvasRef}
-          canvas={canvas}
-          zoom={zoom}
-          showGrid={showGrid}
-          showRulers={showRulers}
-        />
-
-        {/* Right Properties Panel */}
-        <PropertiesPanel
-          selectedObject={selectedObject}
-          onUpdateProperty={handleUpdateProperty}
-          onDeleteObject={handleDelete}
-          onDuplicateObject={handleCopy}
-          onBringForward={handleBringForward}
-          onSendBackward={handleSendBackward}
-          onToggleLock={handleToggleLock}
-          onToggleVisible={handleToggleVisible}
-          layers={layers}
-          onSelectLayer={handleSelectLayer}
-        />
-      </div>
-    </div>
-  );
-}
-


### PR DESCRIPTION
## Summary
- toggle canvas rulers from the editor toolbar
- plumb showRulers state through cover page editor
- align rulers with canvas edges in workspace

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a8e63194c08333b398c9a1bc92adff