### PR TITLE
Use fabric zoom and stabilize cover page layout

### DIFF
--- a/src/components/cover-pages/CanvasWorkspace.tsx
+++ b/src/components/cover-pages/CanvasWorkspace.tsx
@@ -24,12 +24,12 @@ export function CanvasWorkspace({
     const PAGE_W_IN = 8.5;
     const PAGE_H_IN = 11;
 
-    const width = canvas?.getWidth() ?? 0;    // includes zoom
-    const height = canvas?.getHeight() ?? 0;  // includes zoom
+    const width = canvas?.getWidth() ?? 0;
+    const height = canvas?.getHeight() ?? 0;
 
-    // Derive base (unzoomed) size so this keeps working if you change zoom or DPI
-    const baseWidth = width / Math.max(zoom, 0.0001);
-    const baseHeight = height / Math.max(zoom, 0.0001);
+    // Canvas dimensions remain constant; zoom is handled via fabric's viewport
+    const baseWidth = width;
+    const baseHeight = height;
 
     // Pixels per inch along each axis (works even if you change base canvas size)
     const pxPerInchX = baseWidth > 0 ? baseWidth / PAGE_W_IN : 96;
@@ -60,11 +60,8 @@ export function CanvasWorkspace({
     useEffect(() => {
         if (!canvas) return;
 
-        canvas.setDimensions({
-            width: 816 * zoom,
-            height: 1056 * zoom,
-        });
-        canvas.setZoom(1);
+        canvas.setDimensions({width: 816, height: 1056});
+        canvas.setZoom(zoom);
         canvas.renderAll();
     }, [canvas, zoom]);
 
@@ -106,7 +103,7 @@ export function CanvasWorkspace({
             }
             const {type, ...rest} = payload;
 
-            const pt = canvas.getPointer(e as unknown as MouseEvent); // ✅ coords safe under zoom
+            const pt = canvas.getPointer(e as unknown as MouseEvent, true); // ignore viewport zoom
             onDropElement?.({type, data: rest, x: pt.x, y: pt.y});
         };
 

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -626,7 +626,8 @@ export default function CoverPageEditorPage() {
             {/* Main Layout */}
             <div className="flex flex-1 overflow-hidden">
                 {/* Left Sidebar */}
-                <EditorSidebar
+                <div className="flex-none">
+                    <EditorSidebar
                     activePanel={activePanel}
                     setActivePanel={setActivePanel}
                     onSettingsSubmit={handleSubmit(onSubmit)}
@@ -664,10 +665,11 @@ export default function CoverPageEditorPage() {
                     presetBgColors={PRESET_BG_COLORS}
                     updateBgColor={updateBgColor}
                     onAddPlaceholder={handleAddPlaceholder}
-                />
+                    />
+                </div>
 
                 {/* Canvas Workspace */}
-                <div className={"mt-4"}>
+                <div className="mt-4 flex-1 overflow-auto">
                     <CanvasWorkspace
                         canvasRef={canvasRef}
                         canvas={canvas}
@@ -679,18 +681,20 @@ export default function CoverPageEditorPage() {
                 </div>
 
                 {/* Right Properties Panel */}
-                <PropertiesPanel
-                    selectedObject={selectedObject}
-                    onUpdateProperty={handleUpdateProperty}
-                    onDeleteObject={handleDelete}
-                    onDuplicateObject={handleCopy}
-                    onBringForward={handleBringForward}
-                    onSendBackward={handleSendBackward}
-                    onToggleLock={handleToggleLock}
-                    onToggleVisible={handleToggleVisible}
-                    layers={layers}
-                    onSelectLayer={handleSelectLayer}
-                />
+                <div className="flex-none">
+                    <PropertiesPanel
+                        selectedObject={selectedObject}
+                        onUpdateProperty={handleUpdateProperty}
+                        onDeleteObject={handleDelete}
+                        onDuplicateObject={handleCopy}
+                        onBringForward={handleBringForward}
+                        onSendBackward={handleSendBackward}
+                        onToggleLock={handleToggleLock}
+                        onToggleVisible={handleToggleVisible}
+                        layers={layers}
+                        onSelectLayer={handleSelectLayer}
+                    />
+                </div>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- keep canvas size static and zoom via Fabric viewport
- normalize drag/drop pointer coordinates under zoom
- ensure editor sidebars use fixed widths and workspace scrolls independently

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any warnings and import style errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab43a34d8483339a50e21d8bb1764a