### PR TITLE
Add drop payload logging

### DIFF
--- a/src/components/cover-pages/CanvasWorkspace.tsx
+++ b/src/components/cover-pages/CanvasWorkspace.tsx
@@ -102,10 +102,11 @@ export function CanvasWorkspace({
             } catch {
                 return;
             }
-            const {type, ...rest} = payload;
+            const { type, data: payloadData } = payload;
 
             const pt = canvas.getPointer(e as unknown as MouseEvent, true); // ignore viewport zoom
-            onDropElement?.({type, data: rest, x: pt.x, y: pt.y});
+            console.log({ type, payloadData, x: pt.x, y: pt.y });
+            onDropElement?.({ type, data: payloadData, x: pt.x, y: pt.y });
         };
 
         // const onDrop = (e: DragEvent) => {

--- a/src/lib/handleCoverElementDrop.ts
+++ b/src/lib/handleCoverElementDrop.ts
@@ -32,6 +32,7 @@ export function handleCoverElementDrop(
     pushHistory?: () => void,
 ) {
     if (!canvas) return;
+    console.log('Dropping element', { type, data, x, y });
 
     switch (type) {
         case "text":
@@ -68,8 +69,8 @@ export function handleCoverElementDrop(
             break;
         case "image":
             if (data?.url) {
-                console.log("Handling image drop:", { url: data.url, x, y });
                 handlers.addImage?.(data.url, x, y);
+                console.log('Image added', { url: data.url, x, y });
                 pushHistory?.();
             }
             break;


### PR DESCRIPTION
## Summary
- Refactor CanvasWorkspace drop handler to parse `payload.data`, forward it, and log drop coordinates
- Add logging for dropped elements and image additions in handleCoverElementDrop

## Testing
- `npm run lint` *(fails: Unexpected any, require import issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ac511309bc8333b92e89d9c0d77abc