### PR TITLE
feat: add table insertion support

### DIFF
--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -14,6 +14,7 @@ import {
     addText as fabricAddText,
     addTriangle as fabricAddTriangle,
 } from "@/lib/fabricShapes";
+import {createTableGroup} from "@/lib/fabricTables";
 import {handleCoverElementDrop} from "@/lib/handleCoverElementDrop";
 import {Button} from "@/components/ui/button";
 import {Input} from "@/components/ui/input";
@@ -505,6 +506,14 @@ export default function CoverPageEditorPage() {
         fabricAddBidirectionalArrow(canvas, palette);
         pushHistory();
     };
+    const addTable = (rows: number, cols: number, borderColor: string) => {
+        if (!canvas) return;
+        const tbl = createTableGroup(rows, cols, 80, 24, borderColor, 2);
+        canvas.add(tbl);
+        canvas.setActiveObject(tbl);
+        canvas.requestRenderAll();
+        pushHistory();
+    };
     const addIcon = (name: string) => handleAddIcon(name);
     const addClipart = (hex: string) => handleAddClipart(hex);
 
@@ -749,6 +758,7 @@ export default function CoverPageEditorPage() {
                         addBidirectionalArrow={addBidirectionalArrow}
                         addIcon={addIcon}
                         addClipart={addClipart}
+                        addTable={addTable}
                         templateOptions={Object.keys(TEMPLATES)}
                         palette={palette}
                         onApplyPalette={applyPalette}


### PR DESCRIPTION
## Summary
- allow creating table shapes in the cover page editor using fabric utility
- expose addTable to the editor sidebar so tables can be added from UI and via drag-and-drop

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7d85d85c8333a8e25e137012fa15