### PR TITLE
Use merge field placeholders for cover image and logo

### DIFF
--- a/src/components/cover-pages/EditorSidebar.tsx
+++ b/src/components/cover-pages/EditorSidebar.tsx
@@ -62,7 +62,6 @@ export interface EditorSidebarProps {
 
     // FORM FIELDS
     onAddPlaceholder: (label: string, token: string) => void;
-    onAddImageField: (token: string) => void;
 
     // SHORTCUTS
     onShowShortcuts?: () => void;
@@ -77,7 +76,7 @@ export function EditorSidebar(props: EditorSidebarProps) {
         addRect, addCircle, addStar, addTriangle, addPolygonShape, addArrow, addBidirectionalArrow, addIcon, addClipart,
         templateOptions, palette, onApplyPalette,
         bgColor, presetBgColors, updateBgColor,
-        onAddPlaceholder, onAddImageField,
+        onAddPlaceholder,
         onShowShortcuts,
     } = props;
 
@@ -185,7 +184,7 @@ export function EditorSidebar(props: EditorSidebarProps) {
                     icon={<List className="h-4 w-4"/>}
                     title="Form Fields"
                 >
-                    <FormFieldsSection onAddPlaceholder={onAddPlaceholder} onAddImageField={onAddImageField}/>
+                    <FormFieldsSection onAddPlaceholder={onAddPlaceholder}/>
                 </SidebarCard>
             </div>
 

--- a/src/components/cover-pages/editor-sidebar/FormFieldsSection.tsx
+++ b/src/components/cover-pages/editor-sidebar/FormFieldsSection.tsx
@@ -1,39 +1,14 @@
 import {Button} from "@/components/ui/button.tsx";
 import {Accordion, AccordionContent, AccordionItem, AccordionTrigger} from "@/components/ui/accordion.tsx";
-import {contactFields, inspectorFields, organizationFields, reportFields, imageFields} from "@/constants/coverPageFields.ts";
+import {contactFields, inspectorFields, organizationFields, reportFields} from "@/constants/coverPageFields.ts";
 
 export function FormFieldsSection({
                                       onAddPlaceholder,
-                                      onAddImageField,
                                   }: {
     onAddPlaceholder: (label: string, token: string) => void;
-    onAddImageField: (token: string) => void;
 }) {
     return (
         <Accordion type="single" collapsible defaultValue="organization" className="w-full">
-            <AccordionItem value="images">
-                <AccordionTrigger>Image Fields</AccordionTrigger>
-                <AccordionContent className="data-[state=open]:animate-none data-[state=open]:h-auto">
-                    <div className="flex flex-col space-y-2">
-                        {imageFields.map((field) => (
-                            <Button
-                                key={field.token}
-                                variant="outline"
-                                className="w-full justify-start"
-                                draggable
-                                onDragStart={(e) => {
-                                    const payload = JSON.stringify({ type: "image-field", data: { token: field.token } });
-                                    e.dataTransfer?.setData("application/x-cover-element", payload);
-                                    e.dataTransfer!.effectAllowed = "copy";
-                                }}
-                                onClick={() => onAddImageField(field.token)}
-                            >
-                                {field.label}
-                            </Button>
-                        ))}
-                    </div>
-                </AccordionContent>
-            </AccordionItem>
             <AccordionItem value="organization">
                 <AccordionTrigger>Organization Details</AccordionTrigger>
                 <AccordionContent className="data-[state=open]:animate-none data-[state=open]:h-auto">

--- a/src/constants/coverPageFields.ts
+++ b/src/constants/coverPageFields.ts
@@ -8,6 +8,7 @@ export const organizationFields: MergeField[] = [
   { label: "Organization Address", token: "{{organization.address}}" },
   { label: "Organization Phone", token: "{{organization.phone}}" },
   { label: "Organization Email", token: "{{organization.email}}" },
+  { label: "Organization Logo", token: "{{organizational_logo}}" },
 ];
 
 export const inspectorFields: MergeField[] = [
@@ -26,9 +27,5 @@ export const contactFields: MergeField[] = [
 export const reportFields: MergeField[] = [
   { label: "Inspection Date", token: "{{report.inspection_date}}" },
   { label: "Weather Conditions", token: "{{report.weather_conditions}}" },
-];
-
-export const imageFields: MergeField[] = [
-  { label: "Cover Image", token: "{{report.cover_image}}" },
-  { label: "Organization Logo", token: "{{organization.logo_url}}" },
+  { label: "Cover Image", token: "{{cover_image}}" },
 ];

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -675,26 +675,6 @@ export default function CoverPageEditorPage() {
         handleAddText(`${label}: ${token}`);
     };
 
-    const handleAddImageField = (token: string) => {
-        if (!canvas) return;
-        const transform = canvas.viewportTransform || [1, 0, 0, 1, 0, 0];
-        const left = transform[4];
-        const top = transform[5];
-        const x = canvas.getWidth() / 2 - left;
-        const y = canvas.getHeight() / 2 - top;
-        handleCoverElementDrop(
-            canvas,
-            palette,
-            {type: "image-field", data: {token}, x, y},
-            {
-                addImage: (url, px, py) => {
-                    void handleAddImage(url, px, py);
-                },
-                addIcon: handleAddIcon,
-            },
-            pushHistory,
-        );
-    };
 
     const applyPalette = (p: ColorPalette) => {
         setPalette(p);
@@ -987,7 +967,6 @@ export default function CoverPageEditorPage() {
                             presetBgColors={PRESET_BG_COLORS}
                             updateBgColor={updateBgColor}
                             onAddPlaceholder={handleAddPlaceholder}
-                            onAddImageField={handleAddImageField}
                             onShowShortcuts={() => setShortcutsOpen(true)}
                         />
                     </div>

--- a/src/utils/replaceMergeFields.ts
+++ b/src/utils/replaceMergeFields.ts
@@ -29,5 +29,7 @@ export function replaceMergeFields(text: string, { organization, inspector, repo
       reportDetails.weather_conditions || (report as any)?.reportData?.weather_conditions || "",
   };
 
-  return text.replace(/{{[^}]+}}/g, (match) => replacements[match] ?? "");
+  return text.replace(/{{[^}]+}}/g, (match) =>
+    Object.prototype.hasOwnProperty.call(replacements, match) ? replacements[match] : match
+  );
 }


### PR DESCRIPTION
## Summary
- Move cover image and organization logo placeholders into report and organization field groups
- Simplify form fields sidebar to only handle merge field placeholders
- Preserve unknown merge tokens when replacing fields

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 239 problems (217 errors, 22 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68adf807de548333a0db9f41739db3a7