### PR TITLE
feat: show cover image placeholder

### DIFF
--- a/src/lib/handleCoverElementDrop.ts
+++ b/src/lib/handleCoverElementDrop.ts
@@ -87,7 +87,15 @@ export function handleCoverElementDrop(
             const transparentPng =
                 "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAoMBgD1Q9FAAAAAASUVORK5CYII=";
             FabricImage.fromURL(transparentPng, (img) => {
-                img.set({ left: x, top: y, mergeField: "report.coverImage" } as any);
+                img.set({
+                    left: x,
+                    top: y,
+                    mergeField: "report.coverImage",
+                    stroke: "#888",
+                    strokeWidth: 2,
+                    strokeDashArray: [6, 4],
+                    backgroundColor: "#f3f4f6",
+                } as any);
                 img.scaleToWidth(200);
                 img.scaleToHeight(200);
                 canvas.add(img);

--- a/src/utils/replaceCoverImages.ts
+++ b/src/utils/replaceCoverImages.ts
@@ -6,6 +6,10 @@ interface FabricObject extends Record<string, unknown> {
   mergeField?: string;
   src?: string;
   objects?: unknown;
+  stroke?: string;
+  strokeWidth?: number;
+  strokeDashArray?: number[];
+  backgroundColor?: string;
 }
 
 export async function replaceCoverImages(json: unknown, report: Report) {
@@ -23,6 +27,10 @@ export async function replaceCoverImages(json: unknown, report: Report) {
       const o = obj as FabricObject;
       if (o.type === "image" && o.mergeField === "report.coverImage") {
         o.src = url;
+        o.stroke = undefined;
+        o.strokeWidth = undefined;
+        o.strokeDashArray = undefined;
+        o.backgroundColor = undefined;
       }
       if (o.objects) traverse(o.objects);
     }


### PR DESCRIPTION
## Summary
- add a visible dashed placeholder when dropping the Cover Image field on the cover page canvas
- strip placeholder styling once the cover image is merged

## Testing
- `npm run lint` *(fails: Unexpected any, @typescript-eslint/no-explicit-any, and @typescript-eslint/no-require-imports)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ade17f1ecc8333849c1ba2615f1ec5