### PR TITLE
refactor selection listeners in cover page editor

### DIFF
--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -95,9 +95,10 @@ export default function CoverPageEditorPage() {
         setCanvas(c);
 
         // Event listeners
+        const updateSelection = () => setSelectedObjects(c.getActiveObjects());
+        c.on("selection:created", updateSelection);
+        c.on("selection:updated", updateSelection);
         c.on("selection:cleared", () => setSelectedObjects([]));
-        c.on("selection:updated", (e) => setSelectedObjects(e.selected || []));
-        c.on("selection:created", (e) => setSelectedObjects(e.selected || []));
         c.on("object:modified", () => pushHistory());
 
         // Initial history


### PR DESCRIPTION
## Summary
- unify canvas selection event handling in CoverPageEditorPage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6348511883339de44b1a0d5591e8