### PR TITLE
feat: apply new palette to canvas objects

### DIFF
--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -532,6 +532,35 @@ export default function CoverPageEditorPage() {
 
     const applyPalette = (p: ColorPalette) => {
         setPalette(p);
+        if (!canvas) return;
+
+        const applyToObject = (obj: FabricObject, inGroup = false) => {
+            if (obj instanceof Group) {
+                obj.getObjects().forEach((child) => applyToObject(child, true));
+                return;
+            }
+
+            if (obj.type === "image") return;
+
+            if (obj.type === "textbox") {
+                obj.set({fill: p.colors[3] || p.colors[0]});
+                return;
+            }
+
+            if (obj.type === "line") {
+                obj.set({stroke: p.colors[1] || p.colors[0]});
+                return;
+            }
+
+            obj.set({
+                fill: inGroup ? p.colors[1] || p.colors[0] : p.colors[0],
+                stroke: p.colors[1] || p.colors[0],
+            });
+        };
+
+        canvas.getObjects().forEach((obj) => applyToObject(obj));
+        canvas.requestRenderAll();
+        pushHistory();
     };
 
     const updateBgColor = (color: string) => {


### PR DESCRIPTION
## Summary
- update palette across canvas objects when applying new theme
- re-render canvas and push history after palette changes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7f140c748333a46df31e2a54ac31