### PR TITLE
Use Supabase URL for image proxy

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,7 +2,7 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://qnrqwapbxnplypdirdiq.supabase.co";
+export const SUPABASE_URL = "https://qnrqwapbxnplypdirdiq.supabase.co";
 const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InFucnF3YXBieG5wbHlwZGlyZGlxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQ5NTcxMDMsImV4cCI6MjA3MDUzMzEwM30.H_I28jNt5dhxp9tv20lsLMalSLLrrG_IhqFLf0nblRk";
 
 // Import the supabase client like this:

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -28,8 +28,10 @@ import {useCanvasKeyboardShortcuts} from "@/hooks/useCanvasKeyboardShortcuts";
 import {KeyboardShortcutsModal} from "@/components/modals/KeyboardShortcutsModal";
 import {COLOR_PALETTES, type ColorPalette} from "@/constants/colorPalettes";
 import {PRESET_BG_COLORS, REPORT_TYPES, TEMPLATES} from "@/constants/coverPageEditor";
+import {SUPABASE_URL} from "@/integrations/supabase/client";
 import {toast} from "sonner";
-const IMAGE_PROXY_URL = import.meta.env.VITE_IMAGE_PROXY_URL || '/api/image-proxy';
+const DEFAULT_PROXY = `${SUPABASE_URL}/functions/v1/image-proxy`;
+const IMAGE_PROXY_URL = import.meta.env.VITE_IMAGE_PROXY_URL ?? DEFAULT_PROXY;
 
 interface FormValues {
     name: string;


### PR DESCRIPTION
## Summary
- export `SUPABASE_URL` from Supabase client
- build image proxy URL in `CoverPageEditorPage` using Supabase edge function by default

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aba7c149dc8333a8222265b5d93aa9