### PR TITLE
Render placeholder image field after drop

### DIFF
--- a/src/lib/handleCoverElementDrop.ts
+++ b/src/lib/handleCoverElementDrop.ts
@@ -83,7 +83,7 @@ export function handleCoverElementDrop(
                 pushHistory?.();
             }
             break;
-        case "image-field":
+        case "image-field": {
             const transparentPng =
                 "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAoMBgD1Q9FAAAAAASUVORK5CYII=";
             FabricImage.fromURL(transparentPng, (img) => {
@@ -95,14 +95,16 @@ export function handleCoverElementDrop(
                     strokeWidth: 2,
                     strokeDashArray: [6, 4],
                     backgroundColor: "#f3f4f6",
-                } as any);
+                } as unknown as Partial<FabricImage> & { mergeField: string });
                 img.scaleToWidth(200);
                 img.scaleToHeight(200);
                 canvas.add(img);
                 canvas.setActiveObject(img);
+                canvas.requestRenderAll();
                 pushHistory?.();
             });
             break;
+        }
         case "merge-field":
             if (data?.label && data?.token) {
                 fabricAddText(canvas, palette, `${data.label}: ${data.token}`, x, y);


### PR DESCRIPTION
## Summary
- Render image field placeholder immediately when dropped on canvas
- Conform to lint rules by wrapping switch case and avoiding `any`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 234 problems)*
- `npx eslint src/lib/handleCoverElementDrop.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ade3da02cc83339a359744ea124a6f