### PR TITLE
Register cover page reportTypes field

### DIFF
--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -69,6 +69,11 @@ export default function CoverPageEditorPage() {
     });
 
     const {register, handleSubmit, setValue, watch} = form;
+
+    useEffect(() => {
+        register("reportTypes");
+    }, [register]);
+
     const template = watch("template") as keyof typeof TEMPLATES;
     const reportTypes = watch("reportTypes");
     const loaded = useRef(false);


### PR DESCRIPTION
## Summary
- register `reportTypes` field in `CoverPageEditorPage` so default report types pre-fill on load

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, no-explicit-any, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab771051f083339bb07d0c021bf361