### PR TITLE
feat: add openmoji clipart helper

### DIFF
--- a/src/lib/fabricShapes.ts
+++ b/src/lib/fabricShapes.ts
@@ -150,3 +150,37 @@ export async function addLucideIconByName(canvas: FabricCanvas, name: string, st
     } catch {
     }
 }
+
+export async function addOpenmojiClipart(
+    canvas: FabricCanvas,
+    palette: Palette,
+    hex: string,
+    x = 100,
+    y = 100,
+) {
+    try {
+        const res = await fetch(
+            `https://cdn.jsdelivr.net/npm/openmoji@16.0.0/color/svg/${hex}.svg`,
+        );
+        if (!res.ok) return;
+        const svg = await res.text();
+        const stroke = palette.colors[1] || palette.colors[0];
+        await new Promise<void>((resolve) => {
+            loadSVGFromString(svg, (objects, options) => {
+                if (objects) {
+                    const obj = objects as any;
+                    obj.set({left: x, top: y, scaleX: 0.5, scaleY: 0.5, visible: true});
+                    obj.set({stroke});
+                    if (obj._objects) {
+                        obj._objects.forEach((o: any) => o.set({stroke}));
+                    }
+                    canvas.add(obj);
+                    canvas.setActiveObject(obj);
+                    canvas.requestRenderAll();
+                }
+                resolve();
+            });
+        });
+    } catch {
+    }
+}

--- a/src/lib/handleCoverElementDrop.ts
+++ b/src/lib/handleCoverElementDrop.ts
@@ -9,6 +9,7 @@ import {
     addArrow as fabricAddArrow,
     addBidirectionalArrow as fabricAddBidirectionalArrow,
     addText as fabricAddText,
+    addOpenmojiClipart,
 } from "@/lib/fabricShapes";
 
 interface DropPayload {
@@ -21,7 +22,6 @@ interface DropPayload {
 interface ExtraHandlers {
     addImage?: (url: string, x: number, y: number) => void;
     addIcon?: (name: string, x: number, y: number) => void;
-    addClipart?: (hex: string, x: number, y: number) => void;
 }
 
 export function handleCoverElementDrop(
@@ -73,7 +73,10 @@ export function handleCoverElementDrop(
             if (data?.name) handlers.addIcon?.(data.name, x, y);
             break;
         case "clipart":
-            if (data?.hex) handlers.addClipart?.(data.hex, x, y);
+            if (data?.hex)
+                addOpenmojiClipart(canvas, palette, data.hex, x, y).then(() => {
+                    pushHistory?.();
+                });
             break;
         default:
             break;

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -1,12 +1,13 @@
 import {type ChangeEvent, useEffect, useRef, useState} from "react";
 import {useForm} from "react-hook-form";
 import {useNavigate, useParams} from "react-router-dom";
-import {Canvas as FabricCanvas, FabricObject, Group, Image as FabricImage, loadSVGFromString,} from "fabric";
+import {Canvas as FabricCanvas, FabricObject, Group, Image as FabricImage} from "fabric";
 import {
     addArrow as fabricAddArrow,
     addBidirectionalArrow as fabricAddBidirectionalArrow,
     addCircle as fabricAddCircle,
     addLucideIconByName,
+    addOpenmojiClipart,
     addPolygon as fabricAddPolygon,
     addRect as fabricAddRect,
     addStar as fabricAddStar,
@@ -400,22 +401,8 @@ export default function CoverPageEditorPage() {
 
     const handleAddClipart = async (hex: string, x = 100, y = 100) => {
         if (!canvas) return;
-        try {
-            const url = `https://cdn.jsdelivr.net/npm/openmoji@16.0.0/color/svg/${hex}.svg`;
-            const svg = await fetch(url).then((r) => r.text());
-            loadSVGFromString(svg, (objects, options) => {
-                if (objects) {
-                    // In Fabric.js v6, objects is the parsed SVG group already
-                    const obj = objects as any;
-                    obj.set({left: x, top: y, scaleX: 0.5, scaleY: 0.5, visible: true});
-                    canvas.add(obj);
-                    canvas.setActiveObject(obj);
-                    canvas.renderAll();
-                    pushHistory();
-                }
-            });
-        } catch {
-        }
+        await addOpenmojiClipart(canvas, palette, hex, x, y);
+        pushHistory();
     };
 
     const handleAddImage = (imageUrl: string, x = 100, y = 100) => {
@@ -474,7 +461,6 @@ export default function CoverPageEditorPage() {
             {
                 addImage: handleAddImage,
                 addIcon: handleAddIcon,
-                addClipart: handleAddClipart,
             },
             pushHistory,
         );


### PR DESCRIPTION
## Summary
- add `addOpenmojiClipart` utility to load OpenMoji SVGs with palette stroke
- use helper when dropping or adding clipart in cover page editor

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68ab7c9314fc8333a27359541f74bf1c