### PR TITLE
feat: add table editing controls

### DIFF
--- a/src/components/cover-pages/EditorSidebar.tsx
+++ b/src/components/cover-pages/EditorSidebar.tsx
@@ -53,7 +53,12 @@ export interface EditorSidebarProps {
     addClipart: (hex: string) => void;
 
     // TABLES
-    addTable?: (rows: number, cols: number, borderColor: string) => void;
+    addTable?: (rows: number, cols: number, borderColor: string, headerRow: boolean) => void;
+    insertTableRow?: () => void;
+    deleteTableRow?: () => void;
+    insertTableColumn?: () => void;
+    deleteTableColumn?: () => void;
+    toggleHeaderRow?: () => void;
 
     // DESIGN
     templateOptions: string[];
@@ -79,7 +84,7 @@ export function EditorSidebar(props: EditorSidebarProps) {
         addText,
         images, onImageUpload, onDeleteImage, onAddImageFromUrl,
         addRect, addCircle, addStar, addTriangle, addPolygonShape, addArrow, addBidirectionalArrow, addIcon, addClipart,
-        addTable,
+        addTable, insertTableRow, deleteTableRow, insertTableColumn, deleteTableColumn, toggleHeaderRow,
         templateOptions, palette, onApplyPalette,
         bgColor, presetBgColors, updateBgColor,
         onAddPlaceholder,
@@ -161,7 +166,14 @@ export function EditorSidebar(props: EditorSidebarProps) {
                     icon={<TableIcon className="h-4 w-4"/>}
                     title="Tables"
                 >
-                    <TablesSection addTable={addTable}/>
+                    <TablesSection
+                        addTable={addTable}
+                        insertRow={insertTableRow}
+                        deleteRow={deleteTableRow}
+                        insertColumn={insertTableColumn}
+                        deleteColumn={deleteTableColumn}
+                        toggleHeader={toggleHeaderRow}
+                    />
                 </SidebarCard>
 
                 <SidebarCard

--- a/src/components/cover-pages/editor-sidebar/TablesSection.tsx
+++ b/src/components/cover-pages/editor-sidebar/TablesSection.tsx
@@ -2,52 +2,120 @@ import {useState} from "react";
 import {Button} from "@/components/ui/button.tsx";
 import {Input} from "@/components/ui/input.tsx";
 import {Label} from "@/components/ui/label.tsx";
-import {Table as TableIcon} from "lucide-react";
+import {Table as TableIcon, Plus, Minus} from "lucide-react";
 
 export function TablesSection({
-                                  addTable,
-                              }: {
-    addTable?: (rows: number, cols: number, borderColor: string) => void;
+    addTable,
+    insertRow,
+    deleteRow,
+    insertColumn,
+    deleteColumn,
+    toggleHeader,
+}: {
+    addTable?: (rows: number, cols: number, borderColor: string, headerRow: boolean) => void;
+    insertRow?: () => void;
+    deleteRow?: () => void;
+    insertColumn?: () => void;
+    deleteColumn?: () => void;
+    toggleHeader?: () => void;
 }) {
     const [tableRows, setTableRows] = useState(2);
     const [tableCols, setTableCols] = useState(2);
     const [tableBorderColor, setTableBorderColor] = useState("#000000");
+    const [headerRow, setHeaderRow] = useState(false);
+
+    const handleAddRow = () => {
+        setTableRows((r) => r + 1);
+        insertRow?.();
+    };
+    const handleRemoveRow = () => {
+        setTableRows((r) => Math.max(1, r - 1));
+        deleteRow?.();
+    };
+    const handleAddCol = () => {
+        setTableCols((c) => c + 1);
+        insertColumn?.();
+    };
+    const handleRemoveCol = () => {
+        setTableCols((c) => Math.max(1, c - 1));
+        deleteColumn?.();
+    };
+    const handleToggleHeader = () => {
+        setHeaderRow((h) => !h);
+        toggleHeader?.();
+    };
 
     return (
         <div className="space-y-2">
-            <div>
-                <Label htmlFor="table-rows">Rows</Label>
-                <Input
-                    id="table-rows"
-                    type="number"
-                    value={tableRows}
-                    onChange={(e) => setTableRows(parseInt(e.target.value, 10))}
-                />
+            <div className="flex items-center justify-between">
+                <Label>Rows</Label>
+                <div className="flex items-center space-x-1">
+                    <Button size="icon" variant="outline" onClick={handleRemoveRow}>
+                        <Minus className="h-3 w-3" />
+                    </Button>
+                    <span className="w-4 text-center text-sm">{tableRows}</span>
+                    <Button size="icon" variant="outline" onClick={handleAddRow}>
+                        <Plus className="h-3 w-3" />
+                    </Button>
+                </div>
             </div>
-            <div>
-                <Label htmlFor="table-cols">Columns</Label>
-                <Input
-                    id="table-cols"
-                    type="number"
-                    value={tableCols}
-                    onChange={(e) => setTableCols(parseInt(e.target.value, 10))}
-                />
+            <div className="flex items-center justify-between">
+                <Label>Columns</Label>
+                <div className="flex items-center space-x-1">
+                    <Button size="icon" variant="outline" onClick={handleRemoveCol}>
+                        <Minus className="h-3 w-3" />
+                    </Button>
+                    <span className="w-4 text-center text-sm">{tableCols}</span>
+                    <Button size="icon" variant="outline" onClick={handleAddCol}>
+                        <Plus className="h-3 w-3" />
+                    </Button>
+                </div>
             </div>
-            <div>
+            <div className="flex items-center justify-between">
                 <Label htmlFor="table-border-color">Border Color</Label>
                 <Input
                     id="table-border-color"
                     type="color"
                     value={tableBorderColor}
                     onChange={(e) => setTableBorderColor(e.target.value)}
+                    className="h-8 w-16 p-1"
                 />
             </div>
-
+            <div className="flex items-center justify-between">
+                <Label>Header Row</Label>
+                <Button
+                    variant={headerRow ? "default" : "outline"}
+                    size="sm"
+                    onClick={handleToggleHeader}
+                >
+                    {headerRow ? "On" : "Off"}
+                </Button>
+            </div>
+            <div className="border">
+                <div
+                    className="grid"
+                    style={{gridTemplateColumns: `repeat(${tableCols}, 1fr)`}}
+                >
+                    {Array.from({length: tableRows * tableCols}).map((_, i) => {
+                        const r = Math.floor(i / tableCols);
+                        return (
+                            <div
+                                key={i}
+                                className={`h-4 border ${
+                                    headerRow && r === 0 ? "bg-gray-200" : "bg-white"
+                                }`}
+                            />
+                        );
+                    })}
+                </div>
+            </div>
             <Button
-                onClick={() => addTable?.(tableRows, tableCols, tableBorderColor)}
+                onClick={() =>
+                    addTable?.(tableRows, tableCols, tableBorderColor, headerRow)
+                }
                 className="w-full"
             >
-                <TableIcon className="mr-2 h-4 w-4"/> Add Table
+                <TableIcon className="mr-2 h-4 w-4" /> Add Table
             </Button>
         </div>
     );

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -15,7 +15,14 @@ import {
     addTriangle as fabricAddTriangle,
     enableScalingHandles,
 } from "@/lib/fabricShapes";
-import {createTable} from "@/lib/fabricTables";
+import {
+    createTable,
+    insertRow,
+    deleteRow,
+    insertColumn,
+    deleteColumn,
+    toggleHeaderRow,
+} from "@/lib/fabricTables";
 import {handleCoverElementDrop} from "@/lib/handleCoverElementDrop";
 import {Button} from "@/components/ui/button";
 import {EditorToolbar} from "@/components/cover-pages/EditorToolbar";
@@ -657,13 +664,67 @@ export default function CoverPageEditorPage() {
         setLayers([...canvas.getObjects()]);
         pushHistory();
     };
-    const addTable = (rows: number, cols: number, borderColor: string) => {
+    const addTable = (
+        rows: number,
+        cols: number,
+        borderColor: string,
+        header: boolean,
+    ) => {
         if (!canvas) return;
         const tbl = createTable(rows, cols, 80, 24, borderColor, 2);
         canvas.add(tbl);
+        if (header) {
+            toggleHeaderRow(tbl);
+        }
         canvas.setActiveObject(tbl);
         canvas.requestRenderAll();
         pushHistory();
+    };
+
+    const insertTableRow = () => {
+        if (!canvas || selectedObjects.length !== 1) return;
+        const obj = selectedObjects[0];
+        if ((obj as any).data?.type === "table") {
+            insertRow(obj as Group);
+            canvas.requestRenderAll();
+            pushHistory();
+        }
+    };
+    const deleteTableRow = () => {
+        if (!canvas || selectedObjects.length !== 1) return;
+        const obj = selectedObjects[0];
+        if ((obj as any).data?.type === "table") {
+            deleteRow(obj as Group);
+            canvas.requestRenderAll();
+            pushHistory();
+        }
+    };
+    const insertTableColumn = () => {
+        if (!canvas || selectedObjects.length !== 1) return;
+        const obj = selectedObjects[0];
+        if ((obj as any).data?.type === "table") {
+            insertColumn(obj as Group);
+            canvas.requestRenderAll();
+            pushHistory();
+        }
+    };
+    const deleteTableColumn = () => {
+        if (!canvas || selectedObjects.length !== 1) return;
+        const obj = selectedObjects[0];
+        if ((obj as any).data?.type === "table") {
+            deleteColumn(obj as Group);
+            canvas.requestRenderAll();
+            pushHistory();
+        }
+    };
+    const toggleTableHeader = () => {
+        if (!canvas || selectedObjects.length !== 1) return;
+        const obj = selectedObjects[0];
+        if ((obj as any).data?.type === "table") {
+            toggleHeaderRow(obj as Group);
+            canvas.requestRenderAll();
+            pushHistory();
+        }
     };
     const addIcon = (name: string) => handleAddIcon(name);
     const addClipart = (hex: string) => handleAddClipart(hex);
@@ -960,6 +1021,11 @@ export default function CoverPageEditorPage() {
                             addIcon={addIcon}
                             addClipart={addClipart}
                             addTable={addTable}
+                            insertTableRow={insertTableRow}
+                            deleteTableRow={deleteTableRow}
+                            insertTableColumn={insertTableColumn}
+                            deleteTableColumn={deleteTableColumn}
+                            toggleHeaderRow={toggleTableHeader}
                             templateOptions={Object.keys(TEMPLATES)}
                             palette={palette}
                             onApplyPalette={applyPalette}


### PR DESCRIPTION
## Summary
- add sidebar buttons for editing table rows, columns and header row
- support table updates with insert/delete methods and header toggle
- show table preview grid before insertion

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any / require import errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68acdd41a7648333a00777ca7d6e93ed