### PR TITLE
Wrap tooltip content in portal and ensure toolbar provider

### DIFF
--- a/src/components/cover-pages/EditorToolbar.tsx
+++ b/src/components/cover-pages/EditorToolbar.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import {Button} from "@/components/ui/button";
 import {Separator} from "@/components/ui/separator";
-import {Tooltip, TooltipContent, TooltipTrigger} from "@/components/ui/tooltip";
+import {Tooltip, TooltipContent, TooltipTrigger, TooltipProvider} from "@/components/ui/tooltip";
 
 import {
     AlignHorizontalJustifyCenter,
@@ -82,10 +82,11 @@ export function EditorToolbar(props: EditorToolbarProps) {
     const hasMultipleSelection = selectedObjects.length > 1;
 
     return (
-        <div id="editor_toolbar" className="w-full overflow-x-auto">
-            <div className="w-full">
-                <div className="flex items-center justify-center gap-2 p-3 bg-transparent">
-                    <div className="flex items-center gap-2 p-3 bg-white text-foreground border rounded-md shadow-sm">
+        <TooltipProvider>
+            <div id="editor_toolbar" className="w-full overflow-x-auto">
+                <div className="w-full">
+                    <div className="flex items-center justify-center gap-2 p-3 bg-transparent">
+                        <div className="flex items-center gap-2 p-3 bg-white text-foreground border rounded-md shadow-sm">
 
                         {/* History */}
                         <div className="flex items-center gap-1">
@@ -327,6 +328,7 @@ export function EditorToolbar(props: EditorToolbarProps) {
                 </div>
             </div>
         </div>
+        </TooltipProvider>
     );
 }
 

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -13,15 +13,17 @@ const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className
-    )}
-    {...props}
-  />
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 


### PR DESCRIPTION
## Summary
- render tooltip content via `TooltipPrimitive.Portal`
- ensure `EditorToolbar` always provides a tooltip provider

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab586243ec8333a75606b779de3e22