### PR TITLE
Fix CoverPage editor toolbar and ruler layering

### DIFF
--- a/src/components/cover-pages/CanvasWorkspace.tsx
+++ b/src/components/cover-pages/CanvasWorkspace.tsx
@@ -35,12 +35,12 @@ export function CanvasWorkspace({
       <div className="flex items-center justify-center min-h-full">
         <div
           ref={workspaceRef}
-          className={showRulers ? "relative m-8 p-8" : "relative m-8"}
+          className={showRulers ? "relative m-8 pl-8 pt-8" : "relative m-8"}
         >
           {showRulers && (
             <>
               {/* Horizontal Ruler */}
-              <div className="absolute top-0 left-0 right-0 h-8 bg-gray-200 border-b border-gray-300 z-20 pointer-events-none">
+              <div className="absolute top-0 left-0 right-0 h-8 bg-gray-200 border-b border-gray-300 z-30 pointer-events-none">
                 <div className="relative h-full">
                   {Array.from({ length: 41 }, (_, i) => i * 20).map((mark) => (
                     <div
@@ -59,7 +59,7 @@ export function CanvasWorkspace({
               </div>
 
               {/* Vertical Ruler */}
-              <div className="absolute top-0 left-0 bottom-0 w-8 bg-gray-200 border-r border-gray-300 z-20 pointer-events-none">
+              <div className="absolute top-0 left-0 bottom-0 w-8 bg-gray-200 border-r border-gray-300 z-30 pointer-events-none">
                 <div className="relative w-full h-full">
                   {Array.from({ length: 51 }, (_, i) => i * 20).map((mark) => (
                     <div
@@ -78,7 +78,7 @@ export function CanvasWorkspace({
               </div>
 
               {/* Corner */}
-              <div className="absolute top-0 left-0 w-8 h-8 bg-gray-200 border-r border-b border-gray-300 z-20 pointer-events-none" />
+              <div className="absolute top-0 left-0 w-8 h-8 bg-gray-200 border-r border-b border-gray-300 z-30 pointer-events-none" />
             </>
           )}
 

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -1221,7 +1221,7 @@ export default function CoverPageEditorPage() {
           showGrid={showGrid}
           showRulers={showRulers}
         />
-        <div className="absolute top-2 left-1/2 -translate-x-1/2 z-20">
+        <div className="absolute top-2 left-1/2 -translate-x-1/2 z-10">
           <EditorToolbar
               onUndo={undo}
               onRedo={redo}


### PR DESCRIPTION
## Summary
- lower cover page editor toolbar to `z-10` so rulers are visible
- add left/top padding only when rulers are shown
- elevate canvas rulers above the workspace to `z-30`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, no-case-declarations, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fbe3c98883339a4997a8fffe39d7