### PR TITLE
chore: proxy image requests in dev

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 VITE_SUPABASE_PROJECT_ID="qnrqwapbxnplypdirdiq"
 VITE_SUPABASE_PUBLISHABLE_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFucnF3YXBieG5wbHlwZGlyZGlxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQ5NTcxMDMsImV4cCI6MjA3MDUzMzEwM30.H_I28jNt5dhxp9tv20lsLMalSLLrrG_IhqFLf0nblRk"
 VITE_SUPABASE_URL="https://qnrqwapbxnplypdirdiq.supabase.co"
+VITE_IMAGE_PROXY_URL="/api/image-proxy"

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -29,6 +29,7 @@ import {KeyboardShortcutsModal} from "@/components/modals/KeyboardShortcutsModal
 import {COLOR_PALETTES, type ColorPalette} from "@/constants/colorPalettes";
 import {PRESET_BG_COLORS, REPORT_TYPES, TEMPLATES} from "@/constants/coverPageEditor";
 import {toast} from "sonner";
+const IMAGE_PROXY_URL = import.meta.env.VITE_IMAGE_PROXY_URL || '/api/image-proxy';
 
 interface FormValues {
     name: string;
@@ -431,7 +432,7 @@ export default function CoverPageEditorPage() {
             const img = await FabricImage.fromURL(
                 sameOrigin
                     ? imageUrl
-                    : `/api/image-proxy?url=${encodeURIComponent(imageUrl)}`,
+                    : `${IMAGE_PROXY_URL}?url=${encodeURIComponent(imageUrl)}`,
                 sameOrigin ? undefined : {crossOrigin: "anonymous"},
             );
             img.set({

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_IMAGE_PROXY_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,13 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    proxy: {
+      "/api/image-proxy": {
+        target: "http://localhost:54321",
+        changeOrigin: true,
+        rewrite: (p) => p.replace(/^\/api\/image-proxy/, "/functions/v1/image-proxy"),
+      },
+    },
   },
   plugins: [
     react(),


### PR DESCRIPTION
## Summary
- proxy `/api/image-proxy` to local Supabase function during development
- allow overriding image proxy path with `VITE_IMAGE_PROXY_URL`
- type declaration for new env var

## Testing
- `npm run lint` *(fails: `/usr/bin/npm: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68ab96e259b88333b14b33b7214bbac6