### PR TITLE
Add logging for report type selection in cover page editor

### DIFF
--- a/src/components/cover-pages/editor-sidebar/SettingsSection.tsx
+++ b/src/components/cover-pages/editor-sidebar/SettingsSection.tsx
@@ -2,6 +2,7 @@ import {Button} from "@/components/ui/button.tsx";
 import {Input} from "@/components/ui/input.tsx";
 import {Label} from "@/components/ui/label.tsx";
 import {Checkbox} from "@/components/ui/checkbox.tsx";
+import {useEffect} from "react";
 
 export function SettingsSection({
                                     onSettingsSubmit,
@@ -17,6 +18,10 @@ export function SettingsSection({
     toggleReportType: (rt: string) => void;
 }) {
     console.log("SettingsSection render - reportTypes:", reportTypes, "options:", reportTypeOptions);
+
+    useEffect(() => {
+        console.log("SettingsSection reportTypes prop changed:", reportTypes);
+    }, [reportTypes]);
     
     return (
         <form onSubmit={onSettingsSubmit} className="space-y-2">

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -80,7 +80,7 @@ export default function CoverPageEditorPage() {
     }, [register]);
 
     const template = watch("template") as keyof typeof TEMPLATES;
-    const reportTypes = watch("reportTypes");
+    const reportTypes = watch("reportTypes", []);
     const loaded = useRef(false);
 
     useEffect(() => {
@@ -166,6 +166,7 @@ export default function CoverPageEditorPage() {
         setValue("name", cp.name);
         setValue("template", (cp.template_slug as keyof typeof TEMPLATES) || "default");
         setValue("reportTypes", selectedReportTypes);
+        console.log("After setValue reportTypes:", {selectedReportTypes, watched: watch("reportTypes")});
         
         if (!loaded.current && cp.design_json) {
             canvas.loadFromJSON(cp.design_json as any, () => {
@@ -883,11 +884,11 @@ export default function CoverPageEditorPage() {
                         reportTypes={reportTypes}
                         reportTypeOptions={REPORT_TYPES}
                         toggleReportType={(rt) => {
-                            if (reportTypes.includes(rt)) {
-                                setValue("reportTypes", reportTypes.filter((t) => t !== rt));
-                            } else {
-                                setValue("reportTypes", [...reportTypes, rt]);
-                            }
+                            const updatedReportTypes = reportTypes.includes(rt)
+                                ? reportTypes.filter((t) => t !== rt)
+                                : [...reportTypes, rt];
+                            setValue("reportTypes", updatedReportTypes);
+                            console.log("Toggled report type:", rt, "watch result:", watch("reportTypes"));
                         }}
                         addText={addText}
                         images={images}


### PR DESCRIPTION
## Summary
- default report type watcher to empty array
- log form report types when loading or toggling
- log SettingsSection prop changes for debugging

## Testing
- `npm run lint` *(fails: Unexpected any, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_68ac51fe8fa083338ac78f39ead5d64d