### PR TITLE
Add element-specific drag payload handlers

### DIFF
--- a/src/components/cover-pages/EditorSidebar.tsx
+++ b/src/components/cover-pages/EditorSidebar.tsx
@@ -87,30 +87,9 @@ export function EditorSidebar(props: EditorSidebarProps) {
         onShowShortcuts,
     } = props;
 
-    const handleSidebarDragStart: React.DragEventHandler<HTMLDivElement> = (e) => {
-        const el = (e.target as HTMLElement).closest<HTMLElement>("[data-drag-type]");
-
-        if (!el) return;
-
-        const type = el.dataset.dragType!;
-        const payload = el.dataset.dragPayload ? JSON.parse(el.dataset.dragPayload) : {};
-        const bundle = JSON.stringify({type, ...payload});
-        console.log("dragstart:", type, payload);
-        e.dataTransfer?.setData("application/x-cover-element", bundle);
-        e.dataTransfer!.effectAllowed = "copy";
-
-        const dragImg = el.querySelector("[data-drag-image]") as HTMLElement | null;
-        if (dragImg) {
-            const rect = dragImg.getBoundingClientRect();
-            e.dataTransfer!.setDragImage(dragImg, rect.width / 2, rect.height / 2);
-        }
-    };
-
-
     return (
         <div
             className="w-[14rem] h-full p-2 border-r space-y-2 overflow-y-auto overflow-x-visible relative pb-16 bg-[#FFFFFF]"
-            onDragStart={handleSidebarDragStart}
         >
 
             <div className="space-y-2">

--- a/src/components/cover-pages/editor-sidebar/GraphicsSection.tsx
+++ b/src/components/cover-pages/editor-sidebar/GraphicsSection.tsx
@@ -52,7 +52,11 @@ export function GraphicsSection({
             <div className="flex flex-wrap gap-3">
                 <Button
                     draggable
-                    data-drag-type="rectangle"
+                    onDragStart={(e) => {
+                        const payload = JSON.stringify({type: "rectangle"});
+                        e.dataTransfer?.setData("application/x-cover-element", payload);
+                        e.dataTransfer!.effectAllowed = "copy";
+                    }}
                     onClick={addRect}
                     className="bg-[#ededed] w-16 h-16 p-0 rounded-md hover:bg-gray-300 flex items-center justify-center [&>svg]:!size-10"
                     aria-label="Rectangle"
@@ -61,7 +65,11 @@ export function GraphicsSection({
                 </Button>
                 <Button
                     draggable
-                    data-drag-type="circle"
+                    onDragStart={(e) => {
+                        const payload = JSON.stringify({type: "circle"});
+                        e.dataTransfer?.setData("application/x-cover-element", payload);
+                        e.dataTransfer!.effectAllowed = "copy";
+                    }}
                     onClick={addCircle}
                     className="bg-[#ededed] w-16 h-16 p-0 rounded-md hover:bg-gray-300 flex items-center justify-center [&>svg]:!size-10"
                     aria-label="Circle"
@@ -70,7 +78,11 @@ export function GraphicsSection({
                 </Button>
                 <Button
                     draggable
-                    data-drag-type="star"
+                    onDragStart={(e) => {
+                        const payload = JSON.stringify({type: "star"});
+                        e.dataTransfer?.setData("application/x-cover-element", payload);
+                        e.dataTransfer!.effectAllowed = "copy";
+                    }}
                     onClick={addStar}
                     className="bg-[#ededed] w-16 h-16 p-0 rounded-md hover:bg-gray-300 flex items-center justify-center [&>svg]:!size-10"
                     aria-label="Star"
@@ -79,7 +91,11 @@ export function GraphicsSection({
                 </Button>
                 <Button
                     draggable
-                    data-drag-type="triangle"
+                    onDragStart={(e) => {
+                        const payload = JSON.stringify({type: "triangle"});
+                        e.dataTransfer?.setData("application/x-cover-element", payload);
+                        e.dataTransfer!.effectAllowed = "copy";
+                    }}
                     onClick={addTriangle}
                     className="bg-[#ededed] w-16 h-16 p-0 rounded-md hover:bg-gray-300 flex items-center justify-center [&>svg]:!size-10"
                     aria-label="Triangle"
@@ -88,7 +104,11 @@ export function GraphicsSection({
                 </Button>
                 <Button
                     draggable
-                    data-drag-type="polygon"
+                    onDragStart={(e) => {
+                        const payload = JSON.stringify({type: "polygon"});
+                        e.dataTransfer?.setData("application/x-cover-element", payload);
+                        e.dataTransfer!.effectAllowed = "copy";
+                    }}
                     onClick={addPolygonShape}
                     className="bg-[#ededed] w-16 h-16 p-0 rounded-md hover:bg-gray-300 flex items-center justify-center [&>svg]:!size-10"
                     aria-label="Pentagon"
@@ -97,7 +117,11 @@ export function GraphicsSection({
                 </Button>
                 <Button
                     draggable
-                    data-drag-type="arrow"
+                    onDragStart={(e) => {
+                        const payload = JSON.stringify({type: "arrow"});
+                        e.dataTransfer?.setData("application/x-cover-element", payload);
+                        e.dataTransfer!.effectAllowed = "copy";
+                    }}
                     onClick={addArrow}
                     className="bg-[#ededed] w-16 h-16 p-0 rounded-md hover:bg-gray-300 flex items-center justify-center [&>svg]:!size-10"
                     aria-label="Arrow Right"
@@ -106,7 +130,11 @@ export function GraphicsSection({
                 </Button>
                 <Button
                     draggable
-                    data-drag-type="bidirectionalArrow"
+                    onDragStart={(e) => {
+                        const payload = JSON.stringify({type: "bidirectionalArrow"});
+                        e.dataTransfer?.setData("application/x-cover-element", payload);
+                        e.dataTransfer!.effectAllowed = "copy";
+                    }}
                     onClick={addBidirectionalArrow}
                     className="bg-[#ededed] w-16 h-16 p-0 rounded-md hover:bg-gray-300 flex items-center justify-center [&>svg]:!size-10"
                     aria-label="Bidirectional Arrow"
@@ -141,8 +169,11 @@ export function GraphicsSection({
                                     type="button"
                                     className="p-1 border rounded hover:bg-accent flex items-center justify-center"
                                     draggable
-                                    data-drag-type="icon"
-                                    data-drag-payload={JSON.stringify({name})}
+                                    onDragStart={(e) => {
+                                        const payload = JSON.stringify({type: "icon", name});
+                                        e.dataTransfer?.setData("application/x-cover-element", payload);
+                                        e.dataTransfer!.effectAllowed = "copy";
+                                    }}
                                     onClick={() => addIcon(name)}
                                     title={name}
                                 >
@@ -172,8 +203,11 @@ export function GraphicsSection({
                                 type="button"
                                 className="p-1 border rounded hover:bg-accent flex items-center justify-center"
                                 draggable
-                                data-drag-type="clipart"
-                                data-drag-payload={JSON.stringify({hex: c.hexcode})}
+                                onDragStart={(e) => {
+                                    const payload = JSON.stringify({type: "clipart", hex: c.hexcode});
+                                    e.dataTransfer?.setData("application/x-cover-element", payload);
+                                    e.dataTransfer!.effectAllowed = "copy";
+                                }}
                                 onClick={() => addClipart(c.hexcode)}
                                 title={c.annotation}
                             >

--- a/src/components/cover-pages/editor-sidebar/ImagesSection.tsx
+++ b/src/components/cover-pages/editor-sidebar/ImagesSection.tsx
@@ -53,8 +53,11 @@ export function ImagesSection({
                         key={img.path}
                         className="relative group"
                         draggable
-                        data-drag-type="image"
-                        data-drag-payload={JSON.stringify({url: img.url})}
+                        onDragStart={(e) => {
+                            const payload = JSON.stringify({type: "image", url: img.url});
+                            e.dataTransfer?.setData("application/x-cover-element", payload);
+                            e.dataTransfer!.effectAllowed = "copy";
+                        }}
                     >
                         <img
                             src={img.url}

--- a/src/components/cover-pages/editor-sidebar/TextSection.tsx
+++ b/src/components/cover-pages/editor-sidebar/TextSection.tsx
@@ -9,8 +9,11 @@ export function TextSection({addText}: { addText: () => void }) {
                 type="button"
                 className="w-full"
                 draggable
-                data-drag-type="text"
-                data-drag-payload={JSON.stringify({})}
+                onDragStart={(e) => {
+                    const payload = JSON.stringify({type: "text"});
+                    e.dataTransfer?.setData("application/x-cover-element", payload);
+                    e.dataTransfer!.effectAllowed = "copy";
+                }}
                 onClick={addText}
                 title="Drag onto the canvas or click to add"
             >


### PR DESCRIPTION
## Summary
- implement per-element drag payloads in TextSection, GraphicsSection, and ImagesSection
- drop generic drag handler from EditorSidebar

## Testing
- `node - <<'NODE' ... NODE`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 206 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab812391448333bc7ba4b8a622d53d