### PR TITLE
feat: add image proxy endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ The app supports fully customizable cover pages for reports.
 After a cover page is assigned, generate a report PDF from the report preview. The
 selected cover page will appear at the beginning of the PDF.
 
+## Image Proxy
+
+When adding external images, the app routes the request through `/api/image-proxy`.
+This server-side proxy fetches the image and returns it with permissive CORS headers
+to prevent cross-origin errors when loading user-provided URLs.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/069944d1-052a-41dd-b482-c41df0da3591) and click on Share -> Publish.

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -429,7 +429,9 @@ export default function CoverPageEditorPage() {
         try {
             const sameOrigin = imageUrl.startsWith(window.location.origin);
             const img = await FabricImage.fromURL(
-                imageUrl,
+                sameOrigin
+                    ? imageUrl
+                    : `/api/image-proxy?url=${encodeURIComponent(imageUrl)}`,
                 sameOrigin ? undefined : {crossOrigin: "anonymous"},
             );
             img.set({

--- a/supabase/functions/image-proxy/index.ts
+++ b/supabase/functions/image-proxy/index.ts
@@ -1,0 +1,41 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const { searchParams } = new URL(req.url);
+    const targetUrl = searchParams.get("url");
+
+    if (!targetUrl) {
+      return new Response("Missing url parameter", {
+        status: 400,
+        headers: corsHeaders,
+      });
+    }
+
+    const response = await fetch(targetUrl);
+    const contentType = response.headers.get("content-type") || "application/octet-stream";
+
+    return new Response(response.body, {
+      status: response.status,
+      headers: {
+        ...corsHeaders,
+        "Content-Type": contentType,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return new Response(message, {
+      status: 400,
+      headers: corsHeaders,
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- proxy external image URLs through new `/api/image-proxy` Supabase function
- use the proxy when adding images in CoverPageEditorPage
- document that external image URLs are proxied to avoid CORS issues

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 206 errors, 20 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9d37ca108333877d5127c7e761a9