### PR TITLE
chore: remove cover page table debug

### DIFF
--- a/src/components/cover-pages/editor-sidebar/SettingsSection.tsx
+++ b/src/components/cover-pages/editor-sidebar/SettingsSection.tsx
@@ -40,7 +40,6 @@ export function SettingsSection({
         console.log("reportTypes prop (raw):", reportTypes);
         console.log("selected (normalized):", selected);
         console.log("reportTypeOptions:", reportTypeOptions);
-        console.table(rows);
         console.groupEnd();
     });
 


### PR DESCRIPTION
## Summary
- remove leftover console.table debug call from cover page settings section

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: see errors)

------
https://chatgpt.com/codex/tasks/task_e_68adcbd493048333ac9dd75f15eecbec