### PR TITLE
Return signed URL on image upload

### DIFF
--- a/src/components/cover-pages/editor-sidebar/ImagesSection.tsx
+++ b/src/components/cover-pages/editor-sidebar/ImagesSection.tsx
@@ -23,6 +23,7 @@ export function ImagesSection({
     const handleAdd = () => {
         const trimmed = url.trim();
         if (!trimmed) return;
+        // Use the common add-image handler so uploads and manual URLs share the same path
         onAddImageFromUrl(trimmed);
         setUrl("");
     };

--- a/src/hooks/useImageLibrary.ts
+++ b/src/hooks/useImageLibrary.ts
@@ -47,7 +47,13 @@ export default function useImageLibrary() {
         .from(IMAGE_LIBRARY_BUCKET)
         .upload(path, file, { upsert: false });
       if (error) throw error;
-      return path;
+
+      const { data: urlData, error: urlError } = await supabase.storage
+        .from(IMAGE_LIBRARY_BUCKET)
+        .createSignedUrl(path, 3600);
+      if (urlError) throw urlError;
+
+      return { path, url: urlData?.signedUrl || "" };
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["image-library", user?.id] });

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -462,15 +462,10 @@ export default function CoverPageEditorPage() {
 
     const handleUploadImage = async (file: File) => {
         try {
-            const uploadedImageData = await uploadImage(file);
-            if (uploadedImageData) {
-                const imageUrl = typeof uploadedImageData === 'string'
-                    ? uploadedImageData
-                    : (uploadedImageData as any)?.url || '';
-                if (imageUrl) {
-                    handleAddImage(imageUrl);
-                    toast.success("Image uploaded successfully");
-                }
+            const {url} = await uploadImage(file);
+            if (url) {
+                handleAddImage(url);
+                toast.success("Image uploaded successfully");
             }
         } catch (error) {
             toast.error("Failed to upload image");


### PR DESCRIPTION
## Summary
- return signed image URL after upload
- use signed URL to add images to the cover page editor
- clarify ImagesSection to funnel both URLs and uploads through one handler

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ab793ad56c8333a4320da2c8283624