### PR TITLE
feat: specify content type when uploading

### DIFF
--- a/src/hooks/useImageLibrary.ts
+++ b/src/hooks/useImageLibrary.ts
@@ -45,7 +45,7 @@ export default function useImageLibrary() {
       const path = `${folder}/${Date.now()}_${file.name.replace(/\s+/g, "_")}`;
       const { error } = await supabase.storage
         .from(IMAGE_LIBRARY_BUCKET)
-        .upload(path, file, { upsert: false });
+        .upload(path, file, { upsert: false, contentType: file.type });
       if (error) throw error;
 
       const { data: urlData, error: urlError } = await supabase.storage


### PR DESCRIPTION
## Summary
- include file's MIME type when uploading images to storage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_68ab99e5dd888333910c2a3b5574b01a