### PR TITLE
refactor: introduce cell-based fabric table

### DIFF
--- a/src/lib/fabricTables.ts
+++ b/src/lib/fabricTables.ts
@@ -1,4 +1,4 @@
-import {Group, Line} from "fabric";
+import {Group, Rect, Textbox} from "fabric";
 import {enableScalingHandles} from "./fabricShapes";
 
 export interface TableData {
@@ -13,7 +13,7 @@ export interface TableData {
     cellPadY: number;
 }
 
-export function createTableGroup(
+export function createTable(
     rows: number,
     cols: number,
     cellW: number,
@@ -25,26 +25,39 @@ export function createTableGroup(
     cellPadX = 8,
     cellPadY = 4
 ) {
-    const lines: Line[] = [];
-    for (let i = 0; i <= rows; i++) {
-        lines.push(
-            new Line([0, i * cellH, cols * cellW, i * cellH], {
+    const cells: Group[] = [];
+    for (let r = 0; r < rows; r++) {
+        for (let c = 0; c < cols; c++) {
+            const rect = new Rect({
+                left: 0,
+                top: 0,
+                width: cellW,
+                height: cellH,
+                fill: "white",
                 stroke: borderColor,
                 strokeWidth: borderWidth,
                 selectable: false,
-            }),
-        );
-    }
-    for (let i = 0; i <= cols; i++) {
-        lines.push(
-            new Line([i * cellW, 0, i * cellW, rows * cellH], {
-                stroke: borderColor,
-                strokeWidth: borderWidth,
+            });
+            const textbox = new Textbox("", {
+                left: cellPadX,
+                top: cellPadY,
+                width: cellW - 2 * cellPadX,
+                height: cellH - 2 * cellPadY,
+                fontSize: 14,
+                fill: "#000",
                 selectable: false,
-            }),
-        );
+            });
+            const cell = new Group([rect, textbox], {
+                left: c * cellW,
+                top: r * cellH,
+                selectable: false,
+                name: "Cell",
+            });
+            (cell as any).data = {row: r, col: c, content: ""};
+            cells.push(cell);
+        }
     }
-    const group = new Group(lines, {left, top, name: "Table"});
+    const group = new Group(cells, {left, top, name: "Table"});
     const data: TableData = {
         type: "table",
         rows,
@@ -59,4 +72,32 @@ export function createTableGroup(
     (group as any).data = data;
     enableScalingHandles(group);
     return group;
+}
+
+export function getCell(table: Group, row: number, col: number) {
+    return table
+        .getObjects()
+        .find((o) => (o as any).data?.row === row && (o as any).data?.col === col) as
+        | Group
+        | undefined;
+}
+
+export function setCellContent(
+    table: Group,
+    row: number,
+    col: number,
+    content: string,
+) {
+    const cell = getCell(table, row, col);
+    if (!cell) return;
+    const textbox = cell
+        .getObjects()
+        .find((o) => o.type === "textbox") as Textbox | undefined;
+    if (textbox) {
+        textbox.set({text: content});
+    }
+    const data = (cell as any).data;
+    if (data) data.content = content;
+    table.dirty = true;
+    table.canvas?.requestRenderAll();
 }

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -15,7 +15,7 @@ import {
     addTriangle as fabricAddTriangle,
     enableScalingHandles,
 } from "@/lib/fabricShapes";
-import {createTableGroup} from "@/lib/fabricTables";
+import {createTable} from "@/lib/fabricTables";
 import {handleCoverElementDrop} from "@/lib/handleCoverElementDrop";
 import {Button} from "@/components/ui/button";
 import {EditorToolbar} from "@/components/cover-pages/EditorToolbar";
@@ -659,7 +659,7 @@ export default function CoverPageEditorPage() {
     };
     const addTable = (rows: number, cols: number, borderColor: string) => {
         if (!canvas) return;
-        const tbl = createTableGroup(rows, cols, 80, 24, borderColor, 2);
+        const tbl = createTable(rows, cols, 80, 24, borderColor, 2);
         canvas.add(tbl);
         canvas.setActiveObject(tbl);
         canvas.requestRenderAll();


### PR DESCRIPTION
## Summary
- replace line-based table drawing with grouped cell backgrounds
- add helpers to query and update individual table cells
- switch table creation to use new cell-based API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acd8460cac8333b02dffbd21dcb7ac