### PR TITLE
Fix drag payloads for icons, clipart, and image field

### DIFF
--- a/src/components/cover-pages/editor-sidebar/FormFieldsSection.tsx
+++ b/src/components/cover-pages/editor-sidebar/FormFieldsSection.tsx
@@ -92,7 +92,7 @@ export function FormFieldsSection({
                                 className="w-full justify-start"
                                 draggable
                                 onDragStart={(e) => {
-                                    const payload = JSON.stringify({ type: "image-field" });
+                                    const payload = JSON.stringify({ type: "image-field", data: { token: field.token } });
                                     e.dataTransfer?.setData("application/x-cover-element", payload);
                                     e.dataTransfer!.effectAllowed = "copy";
                                 }}

--- a/src/components/cover-pages/editor-sidebar/GraphicsSection.tsx
+++ b/src/components/cover-pages/editor-sidebar/GraphicsSection.tsx
@@ -201,10 +201,10 @@ export function GraphicsSection({
                                 <button
                                     key={name}
                                     type="button"
-                                    className="p-1 border rounded hover:bg-accent flex items-center justify-center"
-                                    draggable
-                                    onDragStart={(e) => {
-                                        const payload = JSON.stringify({type: "icon", name});
+                                className="p-1 border rounded hover:bg-accent flex items-center justify-center"
+                                draggable
+                                onDragStart={(e) => {
+                                        const payload = JSON.stringify({type: "icon", data: {name}});
                                         e.dataTransfer?.setData("application/x-cover-element", payload);
                                         e.dataTransfer!.effectAllowed = "copy";
                                     }}
@@ -238,7 +238,7 @@ export function GraphicsSection({
                                 className="p-1 border rounded hover:bg-accent flex items-center justify-center"
                                 draggable
                                 onDragStart={(e) => {
-                                    const payload = JSON.stringify({type: "clipart", hex: c.hexcode});
+                                    const payload = JSON.stringify({type: "clipart", data: {hex: c.hexcode}});
                                     e.dataTransfer?.setData("application/x-cover-element", payload);
                                     e.dataTransfer!.effectAllowed = "copy";
                                 }}

--- a/src/lib/handleCoverElementDrop.ts
+++ b/src/lib/handleCoverElementDrop.ts
@@ -86,11 +86,12 @@ export function handleCoverElementDrop(
         case "image-field": {
             const transparentPng =
                 "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAoMBgD1Q9FAAAAAASUVORK5CYII=";
+            const mergeField = data?.token ? data.token.replace(/[{}]/g, "") : "report.coverImage";
             FabricImage.fromURL(transparentPng, (img) => {
                 img.set({
                     left: x,
                     top: y,
-                    mergeField: "report.coverImage",
+                    mergeField,
                     stroke: "#888",
                     strokeWidth: 2,
                     strokeDashArray: [6, 4],


### PR DESCRIPTION
## Summary
- Include data payload when dragging icons and clipart so canvas drop handler receives required info
- Provide image field token in drag payload and apply it when adding image placeholders

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ade6aeeb4083339bf20b300de04b77