### PR TITLE
feat: add layer delete option

### DIFF
--- a/src/components/cover-pages/PropertiesPanel.tsx
+++ b/src/components/cover-pages/PropertiesPanel.tsx
@@ -27,6 +27,7 @@ import {
   ArrowUp,
   AlignVerticalJustifyCenter,
   ArrowDown,
+  Trash2,
 } from "lucide-react";
 
 interface PropertiesPanelProps {
@@ -35,6 +36,7 @@ interface PropertiesPanelProps {
   onAlign: (type: "left" | "centerH" | "right" | "top" | "centerV" | "bottom") => void;
   onUpdateProperty: (property: string, value: any) => void;
   onToggleLayerVisibility: (layer: FabricObject) => void;
+  onDeleteLayer: (layer: FabricObject) => void;
   layers: FabricObject[];
   onSelectLayer: (object: FabricObject) => void;
 }
@@ -56,6 +58,7 @@ export function PropertiesPanel({
   onAlign,
   onUpdateProperty,
   onToggleLayerVisibility,
+  onDeleteLayer,
   layers,
   onSelectLayer,
 }: PropertiesPanelProps) {
@@ -380,18 +383,28 @@ export function PropertiesPanel({
                           ? "Text"
                           : layer.type || "Object"} {index + 1}
                       </span>
-                      <span
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onToggleLayerVisibility(layer);
-                        }}
-                      >
-                        {layer.visible ? (
-                          <Eye className="h-4 w-4" />
-                        ) : (
-                          <EyeOff className="h-4 w-4" />
-                        )}
-                      </span>
+                      <div className="flex items-center gap-1">
+                        <span
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onToggleLayerVisibility(layer);
+                          }}
+                        >
+                          {layer.visible ? (
+                            <Eye className="h-4 w-4" />
+                          ) : (
+                            <EyeOff className="h-4 w-4" />
+                          )}
+                        </span>
+                        <span
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onDeleteLayer(layer);
+                          }}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </span>
+                      </div>
                     </Button>
                   ))}
                 </div>

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -610,6 +610,14 @@ export default function CoverPageEditorPage() {
         canvas.renderAll();
     };
 
+    const handleDeleteLayer = (layer: FabricObject) => {
+        canvas.remove(layer);
+        canvas.discardActiveObject();
+        setSelectedObjects(canvas.getActiveObjects());
+        canvas.renderAll();
+        pushHistory();
+    };
+
     const handleSelectLayer = (object: FabricObject) => {
         if (!canvas) return;
 
@@ -793,6 +801,7 @@ export default function CoverPageEditorPage() {
                         onAlign={handleAlign}
                         onUpdateProperty={handleUpdateProperty}
                         onToggleLayerVisibility={handleToggleLayerVisibility}
+                        onDeleteLayer={handleDeleteLayer}
                         layers={layers}
                         onSelectLayer={handleSelectLayer}
                     />


### PR DESCRIPTION
## Summary
- add trash icon to layer list and hook it to new onDeleteLayer prop
- wire CoverPageEditorPage up with layer deletion handler

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 227 problems)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab6f9205cc8333b74215c15a431dc7