### PR TITLE
Fix canvas centering and default zoom in cover page editor

### DIFF
--- a/src/components/cover-pages/CanvasWorkspace.tsx
+++ b/src/components/cover-pages/CanvasWorkspace.tsx
@@ -223,16 +223,18 @@ export function CanvasWorkspace({
                             {/* Corner block */}
                             <div
                                 className="absolute top-0 left-0 w-8 h-8 bg-gray-200 border-r border-b border-gray-300 z-30 pointer-events-none"
-                                style={{
-                                    transform: `scale(${zoom})`,
-                                    transformOrigin: "top left",
-                                }}
                             />
                         </>
                     )}
 
                     {/* Canvas Container */}
-                    <div className="relative inline-block">
+                    <div
+                        className="relative inline-block"
+                        style={{
+                            width: CANVAS_WIDTH * zoom,
+                            height: CANVAS_HEIGHT * zoom,
+                        }}
+                    >
                         <div
                             className="relative bg-white shadow-lg"
                             style={{

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -44,7 +44,7 @@ export default function CoverPageEditorPage() {
     const [canvas, setCanvas] = useState<FabricCanvas | null>(null);
     const [selectedObjects, setSelectedObjects] = useState<FabricObject[]>([]);
     const [layers, setLayers] = useState<FabricObject[]>([]);
-    const [zoom, setZoom] = useState(1);
+    const [zoom, setZoom] = useState(0.5);
     const [showGrid, setShowGrid] = useState(true);
     const [showRulers, setShowRulers] = useState(true);
     const [snapEnabled, setSnapEnabled] = useState(false);


### PR DESCRIPTION
## Summary
- ensure canvas container scales dimensions with zoom to remain centered
- keep ruler corner block size constant to avoid disproportionate scaling
- default editor zoom to 50%

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 234 problems (212 errors, 22 warnings))*


------
https://chatgpt.com/codex/tasks/task_e_68add1eae8fc83338092590c558cc8be