### PR TITLE
feat: make table handles independent

### DIFF
--- a/src/lib/fabricTables.ts
+++ b/src/lib/fabricTables.ts
@@ -176,6 +176,7 @@ function attachResizeHandles(table: Group) {
             data.colWidths[c] = next;
             layoutTable(table);
         });
+        handle.set({absolutePositioned: true, excludeFromExport: true});
         handles.push(handle);
         table.add(handle);
     }
@@ -208,10 +209,12 @@ function attachResizeHandles(table: Group) {
             data.rowHeights[r] = next;
             layoutTable(table);
         });
+        handle.set({absolutePositioned: true, excludeFromExport: true});
         handles.push(handle);
         table.add(handle);
     }
     (table as any).handles = handles;
+    table.setCoords();
 }
 
 function updateHandles(table: Group) {
@@ -231,6 +234,7 @@ function updateHandles(table: Group) {
         }
         h.setCoords();
     });
+    table.setCoords();
     table.dirty = true;
     table.canvas?.requestRenderAll();
 }


### PR DESCRIPTION
## Summary
- ensure table resize handles are absolute and excluded from exports
- refresh table bounds when handles change

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68ace5d5502c8333b41c4e3339b65de6