### PR TITLE
Handle cover page image fields and icon color

### DIFF
--- a/src/constants/coverPageFields.ts
+++ b/src/constants/coverPageFields.ts
@@ -25,4 +25,5 @@ export const contactFields: MergeField[] = [
 
 export const imageFields: MergeField[] = [
   { label: "Cover Image", token: "{{report.cover_image}}" },
+  { label: "Company Logo", token: "{{organization.logo_url}}" },
 ];

--- a/src/lib/fabricShapes.ts
+++ b/src/lib/fabricShapes.ts
@@ -230,8 +230,14 @@ export async function addLucideIconByName(canvas: FabricCanvas, name: string, st
         const obj = Array.isArray(objects)
             ? FabricUtil.groupSVGElements(objects, options)
             : (objects as FabricObject);
-
-        obj.set({left: x, top: y, stroke, fill: "none", visible: true, name});
+        obj.set({left: x, top: y, visible: true, name});
+        if (obj instanceof Group) {
+            obj.getObjects().forEach((child) => {
+                (child as any).set({ stroke, fill: "none" });
+            });
+        } else {
+            (obj as any).set({ stroke, fill: "none" });
+        }
         enableScalingHandles(obj);
         canvas.add(obj);
         canvas.setActiveObject(obj);

--- a/src/lib/handleCoverElementDrop.ts
+++ b/src/lib/handleCoverElementDrop.ts
@@ -86,7 +86,11 @@ export function handleCoverElementDrop(
         case "image-field": {
             const transparentPng =
                 "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAoMBgD1Q9FAAAAAASUVORK5CYII=";
-            const mergeField = data?.token ? data.token.replace(/[{}]/g, "") : "report.coverImage";
+            const mergeField = data?.token
+                ? data.token
+                      .replace(/[{}]/g, "")
+                      .replace(/_([a-z])/g, (_, c) => c.toUpperCase())
+                : "report.coverImage";
             FabricImage.fromURL(transparentPng, (img) => {
                 img.set({
                     left: x,

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -717,6 +717,11 @@ export default function CoverPageEditorPage() {
         if (!canvas || selectedObjects.length === 0) return;
 
         selectedObjects.forEach((obj) => {
+            if (obj instanceof Group) {
+                obj.getObjects().forEach((child) => {
+                    (child as any).set(property, value);
+                });
+            }
             obj.set(property as any, value);
             obj.setCoords();
         });

--- a/src/pages/ReportPreview.tsx
+++ b/src/pages/ReportPreview.tsx
@@ -21,6 +21,7 @@ import {fillWindMitigationPDF} from "@/utils/fillWindMitigationPDF";
 import {coverPagesApi} from "@/integrations/supabase/coverPagesApi";
 import { Canvas as FabricCanvas } from "fabric";
 import { replaceCoverImages } from "@/utils/replaceCoverImages";
+import { getMyOrganization } from "@/integrations/supabase/organizationsApi";
 
 
 function ButtonBar({id}: { id: string }) {
@@ -223,11 +224,12 @@ const ReportPreview: React.FC = () => {
             // assigned cover page
             if (user) {
                 try {
+                    const organization = await getMyOrganization();
                     const cp = await coverPagesApi.getAssignedCoverPage(user.id, report.reportType);
                     if (cp && cp.design_json) {
                         const canvasEl = document.createElement("canvas");
                         coverCanvas = new FabricCanvas(canvasEl, { width: 800, height: 1000 });
-                        const replaced = await replaceCoverImages(cp.design_json, report);
+                        const replaced = await replaceCoverImages(cp.design_json, report, organization);
                         coverCanvas.loadFromJSON(replaced as any, () => {
                             coverCanvas?.renderAll();
                             const url = coverCanvas?.toDataURL({ format: "png", multiplier: 1 });

--- a/src/utils/fillWindMitigationPDF.ts
+++ b/src/utils/fillWindMitigationPDF.ts
@@ -504,7 +504,7 @@ export async function fillWindMitigationPDF(report: any): Promise<Blob> {
         if (assignedCoverPage.design_json) {
             const canvasEl = document.createElement("canvas");
             const fabricCanvas = new FabricCanvas(canvasEl, {width, height});
-            const replaced = await replaceCoverImages(assignedCoverPage.design_json, report);
+            const replaced = await replaceCoverImages(assignedCoverPage.design_json, report, organization);
             await new Promise<void>((resolve) => {
                 fabricCanvas.loadFromJSON(replaced as any, () => {
                     fabricCanvas.renderAll();


### PR DESCRIPTION
## Summary
- Convert image field tokens to camelCase and add Organization logo option for cover pages
- Replace logo and cover image placeholders when rendering cover pages and PDFs
- Allow updating icon colors by propagating stroke/fill to grouped paths

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, require import)*

------
https://chatgpt.com/codex/tasks/task_e_68adeaec23788333b17d0ca9595c4fa3