### PR TITLE
Use useWatch for report type selection in cover page editor

### DIFF
--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -1,5 +1,5 @@
 import {type ChangeEvent, useEffect, useRef, useState} from "react";
-import {useForm} from "react-hook-form";
+import {useForm, useWatch} from "react-hook-form";
 import {useNavigate, useParams} from "react-router-dom";
 import {Canvas as FabricCanvas, FabricObject, Group, Image as FabricImage} from "fabric";
 import {
@@ -76,12 +76,8 @@ export default function CoverPageEditorPage() {
 
     const {register, handleSubmit, setValue, watch} = form;
 
-    useEffect(() => {
-        register("reportTypes");
-    }, [register]);
-
     const template = watch("template") as keyof typeof TEMPLATES;
-    const reportTypes = watch("reportTypes", []);
+    const reportTypes = useWatch({ control: form.control, name: "reportTypes", defaultValue: [] });
     const loaded = useRef(false);
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
- import `useWatch` in `CoverPageEditorPage`
- remove manual `register("reportTypes")` effect
- watch report types with `useWatch` for automatic checkbox pre-selection

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any / other lint errors)*
- `npx eslint src/pages/CoverPageEditorPage.tsx` *(fails: existing any/React hook warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac73c27e488333b607be6ddda06f2e