### PR TITLE
Simplify SVG load handling

### DIFF
--- a/src/lib/fabricShapes.ts
+++ b/src/lib/fabricShapes.ts
@@ -135,22 +135,15 @@ export async function addLucideIconByName(canvas: FabricCanvas, name: string, st
         const res = await fetch(`https://unpkg.com/lucide-static@latest/icons/${iconName}.svg`);
         if (!res.ok) return;
         const svg = await res.text();
-        await new Promise<void>(resolve => {
-            loadSVGFromString(svg, (objects, options) => {
-                if (objects) {
-                    // In Fabric.js v6, objects is the parsed SVG group already
-                    const obj = Array.isArray(objects)
-                        ? FabricUtil.groupSVGElements(objects, options)
-                        : (objects as any);
+        const { objects, options } = await loadSVGFromString(svg);
+        const obj = Array.isArray(objects)
+            ? FabricUtil.groupSVGElements(objects, options)
+            : (objects as any);
 
-                    obj.set({left: x, top: y, stroke, fill: "none", visible: true});
-                    canvas.add(obj);
-                    canvas.setActiveObject(obj);
-                    canvas.requestRenderAll();
-                }
-                resolve();
-            });
-        });
+        obj.set({left: x, top: y, stroke, fill: "none", visible: true});
+        canvas.add(obj);
+        canvas.setActiveObject(obj);
+        canvas.requestRenderAll();
     } catch {
     }
 }
@@ -169,25 +162,19 @@ export async function addOpenmojiClipart(
         if (!res.ok) return;
         const svg = await res.text();
         const stroke = palette.colors[1] || palette.colors[0];
-        await new Promise<void>((resolve) => {
-            loadSVGFromString(svg, (objects, options) => {
-                if (objects) {
-                    const obj = Array.isArray(objects)
-                        ? FabricUtil.groupSVGElements(objects, options)
-                        : (objects as any);
+        const { objects, options } = await loadSVGFromString(svg);
+        const obj = Array.isArray(objects)
+            ? FabricUtil.groupSVGElements(objects, options)
+            : (objects as any);
 
-                    obj.set({left: x, top: y, scaleX: 0.5, scaleY: 0.5, visible: true});
-                    obj.set({stroke});
-                    if (obj._objects) {
-                        obj._objects.forEach((o: any) => o.set({stroke}));
-                    }
-                    canvas.add(obj);
-                    canvas.setActiveObject(obj);
-                    canvas.requestRenderAll();
-                }
-                resolve();
-            });
-        });
+        obj.set({left: x, top: y, scaleX: 0.5, scaleY: 0.5, visible: true});
+        obj.set({stroke});
+        if (obj._objects) {
+            obj._objects.forEach((o: any) => o.set({stroke}));
+        }
+        canvas.add(obj);
+        canvas.setActiveObject(obj);
+        canvas.requestRenderAll();
     } catch {
     }
 }


### PR DESCRIPTION
## Summary
- Refactor `addLucideIconByName` to await `loadSVGFromString` and streamline object setup
- Refactor `addOpenmojiClipart` with async SVG loading and remove manual Promise wrapper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and require-import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9bf0a1f48333b828fe536ad3bf35