### PR TITLE
Group SVG elements when loading clipart

### DIFF
--- a/src/lib/fabricShapes.ts
+++ b/src/lib/fabricShapes.ts
@@ -138,7 +138,10 @@ export async function addLucideIconByName(canvas: FabricCanvas, name: string, st
             loadSVGFromString(svg, (objects, options) => {
                 if (objects) {
                     // In Fabric.js v6, objects is the parsed SVG group already
-                    const obj = objects as any;
+                    const obj = Array.isArray(objects)
+                        ? FabricUtil.groupSVGElements(objects, options)
+                        : (objects as any);
+
                     obj.set({left: x, top: y, stroke, fill: "none", visible: true});
                     canvas.add(obj);
                     canvas.setActiveObject(obj);
@@ -168,7 +171,10 @@ export async function addOpenmojiClipart(
         await new Promise<void>((resolve) => {
             loadSVGFromString(svg, (objects, options) => {
                 if (objects) {
-                    const obj = objects as any;
+                    const obj = Array.isArray(objects)
+                        ? FabricUtil.groupSVGElements(objects, options)
+                        : (objects as any);
+
                     obj.set({left: x, top: y, scaleX: 0.5, scaleY: 0.5, visible: true});
                     obj.set({stroke});
                     if (obj._objects) {


### PR DESCRIPTION
## Summary
- Combine parsed SVG arrays into grouped fabric objects when adding Lucide icons or OpenMoji clipart
- Render grouped icon elements on canvas

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 235 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68ab97679af0833393b9c2bff64e23d9