### PR TITLE
refactor: use shared cover page editor constants

### DIFF
--- a/src/pages/CoverPageEditorPageNew.tsx
+++ b/src/pages/CoverPageEditorPageNew.tsx
@@ -27,21 +27,9 @@ import {CanvasWorkspace} from "@/components/cover-pages/CanvasWorkspace";
 import useCoverPages from "@/hooks/useCoverPages";
 import useImageLibrary from "@/hooks/useImageLibrary";
 import {COLOR_PALETTES, type ColorPalette} from "@/constants/colorPalettes";
+import {FONTS, PRESET_BG_COLORS, REPORT_TYPES, TEMPLATES} from "@/constants/coverPageEditor";
 import * as LucideIcons from "lucide-react";
 import {toast} from "sonner";
-
-const TEMPLATES: Record<string, string> = {
-    default: "#ffffff",
-    blue: "#ebf8ff",
-};
-
-const REPORT_TYPES = [
-    {value: "home_inspection", label: "Home Inspection"},
-    {value: "wind_mitigation", label: "Wind Mitigation"},
-];
-
-const FONTS = ["Arial", "Helvetica", "Times New Roman", "Courier New"];
-const PRESET_BG_COLORS = Object.values(TEMPLATES);
 
 interface FormValues {
     name: string;


### PR DESCRIPTION
## Summary
- replace local cover page editor constants with shared imports

## Testing
- `npm run lint` *(fails: Unexpected any / require import)*

------
https://chatgpt.com/codex/tasks/task_e_68ab39859fb48333b35550c8e35b2146