### PR TITLE
Preserve image storage paths

### DIFF
--- a/src/components/cover-pages/editor-sidebar/ImagesSection.tsx
+++ b/src/components/cover-pages/editor-sidebar/ImagesSection.tsx
@@ -67,8 +67,8 @@ export function ImagesSection({
                         onDragStart={(e) => {
                             console.log("Starting drag with image:", img.url);
                             const payload = JSON.stringify({
-                                type: "image", 
-                                data: { url: img.url, name: img.name }
+                                type: "image",
+                                data: { url: img.url, name: img.name, path: img.path }
                             });
                             e.dataTransfer?.setData("application/x-cover-element", payload);
                             e.dataTransfer!.effectAllowed = "copy";

--- a/src/lib/handleCoverElementDrop.ts
+++ b/src/lib/handleCoverElementDrop.ts
@@ -16,13 +16,22 @@ import {
 
 interface DropPayload {
     type: string;
-    data: { url?: string; name?: string; hex?: string; label?: string; token?: string } | undefined;
+    data:
+        | {
+              url?: string;
+              name?: string;
+              path?: string;
+              hex?: string;
+              label?: string;
+              token?: string;
+          }
+        | undefined;
     x: number;
     y: number;
 }
 
 interface ExtraHandlers {
-    addImage?: (url: string, x: number, y: number) => void;
+    addImage?: (url: string, x: number, y: number, path?: string) => void;
     addIcon?: (name: string, x: number, y: number) => void;
 }
 
@@ -78,8 +87,8 @@ export function handleCoverElementDrop(
             break;
         case "image":
             if (data?.url) {
-                handlers.addImage?.(data.url, x, y);
-                console.log('Image added', { url: data.url, x, y });
+                handlers.addImage?.(data.url, x, y, data.path);
+                console.log('Image added', { url: data.url, path: data.path, x, y });
                 pushHistory?.();
             }
             break;


### PR DESCRIPTION
## Summary
- include storage path in image drag payload and drop handling
- persist `storagePath` in canvas objects and save JSON
- refresh signed image URLs before loading saved designs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ae0ce788988333a37c0438300e237a