### PR TITLE
Fix selection state to enable alignment controls

### DIFF
--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -95,7 +95,7 @@ export default function CoverPageEditorPage() {
         setCanvas(c);
 
         // Event listeners
-        const updateSelection = () => setSelectedObjects(c.getActiveObjects());
+        const updateSelection = () => setSelectedObjects([...c.getActiveObjects()]);
         c.on("selection:created", updateSelection);
         c.on("selection:updated", updateSelection);
         c.on("selection:cleared", () => setSelectedObjects([]));


### PR DESCRIPTION
## Summary
- copy Fabric canvas selection objects into state so React updates
- ensure EditorToolbar alignment controls activate only with multiple selections

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6852f33083339d2536aef0c842f5