### PR TITLE
refactor: centralize cover element dropping

### DIFF
--- a/src/lib/handleCoverElementDrop.ts
+++ b/src/lib/handleCoverElementDrop.ts
@@ -1,0 +1,83 @@
+import { Canvas as FabricCanvas } from "fabric";
+import { ColorPalette } from "@/constants/colorPalettes";
+import {
+    addRect as fabricAddRect,
+    addCircle as fabricAddCircle,
+    addStar as fabricAddStar,
+    addTriangle as fabricAddTriangle,
+    addPolygon as fabricAddPolygon,
+    addArrow as fabricAddArrow,
+    addBidirectionalArrow as fabricAddBidirectionalArrow,
+    addText as fabricAddText,
+} from "@/lib/fabricShapes";
+
+interface DropPayload {
+    type: string;
+    data: unknown;
+    x: number;
+    y: number;
+}
+
+interface ExtraHandlers {
+    addImage?: (url: string, x: number, y: number) => void;
+    addIcon?: (name: string, x: number, y: number) => void;
+    addClipart?: (hex: string, x: number, y: number) => void;
+}
+
+export function handleCoverElementDrop(
+    canvas: FabricCanvas | null,
+    palette: ColorPalette,
+    {type, data, x, y}: DropPayload,
+    handlers: ExtraHandlers,
+    pushHistory?: () => void,
+) {
+    if (!canvas) return;
+
+    switch (type) {
+        case "text":
+            fabricAddText(canvas, palette, "Add your text here", x, y);
+            pushHistory?.();
+            break;
+        case "rectangle":
+            fabricAddRect(canvas, palette, x, y);
+            pushHistory?.();
+            break;
+        case "circle":
+            fabricAddCircle(canvas, palette, x, y);
+            pushHistory?.();
+            break;
+        case "star":
+            fabricAddStar(canvas, palette, x, y);
+            pushHistory?.();
+            break;
+        case "triangle":
+            fabricAddTriangle(canvas, palette, x, y);
+            pushHistory?.();
+            break;
+        case "polygon":
+            fabricAddPolygon(canvas, palette, 5, 50, x, y);
+            pushHistory?.();
+            break;
+        case "arrow":
+            fabricAddArrow(canvas, palette, x, y);
+            pushHistory?.();
+            break;
+        case "bidirectionalArrow":
+            fabricAddBidirectionalArrow(canvas, palette, x, y);
+            pushHistory?.();
+            break;
+        case "image":
+            if (data?.url) handlers.addImage?.(data.url, x, y);
+            break;
+        case "icon":
+            if (data?.name) handlers.addIcon?.(data.name, x, y);
+            break;
+        case "clipart":
+            if (data?.hex) handlers.addClipart?.(data.hex, x, y);
+            break;
+        default:
+            break;
+    }
+}
+
+export type { DropPayload };

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -18,6 +18,7 @@ import {
     addBidirectionalArrow as fabricAddBidirectionalArrow,
     addText as fabricAddText,
 } from "@/lib/fabricShapes";
+import {handleCoverElementDrop} from "@/lib/handleCoverElementDrop";
 import {Button} from "@/components/ui/button";
 import {Input} from "@/components/ui/input";
 import {EditorToolbar} from "@/components/cover-pages/EditorToolbar";
@@ -382,54 +383,18 @@ export default function CoverPageEditorPage() {
         }
     };
 
-    const handleDropElement = ({type, data, x, y}: {type: string; data: any; x: number; y: number}) => {
-        if (!canvas) return;
-        switch (type) {
-            case "text":
-                fabricAddText(canvas, palette, "Add your text here", x, y);
-                pushHistory();
-                break;
-            case "rectangle":
-                fabricAddRect(canvas, palette, x, y);
-                pushHistory();
-                break;
-            case "circle":
-                fabricAddCircle(canvas, palette, x, y);
-                pushHistory();
-                break;
-            case "star":
-                fabricAddStar(canvas, palette, x, y);
-                pushHistory();
-                break;
-            case "triangle":
-                fabricAddTriangle(canvas, palette, x, y);
-                pushHistory();
-                break;
-            case "polygon":
-                fabricAddPolygon(canvas, palette, 5, 50, x, y);
-                pushHistory();
-                break;
-            case "arrow":
-                fabricAddArrow(canvas, palette, x, y);
-                pushHistory();
-                break;
-            case "bidirectionalArrow":
-                fabricAddBidirectionalArrow(canvas, palette, x, y);
-                pushHistory();
-                break;
-            case "image":
-                if (data?.url) handleAddImage(data.url, x, y);
-                break;
-            case "icon":
-                if (data?.name) handleAddIcon(data.name, x, y);
-                break;
-            case "clipart":
-                if (data?.hex) handleAddClipart(data.hex, x, y);
-                break;
-            default:
-                break;
-        }
-    };
+    const handleDropElement = ({type, data, x, y}: {type: string; data: unknown; x: number; y: number}) =>
+        handleCoverElementDrop(
+            canvas,
+            palette,
+            {type, data, x, y},
+            {
+                addImage: handleAddImage,
+                addIcon: handleAddIcon,
+                addClipart: handleAddClipart,
+            },
+            pushHistory,
+        );
 
     const addText = () => {
         if (!canvas) return;


### PR DESCRIPTION
## Summary
- add shared `handleCoverElementDrop` utility for converting drag payloads to fabric actions
- use new helper in `CoverPageEditorPage` to handle dropped elements

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 232 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab3d925f7c8333be0ea4b299da63da