### PR TITLE
Handle cover page assignment loading

### DIFF
--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -62,6 +62,7 @@ export default function CoverPageEditorPage() {
         createCoverPage,
         updateCoverPage,
         assignments,
+        isLoadingAssignments,
         assignCoverPageToReportType,
         removeAssignmentFromReportType,
         coverPages,
@@ -142,7 +143,7 @@ export default function CoverPageEditorPage() {
 
     // Load existing cover page
     useEffect(() => {
-        if (!canvas || !id || !coverPages.length) return;
+        if (!canvas || !id || !coverPages.length || isLoadingAssignments) return;
         const cp = coverPages.find((c) => c.id === id);
         if (!cp) return;
         const selectedReportTypes = Object.entries(assignments)
@@ -175,7 +176,7 @@ export default function CoverPageEditorPage() {
             });
             loaded.current = true;
         }
-    }, [canvas, id, coverPages, assignments, form, setValue]);
+    }, [canvas, id, coverPages, assignments, isLoadingAssignments, form, setValue]);
 
     useEffect(() => {
         if (canvas) {


### PR DESCRIPTION
## Summary
- Import `isLoadingAssignments` from `useCoverPages`
- Re-run cover page loading effect once assignments load and guard early when assignments are still fetching

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 227 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6da19d048333a0f33da410457e06