### PR TITLE
Make CanvasWorkspace drop handler optional

### DIFF
--- a/src/components/cover-pages/CanvasWorkspace.tsx
+++ b/src/components/cover-pages/CanvasWorkspace.tsx
@@ -7,7 +7,7 @@ interface CanvasWorkspaceProps {
     zoom: number;
     showGrid: boolean;
     showRulers: boolean;
-    onDropElement: (item: {type: string; data: any; x: number; y: number}) => void;
+    onDropElement?: (item: {type: string; data: any; x: number; y: number}) => void;
 }
 
 export function CanvasWorkspace({
@@ -150,7 +150,7 @@ export function CanvasWorkspace({
                                 const x = rect ? (e.clientX - rect.left) / zoom : 0;
                                 const y = rect ? (e.clientY - rect.top) / zoom : 0;
                                 const {type, ...rest} = payload;
-                                onDropElement({type, data: rest, x, y});
+                                onDropElement?.({type, data: rest, x, y});
                             }}
                         >
                             <canvas ref={canvasRef}/>


### PR DESCRIPTION
## Summary
- allow CanvasWorkspace to be used without a drop handler
- guard drop handler call with optional chaining

## Testing
- `npm run lint` *(fails: Unexpected any ...)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab038e8b488333987736db4ff6d095