### PR TITLE
Ensure canvas objects visible after JSON load

### DIFF
--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -118,7 +118,8 @@ export default function CoverPageEditorPage() {
 
         if (cp.design_json) {
             canvas.loadFromJSON(cp.design_json as any, () => {
-                canvas.renderAll();
+                canvas.getObjects().forEach((obj) => obj.set({ visible: true }));
+                canvas.requestRenderAll();
                 const json = JSON.stringify(canvas.toJSON());
                 setHistory([json]);
                 setHistoryIndex(0);


### PR DESCRIPTION
## Summary
- Force all Fabric canvas objects to be visible when loading saved design JSON
- Trigger `requestRenderAll` so canvas renders without user interaction

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any; A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ab47ddda2483338de1c69889b64f5e