### PR TITLE
Activate table on click

### DIFF
--- a/src/hooks/useTableInteractions.ts
+++ b/src/hooks/useTableInteractions.ts
@@ -162,6 +162,9 @@ export function useTableInteractions({canvas}: Args) {
             } else {
                 selectionRef.current = {table, start: {row: 0, col: 0}, end: {row: 0, col: 0}};
             }
+            table.bringToFront?.();
+            canvas.setActiveObject(table);
+            canvas.requestRenderAll();
             selectionRef.current.table.on("moving", updateOverlay);
             updateOverlay();
         };


### PR DESCRIPTION
## Summary
- ensure table becomes active when clicked so selection controls are visible
- trigger canvas render and bring table to front for accurate z-order

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, require import, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68acf10a91308333a330cdc9b26b776c