### PR TITLE
feat: improve cover page zoom handling

### DIFF
--- a/src/components/cover-pages/CanvasWorkspace.tsx
+++ b/src/components/cover-pages/CanvasWorkspace.tsx
@@ -17,11 +17,20 @@ export function CanvasWorkspace({
   showRulers,
 }: CanvasWorkspaceProps) {
   const workspaceRef = useRef<HTMLDivElement>(null);
+  const width = canvas?.getWidth() ?? 0;
+  const height = canvas?.getHeight() ?? 0;
+  const baseWidth = width / zoom;
+  const baseHeight = height / zoom;
+  const horizontalMarks = Math.ceil(baseWidth / 20) + 1;
+  const verticalMarks = Math.ceil(baseHeight / 20) + 1;
 
   useEffect(() => {
     if (!canvas) return;
 
-    // Apply zoom
+    canvas.setDimensions({
+      width: 816 * zoom,
+      height: 1056 * zoom,
+    });
     canvas.setZoom(zoom);
     canvas.renderAll();
   }, [canvas, zoom]);
@@ -42,38 +51,42 @@ export function CanvasWorkspace({
               {/* Horizontal Ruler */}
               <div className="absolute top-0 left-0 right-0 h-8 bg-gray-200 border-b border-gray-300 z-30 pointer-events-none">
                 <div className="relative h-full">
-                  {Array.from({ length: 41 }, (_, i) => i * 20).map((mark) => (
-                    <div
-                      key={mark}
-                      className="absolute top-0 h-full border-l border-gray-300/50"
-                      style={{ left: `${mark * zoom}px` }}
-                    >
-                      {mark % 100 === 0 && (
-                        <span className="absolute top-1 left-1 text-xs text-gray-500">
-                          {mark}
-                        </span>
-                      )}
-                    </div>
-                  ))}
+                  {Array.from({ length: horizontalMarks }, (_, i) => i * 20).map(
+                    (mark) => (
+                      <div
+                        key={mark}
+                        className="absolute top-0 h-full border-l border-gray-300/50"
+                        style={{ left: `${mark * zoom}px` }}
+                      >
+                        {mark % 100 === 0 && (
+                          <span className="absolute top-1 left-1 text-xs text-gray-500">
+                            {mark}
+                          </span>
+                        )}
+                      </div>
+                    )
+                  )}
                 </div>
               </div>
 
               {/* Vertical Ruler */}
               <div className="absolute top-0 left-0 bottom-0 w-8 bg-gray-200 border-r border-gray-300 z-30 pointer-events-none">
                 <div className="relative w-full h-full">
-                  {Array.from({ length: 51 }, (_, i) => i * 20).map((mark) => (
-                    <div
-                      key={mark}
-                      className="absolute left-0 w-full border-t border-gray-300/50"
-                      style={{ top: `${mark * zoom}px` }}
-                    >
-                      {mark % 100 === 0 && (
-                        <span className="absolute top-1 left-1 text-xs text-gray-500 transform -rotate-90 origin-top-left">
-                          {mark}
-                        </span>
-                      )}
-                    </div>
-                  ))}
+                  {Array.from({ length: verticalMarks }, (_, i) => i * 20).map(
+                    (mark) => (
+                      <div
+                        key={mark}
+                        className="absolute left-0 w-full border-t border-gray-300/50"
+                        style={{ top: `${mark * zoom}px` }}
+                      >
+                        {mark % 100 === 0 && (
+                          <span className="absolute top-1 left-1 text-xs text-gray-500 transform -rotate-90 origin-top-left">
+                            {mark}
+                          </span>
+                        )}
+                      </div>
+                    )
+                  )}
                 </div>
               </div>
 
@@ -101,7 +114,7 @@ export function CanvasWorkspace({
             </div>
 
             <div className="absolute -bottom-6 left-0 text-xs text-muted-foreground">
-              800 × 1000px
+              816 × 1056px
             </div>
           </div>
         </div>

--- a/src/components/cover-pages/EditorToolbar.tsx
+++ b/src/components/cover-pages/EditorToolbar.tsx
@@ -225,7 +225,13 @@ export function EditorToolbar({
                         <Input
                             type="number"
                             value={Math.round(zoom * 100)}
-                            onChange={(e) => onZoomChange(Number(e.target.value) / 100)}
+                            onChange={(e) => {
+                                const value = Math.min(
+                                    500,
+                                    Math.max(10, Number(e.target.value))
+                                );
+                                onZoomChange(value / 100);
+                            }}
                             className="w-16 h-8 text-xs text-center"
                             min="10"
                             max="500"

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -101,7 +101,7 @@ export default function CoverPageEditorPage() {
   const [selectedObjects, setSelectedObjects] = useState<FabricObject[]>([]);
   const [selected, setSelected] = useState<CanvasObject | null>(null);
   const [fitScale, setFitScale] = useState(1);
-  const [zoom, setZoom] = useState(1);
+  const [zoom, setZoom] = useState(0.85);
   const [history, setHistory] = useState<string[]>([]);
   const [historyIndex, setHistoryIndex] = useState(-1);
   const { id } = useParams<{ id: string }>();
@@ -797,8 +797,18 @@ export default function CoverPageEditorPage() {
     setHistoryIndex(historyIndex + 1);
   };
 
-  const zoomIn = () => setZoom((z) => z * 1.1);
-  const zoomOut = () => setZoom((z) => z / 1.1);
+  const zoomIn = () =>
+    setZoom((z) => {
+      const newZoom = Math.min(5, z * 1.1);
+      console.log("Zoom set to", newZoom);
+      return newZoom;
+    });
+  const zoomOut = () =>
+    setZoom((z) => {
+      const newZoom = Math.max(0.1, z / 1.1);
+      console.log("Zoom set to", newZoom);
+      return newZoom;
+    });
 
   useEffect(() => {
     const updateScale = () => {


### PR DESCRIPTION
## Summary
- initialize cover page editor at 85% zoom and clamp zoom controls between 10% and 500%
- resize canvas with zoom and align rulers/grid with dynamic canvas dimensions
- sanitize toolbar zoom input to always stay within valid range

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, no-case-declarations, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8fcf6c8f8833388168ae66f15ee35