### PR TITLE
Make cover page canvas scrollable

### DIFF
--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -580,7 +580,7 @@ export default function CoverPageEditorPage() {
                 open={shortcutsOpen}
                 onClose={() => setShortcutsOpen(false)}
             />
-            <div className=" flex flex-col bg-background">
+            <div className="flex flex-col h-full overflow-hidden bg-background">
             {/* Header */}
             <div className="flex items-center justify-between px-4 border-b">
                 {/* Toolbar */}


### PR DESCRIPTION
## Summary
- keep toolbar visible by constraining cover page editor height and making canvas area scrollable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any & other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5b16f08c8333b8bd7e1525a58fc5