### PR TITLE
refactor: normalize table interactions

### DIFF
--- a/src/components/cover-pages/PropertiesPanel.tsx
+++ b/src/components/cover-pages/PropertiesPanel.tsx
@@ -83,23 +83,14 @@ export function PropertiesPanel({
   const hasStroke = !multipleSelection && selectedObject && "stroke" in selectedObject;
   const hasSkewX = !multipleSelection && selectedObject && "skewX" in selectedObject;
   const hasSkewY = !multipleSelection && selectedObject && "skewY" in selectedObject;
-  const defaultSection = multipleSelection
-    ? "layers"
-    : isTable
-    ? "table"
-    : hasPosition
-    ? "position"
-    : isTextObject
-    ? "text"
-    : hasFill || hasStroke
-    ? "appearance"
-    : "layers";
 
-  const [value, setValue] = React.useState<string>(defaultSection);
+  const [value, setValue] = React.useState<string>("layers");
 
   React.useEffect(() => {
-    setValue(defaultSection);
-  }, [selectedObject, selectedObjects]);
+    if (!multipleSelection && isTable) {
+      setValue("table");
+    }
+  }, [isTable, multipleSelection, selectedObject, selectedObjects]);
 
   return (
     <div className="w-80 h-full border-l bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">

--- a/src/hooks/useTableInteractions.ts
+++ b/src/hooks/useTableInteractions.ts
@@ -168,6 +168,7 @@ export function useTableInteractions({canvas}: Args) {
             }
             table.bringToFront?.();
             canvas.setActiveObject(table);
+            table.setCoords();
             canvas.requestRenderAll();
             selectionRef.current.table.on("moving", updateOverlay);
             updateOverlay();

--- a/src/lib/fabricTables.ts
+++ b/src/lib/fabricTables.ts
@@ -75,6 +75,7 @@ export function createTable(
     (group as any).data = data;
     enableScalingHandles(group);
     layoutTable(group);
+    group.setCoords();
     return group;
 }
 
@@ -187,8 +188,14 @@ function attachResizeHandles(table: Group) {
     }
     const moveHandler = (table as any)._tableMoveHandler as (() => void) | undefined;
     if (moveHandler) table.off("moving", moveHandler);
+    const deselectHandler = (table as any)._tableDeselectHandler as (() => void) | undefined;
+    if (deselectHandler) {
+        canvas?.off("selection:cleared", deselectHandler);
+        canvas?.off("selection:updated", deselectHandler);
+    }
     if (!canvas || canvas.getActiveObject() !== table) {
         (table as any)._tableMoveHandler = undefined;
+        (table as any)._tableDeselectHandler = undefined;
         (table as any).tableHandles = undefined;
         canvas?.requestRenderAll();
         return;
@@ -271,6 +278,10 @@ function attachResizeHandles(table: Group) {
     const newMoveHandler = () => updateHandles(table);
     (table as any)._tableMoveHandler = newMoveHandler;
     table.on("moving", newMoveHandler);
+    const newDeselectHandler = () => updateHandles(table);
+    (table as any)._tableDeselectHandler = newDeselectHandler;
+    canvas.on("selection:cleared", newDeselectHandler);
+    canvas.on("selection:updated", newDeselectHandler);
     table.setCoords();
 }
 


### PR DESCRIPTION
## Summary
- normalize table group coordinates and resize handles
- track active tables to show selection overlays correctly
- reset properties panel accordion when a table is selected

## Testing
- `npm run lint` *(fails: Unexpected any, forbidden require imports)*

------
https://chatgpt.com/codex/tasks/task_e_68acf59a33548333b1b719afa894d46b