### PR TITLE
feat: add table keyboard interactions

### DIFF
--- a/src/hooks/useCanvasKeyboardShortcuts.ts
+++ b/src/hooks/useCanvasKeyboardShortcuts.ts
@@ -57,6 +57,7 @@ export function useCanvasKeyboardShortcuts({
         if (!canvas) return;
 
         const handler = async (e: KeyboardEvent) => {
+            if (e.defaultPrevented) return;
             // don’t hijack typing in inputs or while editing a Fabric Textbox
             if (isTypingTarget(e.target)) return;
 

--- a/src/hooks/useTableInteractions.ts
+++ b/src/hooks/useTableInteractions.ts
@@ -1,0 +1,178 @@
+import {useEffect, useRef} from "react";
+import {Group, Rect} from "fabric";
+import type {Canvas as FabricCanvas, FabricObject} from "fabric";
+import type {TableData} from "@/lib/fabricTables";
+
+type CellPos = {row: number; col: number};
+
+type Selection = {
+    table: Group;
+    start: CellPos;
+    end: CellPos;
+};
+
+type Args = {
+    canvas: FabricCanvas | null;
+};
+
+export function useTableInteractions({canvas}: Args) {
+    const selectionRef = useRef<Selection | null>(null);
+    const overlayRef = useRef<Rect | null>(null);
+
+    useEffect(() => {
+        if (!canvas) return;
+
+        const clear = () => {
+            const sel = selectionRef.current;
+            if (sel && overlayRef.current) {
+                sel.table.remove(overlayRef.current);
+                overlayRef.current = null;
+                sel.table.dirty = true;
+                sel.table.canvas?.requestRenderAll();
+            }
+            selectionRef.current = null;
+        };
+
+        const updateOverlay = () => {
+            const sel = selectionRef.current;
+            if (!sel) return;
+            const data = (sel.table as unknown as {data: TableData}).data;
+            const r1 = Math.min(sel.start.row, sel.end.row);
+            const r2 = Math.max(sel.start.row, sel.end.row);
+            const c1 = Math.min(sel.start.col, sel.end.col);
+            const c2 = Math.max(sel.start.col, sel.end.col);
+            const left = data.colWidths.slice(0, c1).reduce((a, b) => a + b, 0);
+            const top = data.rowHeights.slice(0, r1).reduce((a, b) => a + b, 0);
+            const width = data.colWidths.slice(c1, c2 + 1).reduce((a, b) => a + b, 0);
+            const height = data.rowHeights.slice(r1, r2 + 1).reduce((a, b) => a + b, 0);
+            if (!overlayRef.current) {
+                overlayRef.current = new Rect({
+                    left,
+                    top,
+                    width,
+                    height,
+                    fill: "rgba(33,150,243,0.1)",
+                    stroke: "#2196f3",
+                    strokeWidth: 1,
+                    selectable: false,
+                    evented: false,
+                });
+                sel.table.add(overlayRef.current);
+            } else {
+                overlayRef.current.set({left, top, width, height});
+            }
+            overlayRef.current.bringToFront?.();
+            sel.table.dirty = true;
+            sel.table.canvas?.requestRenderAll();
+        };
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+            const sel = selectionRef.current;
+            if (!sel) return;
+            const data = (sel.table as unknown as {data: TableData}).data;
+            let {row, col} = sel.end;
+            let handled = false;
+            switch (e.key) {
+                case "ArrowUp":
+                    if (row > 0) {row -= 1; handled = true;}
+                    break;
+                case "ArrowDown":
+                    if (row < data.rows - 1) {row += 1; handled = true;}
+                    break;
+                case "ArrowLeft":
+                    if (col > 0) {col -= 1; handled = true;}
+                    break;
+                case "ArrowRight":
+                    if (col < data.cols - 1) {col += 1; handled = true;}
+                    break;
+                case "Tab":
+                    handled = true;
+                    if (e.shiftKey) {
+                        if (col > 0) {
+                            col -= 1;
+                        } else if (row > 0) {
+                            row -= 1;
+                            col = data.cols - 1;
+                        }
+                    } else {
+                        if (col < data.cols - 1) {
+                            col += 1;
+                        } else if (row < data.rows - 1) {
+                            row += 1;
+                            col = 0;
+                        }
+                    }
+                    break;
+                default:
+                    break;
+            }
+            if (!handled) return;
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            if (e.shiftKey && e.key.startsWith("Arrow")) {
+                sel.end = {row, col};
+            } else if (e.shiftKey && e.key === "Tab") {
+                sel.end = {row, col};
+            } else {
+                sel.start = {row, col};
+                sel.end = {row, col};
+            }
+            updateOverlay();
+        };
+
+        const handleMouseDown = (opt: {target?: FabricObject | null; e: MouseEvent}) => {
+            const target = opt.target as (FabricObject & {name?: string; group?: Group | null; data?: Record<string, unknown>}) | undefined;
+            if (!target) {
+                clear();
+                return;
+            }
+            let cell: Group | null = null;
+            let table: Group | null = null;
+            if (target.name === "Cell") {
+                cell = target as unknown as Group;
+                table = (cell.group as Group) || null;
+            } else if (target.group && target.group.name === "Cell") {
+                cell = target.group as Group;
+                table = (cell.group as Group) || null;
+            } else if ((target.data as Record<string, unknown> | undefined)?.type === "table") {
+                table = target as unknown as Group;
+            } else {
+                clear();
+                return;
+            }
+            if (!table) {
+                clear();
+                return;
+            }
+            if (cell) {
+                const cellData = (cell as unknown as {data: {row: number; col: number}}).data;
+                const row = cellData.row;
+                const col = cellData.col;
+                if (opt.e.shiftKey && selectionRef.current?.table === table) {
+                    selectionRef.current!.end = {row, col};
+                } else {
+                    selectionRef.current = {table, start: {row, col}, end: {row, col}};
+                }
+            } else {
+                selectionRef.current = {table, start: {row: 0, col: 0}, end: {row: 0, col: 0}};
+            }
+            updateOverlay();
+        };
+
+        const handleSelectionCleared = () => {
+            clear();
+        };
+
+        canvas.on("mouse:down", handleMouseDown);
+        canvas.on("selection:cleared", handleSelectionCleared);
+        document.addEventListener("keydown", handleKeyDown);
+
+        return () => {
+            canvas.off("mouse:down", handleMouseDown);
+            canvas.off("selection:cleared", handleSelectionCleared);
+            document.removeEventListener("keydown", handleKeyDown);
+            clear();
+        };
+    }, [canvas]);
+}
+

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -33,6 +33,7 @@ import {CanvasWorkspace} from "@/components/cover-pages/CanvasWorkspace";
 import useCoverPages from "@/hooks/useCoverPages";
 import useImageLibrary from "@/hooks/useImageLibrary";
 import {useCanvasKeyboardShortcuts} from "@/hooks/useCanvasKeyboardShortcuts";
+import {useTableInteractions} from "@/hooks/useTableInteractions";
 import {KeyboardShortcutsModal} from "@/components/modals/KeyboardShortcutsModal";
 import {COLOR_PALETTES, type ColorPalette} from "@/constants/colorPalettes";
 import {PRESET_BG_COLORS, REPORT_TYPES, TEMPLATES} from "@/constants/coverPageEditor";
@@ -1083,6 +1084,8 @@ export default function CoverPageEditorPage() {
     };
 
     const selectedObject = selectedObjects[0] || null;
+
+    useTableInteractions({canvas});
 
     useCanvasKeyboardShortcuts({
         canvas,


### PR DESCRIPTION
## Summary
- enable keyboard navigation and range selection for table cells
- avoid conflicts with canvas shortcuts during table navigation
- wire table interactions into cover page editor

## Testing
- `npm run lint` *(fails: Unexpected any / require warnings)*


------
https://chatgpt.com/codex/tasks/task_e_68ace291744883339830b133db2c7a06