### PR TITLE
feat: support report cover images

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ The app supports fully customizable cover pages for reports.
 After a cover page is assigned, generate a report PDF from the report preview. The
 selected cover page will appear at the beginning of the PDF.
 
+### Cover image merge field
+
+Reports now support a dedicated cover image. Upload an image in the report editor and it will be stored on the report as `coverImage`. In the cover page editor, drag the **Cover Image** field into the canvas to place a resizable placeholder. During preview and PDF generation this placeholder is replaced with the report's cover image.
+
 ## Image Proxy
 
 When adding external images, the app routes the request through `/api/image-proxy`.

--- a/src/components/cover-pages/editor-sidebar/FormFieldsSection.tsx
+++ b/src/components/cover-pages/editor-sidebar/FormFieldsSection.tsx
@@ -1,6 +1,6 @@
 import {Button} from "@/components/ui/button.tsx";
 import {Accordion, AccordionContent, AccordionItem, AccordionTrigger} from "@/components/ui/accordion.tsx";
-import {contactFields, inspectorFields, organizationFields} from "@/constants/coverPageFields.ts";
+import {contactFields, inspectorFields, organizationFields, imageFields} from "@/constants/coverPageFields.ts";
 
 export function FormFieldsSection({
                                       onAddPlaceholder,
@@ -55,6 +55,29 @@ export function FormFieldsSection({
                                 variant="outline"
                                 className="w-full justify-start"
                                 onClick={() => onAddPlaceholder(field.token)}
+                            >
+                                {field.label}
+                            </Button>
+                        ))}
+                    </div>
+                </AccordionContent>
+            </AccordionItem>
+
+            <AccordionItem value="images">
+                <AccordionTrigger>Image Fields</AccordionTrigger>
+                <AccordionContent className="data-[state=open]:animate-none data-[state=open]:h-auto">
+                    <div className="flex flex-col space-y-2">
+                        {imageFields.map((field) => (
+                            <Button
+                                key={field.token}
+                                variant="outline"
+                                className="w-full justify-start"
+                                draggable
+                                onDragStart={(e) => {
+                                    const payload = JSON.stringify({ type: "image-field" });
+                                    e.dataTransfer?.setData("application/x-cover-element", payload);
+                                    e.dataTransfer!.effectAllowed = "copy";
+                                }}
                             >
                                 {field.label}
                             </Button>

--- a/src/constants/coverPageFields.ts
+++ b/src/constants/coverPageFields.ts
@@ -22,3 +22,7 @@ export const contactFields: MergeField[] = [
   { label: "Client Email", token: "{{contact.email}}" },
   { label: "Client Phone", token: "{{contact.phone}}" },
 ];
+
+export const imageFields: MergeField[] = [
+  { label: "Cover Image", token: "{{report.cover_image}}" },
+];

--- a/src/lib/handleCoverElementDrop.ts
+++ b/src/lib/handleCoverElementDrop.ts
@@ -1,4 +1,4 @@
-import { Canvas as FabricCanvas } from "fabric";
+import { Canvas as FabricCanvas, Image as FabricImage } from "fabric";
 import { ColorPalette } from "@/constants/colorPalettes";
 import {
     addRect as fabricAddRect,
@@ -82,6 +82,18 @@ export function handleCoverElementDrop(
                 console.log('Image added', { url: data.url, x, y });
                 pushHistory?.();
             }
+            break;
+        case "image-field":
+            const transparentPng =
+                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAoMBgD1Q9FAAAAAASUVORK5CYII=";
+            FabricImage.fromURL(transparentPng, (img) => {
+                img.set({ left: x, top: y, mergeField: "report.coverImage" } as any);
+                img.scaleToWidth(200);
+                img.scaleToHeight(200);
+                canvas.add(img);
+                canvas.setActiveObject(img);
+                pushHistory?.();
+            });
             break;
         case "icon":
             if (data?.name) handlers.addIcon?.(data.name, x, y);

--- a/src/pages/ReportPreview.tsx
+++ b/src/pages/ReportPreview.tsx
@@ -20,6 +20,7 @@ import "../styles/pdf.css";
 import {fillWindMitigationPDF} from "@/utils/fillWindMitigationPDF";
 import {coverPagesApi} from "@/integrations/supabase/coverPagesApi";
 import { Canvas as FabricCanvas } from "fabric";
+import { replaceCoverImages } from "@/utils/replaceCoverImages";
 
 
 function ButtonBar({id}: { id: string }) {
@@ -226,7 +227,8 @@ const ReportPreview: React.FC = () => {
                     if (cp && cp.design_json) {
                         const canvasEl = document.createElement("canvas");
                         coverCanvas = new FabricCanvas(canvasEl, { width: 800, height: 1000 });
-                        coverCanvas.loadFromJSON(cp.design_json as any, () => {
+                        const replaced = await replaceCoverImages(cp.design_json, report);
+                        coverCanvas.loadFromJSON(replaced as any, () => {
                             coverCanvas?.renderAll();
                             const url = coverCanvas?.toDataURL({ format: "png", multiplier: 1 });
                             if (!cancelled && url) {

--- a/src/utils/fillWindMitigationPDF.ts
+++ b/src/utils/fillWindMitigationPDF.ts
@@ -9,6 +9,8 @@ import {getSignedUrlFromSupabaseUrl, isSupabaseUrl} from "@/integrations/supabas
 import {coverPagesApi} from "@/integrations/supabase/coverPagesApi";
 import {getMyOrganization, getMyProfile} from "@/integrations/supabase/organizationsApi";
 import {replaceMergeFields} from "@/utils/replaceMergeFields";
+import { replaceCoverImages } from "@/utils/replaceCoverImages";
+import { Canvas as FabricCanvas } from "fabric";
 
 // Keys that are handled manually elsewhere in the code (e.g. custom logic
 // for building code options) and should be ignored when reporting unmapped
@@ -479,22 +481,16 @@ export async function fillWindMitigationPDF(report: any): Promise<Blob> {
     }
 
     // fetch assigned cover page
-    let assignedCoverPage: {title: string; text?: string; color: string; imageUrl?: string | null} | null = null;
+    let assignedCoverPage: any | null = null;
     try {
         const {data: {user}} = await supabase.auth.getUser();
         if (user) {
             const cp = await coverPagesApi.getAssignedCoverPage(user.id, report.reportType);
             if (cp) {
-                let imageUrl = cp.image_url;
-                if (imageUrl && isSupabaseUrl(imageUrl)) {
-                    imageUrl = await getSignedUrlFromSupabaseUrl(imageUrl);
+                if (cp.image_url && isSupabaseUrl(cp.image_url)) {
+                    cp.image_url = await getSignedUrlFromSupabaseUrl(cp.image_url);
                 }
-                assignedCoverPage = {
-                    title: cp.name,
-                    text: cp.text_content as string | undefined,
-                    color: cp.color_palette_key || "#FFFFFF",
-                    imageUrl,
-                };
+                assignedCoverPage = cp;
             }
         }
     } catch (err) {
@@ -504,54 +500,73 @@ export async function fillWindMitigationPDF(report: any): Promise<Blob> {
     if (assignedCoverPage) {
         const pages = pdfDoc.getPages();
         const {width, height} = pages[0].getSize();
-        const coverPage = pdfDoc.insertPage(0, [width, height]);
-        const {r, g, b} = hexToRgb(assignedCoverPage.color);
-        coverPage.drawRectangle({x: 0, y: height / 2, width, height: height / 2, color: rgb(r, g, b)});
 
-        if (assignedCoverPage.imageUrl) {
-            try {
-                const imgBytes = await fetch(assignedCoverPage.imageUrl).then((res) => res.arrayBuffer());
-                const image = assignedCoverPage.imageUrl.toLowerCase().endsWith(".png")
-                    ? await pdfDoc.embedPng(imgBytes)
-                    : await pdfDoc.embedJpg(imgBytes);
-                const imgWidth = Math.min(image.width, width - 100);
-                const imgHeight = (imgWidth / image.width) * image.height;
-                coverPage.drawImage(image, {
-                    x: (width - imgWidth) / 2,
-                    y: height / 2 + (height / 2 - imgHeight) / 2,
-                    width: imgWidth,
-                    height: imgHeight,
+        if (assignedCoverPage.design_json) {
+            const canvasEl = document.createElement("canvas");
+            const fabricCanvas = new FabricCanvas(canvasEl, {width, height});
+            const replaced = await replaceCoverImages(assignedCoverPage.design_json, report);
+            await new Promise<void>((resolve) => {
+                fabricCanvas.loadFromJSON(replaced as any, () => {
+                    fabricCanvas.renderAll();
+                    resolve();
                 });
-            } catch (err) {
-                console.error("Error embedding cover image", err);
-            }
-        }
+            });
+            const dataUrl = fabricCanvas.toDataURL({format: "png", multiplier: 1});
+            fabricCanvas.dispose();
+            const imgBytes = await fetch(dataUrl).then(res => res.arrayBuffer());
+            const image = await pdfDoc.embedPng(imgBytes);
+            const coverPage = pdfDoc.insertPage(0, [width, height]);
+            coverPage.drawImage(image, {x: 0, y: 0, width, height});
+        } else {
+            const coverPage = pdfDoc.insertPage(0, [width, height]);
+            const {r, g, b} = hexToRgb(assignedCoverPage.color_palette_key || "#FFFFFF");
+            coverPage.drawRectangle({x: 0, y: height / 2, width, height: height / 2, color: rgb(r, g, b)});
 
-        const titleFont = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
-        const bodyFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
-        const replacedTitle = replaceMergeFields(assignedCoverPage.title, {
-            organization,
-            inspector,
-            report,
-        });
-        coverPage.drawText(replacedTitle, {
-            x: 50,
-            y: height / 2 - 80,
-            size: 24,
-            font: titleFont,
-        });
-        if (assignedCoverPage.text) {
-            const replacedText = replaceMergeFields(assignedCoverPage.text, {
+            if (assignedCoverPage.image_url) {
+                try {
+                    const imgBytes = await fetch(assignedCoverPage.image_url).then((res) => res.arrayBuffer());
+                    const image = assignedCoverPage.image_url.toLowerCase().endsWith(".png")
+                        ? await pdfDoc.embedPng(imgBytes)
+                        : await pdfDoc.embedJpg(imgBytes);
+                    const imgWidth = Math.min(image.width, width - 100);
+                    const imgHeight = (imgWidth / image.width) * image.height;
+                    coverPage.drawImage(image, {
+                        x: (width - imgWidth) / 2,
+                        y: height / 2 + (height / 2 - imgHeight) / 2,
+                        width: imgWidth,
+                        height: imgHeight,
+                    });
+                } catch (err) {
+                    console.error("Error embedding cover image", err);
+                }
+            }
+
+            const titleFont = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+            const bodyFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
+            const replacedTitle = replaceMergeFields(assignedCoverPage.name, {
                 organization,
                 inspector,
                 report,
             });
-            coverPage.drawText(replacedText, {
+            coverPage.drawText(replacedTitle, {
                 x: 50,
-                y: height / 2 - 110,
-                size: 12,
-                font: bodyFont,
+                y: height / 2 - 80,
+                size: 24,
+                font: titleFont,
             });
+            if (assignedCoverPage.text_content) {
+                const replacedText = replaceMergeFields(assignedCoverPage.text_content as string, {
+                    organization,
+                    inspector,
+                    report,
+                });
+                coverPage.drawText(replacedText, {
+                    x: 50,
+                    y: height / 2 - 110,
+                    size: 12,
+                    font: bodyFont,
+                });
+            }
         }
     }
 

--- a/src/utils/replaceCoverImages.ts
+++ b/src/utils/replaceCoverImages.ts
@@ -1,0 +1,32 @@
+import { isSupabaseUrl, getSignedUrlFromSupabaseUrl } from "@/integrations/supabase/storage";
+import type { Report } from "@/lib/reportSchemas";
+
+interface FabricObject extends Record<string, unknown> {
+  type?: string;
+  mergeField?: string;
+  src?: string;
+  objects?: unknown;
+}
+
+export async function replaceCoverImages(json: unknown, report: Report) {
+  if (!json || !report?.coverImage) return json;
+  const url = isSupabaseUrl(report.coverImage)
+    ? await getSignedUrlFromSupabaseUrl(report.coverImage)
+    : report.coverImage;
+  const clone: FabricObject = JSON.parse(JSON.stringify(json));
+  const traverse = (obj: unknown): void => {
+    if (Array.isArray(obj)) {
+      obj.forEach(traverse);
+      return;
+    }
+    if (obj && typeof obj === "object") {
+      const o = obj as FabricObject;
+      if (o.type === "image" && o.mergeField === "report.coverImage") {
+        o.src = url;
+      }
+      if (o.objects) traverse(o.objects);
+    }
+  };
+  if (clone.objects) traverse(clone.objects);
+  return clone;
+}


### PR DESCRIPTION
## Summary
- allow reports to upload and persist a cover image
- add draggable "Cover Image" merge field for cover pages
- render report cover images in preview and PDF outputs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acfd6443888333b032bdce48abba45