### PR TITLE
feat: use unified merge field placeholders

### DIFF
--- a/src/components/cover-pages/EditorSidebar.tsx
+++ b/src/components/cover-pages/EditorSidebar.tsx
@@ -61,8 +61,7 @@ export interface EditorSidebarProps {
     updateBgColor: (color: string) => void;
 
     // FORM FIELDS
-    onAddPlaceholder: (label: string, token: string) => void;
-    onAddImagePlaceholder: (token: string) => void;
+    onAddPlaceholder: (token: string) => void;
 
     // SHORTCUTS
     onShowShortcuts?: () => void;
@@ -78,7 +77,6 @@ export function EditorSidebar(props: EditorSidebarProps) {
         templateOptions, palette, onApplyPalette,
         bgColor, presetBgColors, updateBgColor,
         onAddPlaceholder,
-        onAddImagePlaceholder,
         onShowShortcuts,
     } = props;
 
@@ -188,7 +186,6 @@ export function EditorSidebar(props: EditorSidebarProps) {
                 >
                     <FormFieldsSection
                         onAddPlaceholder={onAddPlaceholder}
-                        onAddImagePlaceholder={onAddImagePlaceholder}
                     />
                 </SidebarCard>
             </div>

--- a/src/components/cover-pages/editor-sidebar/FormFieldsSection.tsx
+++ b/src/components/cover-pages/editor-sidebar/FormFieldsSection.tsx
@@ -5,17 +5,12 @@ import {
     inspectorFields,
     organizationFields,
     reportFields,
-    IMAGE_FIELD_TOKENS,
 } from "@/constants/coverPageFields.ts";
-
-const IMAGE_FIELD_TOKENS = ["{{organizational_logo}}", "{{cover_image}}"];
 
 export function FormFieldsSection({
                                       onAddPlaceholder,
-                                      onAddImagePlaceholder,
                                   }: {
-    onAddPlaceholder: (label: string, token: string) => void;
-    onAddImagePlaceholder: (token: string) => void;
+    onAddPlaceholder: (token: string) => void;
 }) {
     return (
         <Accordion type="single" collapsible defaultValue="organization" className="w-full">
@@ -23,34 +18,22 @@ export function FormFieldsSection({
                 <AccordionTrigger>Organization Details</AccordionTrigger>
                 <AccordionContent className="data-[state=open]:animate-none data-[state=open]:h-auto">
                     <div className="flex flex-col space-y-2">
-                        {organizationFields.map((field) => {
-                            const isImage = IMAGE_FIELD_TOKENS.includes(field.token);
-                            return (
-                                <Button
-                                    key={field.token}
-                                    variant="outline"
-                                    className="w-full justify-start"
-                                    draggable
-                                    onDragStart={(e) => {
-                                        const payload = JSON.stringify({
-                                            type: isImage ? "image-field" : "merge-field",
-                                            data: isImage
-                                                ? { token: field.token }
-                                                : { label: field.label, token: field.token },
-                                        });
-                                        e.dataTransfer?.setData("application/x-cover-element", payload);
-                                        e.dataTransfer!.effectAllowed = "copy";
-                                    }}
-                                    onClick={() =>
-                                        isImage
-                                            ? onAddImagePlaceholder(field.token)
-                                            : onAddPlaceholder(field.label, field.token)
-                                    }
-                                >
-                                    {field.label}
-                                </Button>
-                            );
-                        })}
+                        {organizationFields.map((field) => (
+                            <Button
+                                key={field.token}
+                                variant="outline"
+                                className="w-full justify-start"
+                                draggable
+                                onDragStart={(e) => {
+                                    const payload = JSON.stringify({ type: "merge-field", data: { token: field.token } });
+                                    e.dataTransfer?.setData("application/x-cover-element", payload);
+                                    e.dataTransfer!.effectAllowed = "copy";
+                                }}
+                                onClick={() => onAddPlaceholder(field.token)}
+                            >
+                                {field.label}
+                            </Button>
+                        ))}
                     </div>
                 </AccordionContent>
             </AccordionItem>
@@ -66,11 +49,11 @@ export function FormFieldsSection({
                                 className="w-full justify-start"
                                 draggable
                                 onDragStart={(e) => {
-                                    const payload = JSON.stringify({ type: "merge-field", data: { label: field.label, token: field.token } });
+                                    const payload = JSON.stringify({ type: "merge-field", data: { token: field.token } });
                                     e.dataTransfer?.setData("application/x-cover-element", payload);
                                     e.dataTransfer!.effectAllowed = "copy";
                                 }}
-                                onClick={() => onAddPlaceholder(field.label, field.token)}
+                                onClick={() => onAddPlaceholder(field.token)}
                             >
                                 {field.label}
                             </Button>
@@ -90,11 +73,11 @@ export function FormFieldsSection({
                                 className="w-full justify-start"
                                 draggable
                                 onDragStart={(e) => {
-                                    const payload = JSON.stringify({ type: "merge-field", data: { label: field.label, token: field.token } });
+                                    const payload = JSON.stringify({ type: "merge-field", data: { token: field.token } });
                                     e.dataTransfer?.setData("application/x-cover-element", payload);
                                     e.dataTransfer!.effectAllowed = "copy";
                                 }}
-                                onClick={() => onAddPlaceholder(field.label, field.token)}
+                                onClick={() => onAddPlaceholder(field.token)}
                             >
                                 {field.label}
                             </Button>
@@ -107,34 +90,22 @@ export function FormFieldsSection({
                 <AccordionTrigger>Report Details</AccordionTrigger>
                 <AccordionContent className="data-[state=open]:animate-none data-[state=open]:h-auto">
                     <div className="flex flex-col space-y-2">
-                        {reportFields.map((field) => {
-                            const isImage = IMAGE_FIELD_TOKENS.includes(field.token);
-                            return (
-                                <Button
-                                    key={field.token}
-                                    variant="outline"
-                                    className="w-full justify-start"
-                                    draggable
-                                    onDragStart={(e) => {
-                                        const payload = JSON.stringify({
-                                            type: isImage ? "image-field" : "merge-field",
-                                            data: isImage
-                                                ? { token: field.token }
-                                                : { label: field.label, token: field.token },
-                                        });
-                                        e.dataTransfer?.setData("application/x-cover-element", payload);
-                                        e.dataTransfer!.effectAllowed = "copy";
-                                    }}
-                                    onClick={() =>
-                                        isImage
-                                            ? onAddImagePlaceholder(field.token)
-                                            : onAddPlaceholder(field.label, field.token)
-                                    }
-                                >
-                                    {field.label}
-                                </Button>
-                            );
-                        })}
+                        {reportFields.map((field) => (
+                            <Button
+                                key={field.token}
+                                variant="outline"
+                                className="w-full justify-start"
+                                draggable
+                                onDragStart={(e) => {
+                                    const payload = JSON.stringify({ type: "merge-field", data: { token: field.token } });
+                                    e.dataTransfer?.setData("application/x-cover-element", payload);
+                                    e.dataTransfer!.effectAllowed = "copy";
+                                }}
+                                onClick={() => onAddPlaceholder(field.token)}
+                            >
+                                {field.label}
+                            </Button>
+                        ))}
                     </div>
                 </AccordionContent>
             </AccordionItem>

--- a/src/constants/coverPageFields.ts
+++ b/src/constants/coverPageFields.ts
@@ -31,13 +31,3 @@ export const reportFields: MergeField[] = [
   { label: "Weather Conditions", token: "{{report.weather_conditions}}" },
   { label: "Cover Image", token: "{{cover_image}}" },
 ];
-
-const IMAGE_FIELD_REGEX = /logo|image/i;
-export const IMAGE_FIELD_TOKENS = [
-  ...organizationFields,
-  ...inspectorFields,
-  ...contactFields,
-  ...reportFields,
-]
-  .filter((field) => IMAGE_FIELD_REGEX.test(field.label))
-  .map((field) => field.token);

--- a/src/lib/fabricShapes.ts
+++ b/src/lib/fabricShapes.ts
@@ -9,6 +9,7 @@ import {
     Polygon,
     Rect,
     Textbox,
+    Text as FabricText,
     util as FabricUtil,
     FabricObject,
 } from "fabric";
@@ -211,6 +212,59 @@ export function addText(canvas: FabricCanvas, palette: Palette, text = "Text", x
     canvas.setActiveObject(tb);
     canvas.requestRenderAll();
     return tb;
+}
+
+export function addMergeField(canvas: FabricCanvas, token: string, x = 120, y = 120) {
+    const mapTokenToMergeField = (t?: string) => {
+        switch (t) {
+            case "{{cover_image}}":
+                return "report.coverImage";
+            case "{{organizational_logo}}":
+                return "organization.logoUrl";
+            default:
+                return t ? t.replace(/[{}]/g, "").replace(/_([a-z])/g, (_, c) => c.toUpperCase()) : "";
+        }
+    };
+    const mergeField = mapTokenToMergeField(token);
+    const rect = new Rect({
+        left: x,
+        top: y,
+        width: 200,
+        height: 50,
+        stroke: "#888",
+        strokeWidth: 2,
+        strokeDashArray: [6, 4],
+        fill: "#f3f4f6",
+        backgroundColor: "#f3f4f6",
+        mergeField,
+        displayToken: token,
+        name: "Merge Field",
+    } as unknown as Partial<Rect> & { mergeField: string; displayToken: string });
+    enableScalingHandles(rect);
+    const text = new FabricText(token, {
+        fontSize: 16,
+        originX: "center",
+        originY: "center",
+        selectable: false,
+        evented: false,
+        excludeFromExport: true,
+    });
+    const center = rect.getCenterPoint();
+    text.set({ left: center.x, top: center.y });
+    const updateText = () => {
+        const cpt = rect.getCenterPoint();
+        text.set({ left: cpt.x, top: cpt.y });
+        text.setCoords();
+    };
+    rect.on("moving", updateText);
+    rect.on("scaling", updateText);
+    rect.on("rotating", updateText);
+    rect.on("removed", () => canvas.remove(text));
+    canvas.add(rect);
+    canvas.add(text);
+    canvas.setActiveObject(rect);
+    canvas.requestRenderAll();
+    return rect;
 }
 
 export async function addImageFromUrl(canvas: FabricCanvas, url: string, x = 150, y = 150) {

--- a/src/lib/handleCoverElementDrop.ts
+++ b/src/lib/handleCoverElementDrop.ts
@@ -1,4 +1,4 @@
-import { Canvas as FabricCanvas, Image as FabricImage, Text as FabricText } from "fabric";
+import { Canvas as FabricCanvas } from "fabric";
 import { ColorPalette } from "@/constants/colorPalettes";
 import {
     addRect as fabricAddRect,
@@ -12,6 +12,7 @@ import {
     addBezierCurve as fabricAddBezierCurve,
     addText as fabricAddText,
     addOpenmojiClipart,
+    addMergeField as fabricAddMergeField,
 } from "@/lib/fabricShapes";
 
 interface DropPayload {
@@ -92,71 +93,9 @@ export function handleCoverElementDrop(
                 pushHistory?.();
             }
             break;
-        case "image-field": {
-            const transparentPng =
-                "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8Xw8AAoMBgD1Q9FAAAAAASUVORK5CYII=";
-            const mapTokenToMergeField = (token?: string) => {
-                switch (token) {
-                    case "{{cover_image}}":
-                        return "report.coverImage";
-                    case "{{organizational_logo}}":
-                        return "organization.logoUrl";
-                    default:
-                        return token
-                            ? token
-                                  .replace(/[{}]/g, "")
-                                  .replace(/_([a-z])/g, (_, c) => c.toUpperCase())
-                            : "report.coverImage";
-                }
-            };
-            const mergeField = mapTokenToMergeField(data?.token);
-            const displayToken = data?.token ?? "";
-            FabricImage.fromURL(transparentPng, (img) => {
-                img.set({
-                    left: x,
-                    top: y,
-                    mergeField,
-                    displayToken,
-                    stroke: "#888",
-                    strokeWidth: 2,
-                    strokeDashArray: [6, 4],
-                    backgroundColor: "#f3f4f6",
-                } as unknown as Partial<FabricImage> & { mergeField: string; displayToken: string });
-                img.scaleToWidth(200);
-                img.scaleToHeight(200);
-
-                const text = new FabricText(displayToken, {
-                    fontSize: 16,
-                    originX: "center",
-                    originY: "center",
-                    selectable: false,
-                    evented: false,
-                    excludeFromExport: true,
-                });
-                const center = img.getCenterPoint();
-                text.set({ left: center.x, top: center.y });
-
-                const updateText = () => {
-                    const c = img.getCenterPoint();
-                    text.set({ left: c.x, top: c.y });
-                    text.setCoords();
-                };
-                img.on("moving", updateText);
-                img.on("scaling", updateText);
-                img.on("rotating", updateText);
-                img.on("removed", () => canvas.remove(text));
-
-                canvas.add(img);
-                canvas.add(text);
-                canvas.setActiveObject(img);
-                canvas.requestRenderAll();
-                pushHistory?.();
-            });
-            break;
-        }
         case "merge-field":
-            if (data?.label && data?.token) {
-                fabricAddText(canvas, palette, `${data.label}: ${data.token}`, x, y);
+            if (data?.token) {
+                fabricAddMergeField(canvas, data.token, x, y);
                 pushHistory?.();
             }
             break;

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -258,9 +258,9 @@ export default function CoverPageEditorPage() {
 
     const restoreMergeFieldOverlays = (c: FabricCanvas) => {
         c.getObjects().forEach((obj) => {
-            if (obj.type === "image" && (obj as any).mergeField) {
-                const img = obj as FabricImage & { mergeField: string; displayToken?: string };
-                const token = (img as any).displayToken ?? "";
+            const token = (obj as any).displayToken;
+            const mergeField = (obj as any).mergeField;
+            if (mergeField && token) {
                 const text = new FabricText(token, {
                     fontSize: 16,
                     originX: "center",
@@ -269,19 +269,19 @@ export default function CoverPageEditorPage() {
                     evented: false,
                     excludeFromExport: true,
                 });
-                const center = img.getCenterPoint();
+                const center = obj.getCenterPoint();
                 text.set({ left: center.x, top: center.y });
                 const updateText = () => {
-                    const cpt = img.getCenterPoint();
+                    const cpt = obj.getCenterPoint();
                     text.set({ left: cpt.x, top: cpt.y });
                     text.setCoords();
                 };
-                img.on("moving", updateText);
-                img.on("scaling", updateText);
-                img.on("rotating", updateText);
-                img.on("removed", () => c.remove(text));
+                obj.on("moving", updateText);
+                obj.on("scaling", updateText);
+                obj.on("rotating", updateText);
+                obj.on("removed", () => c.remove(text));
                 c.add(text);
-                text.moveTo(c.getObjects().indexOf(img) + 1);
+                text.moveTo(c.getObjects().indexOf(obj) + 1);
             }
         });
     };
@@ -766,21 +766,17 @@ export default function CoverPageEditorPage() {
         pushHistory();
     };
 
-    const handleAddPlaceholder = (label: string, token: string) => {
-        handleAddText(`${label}: ${token}`);
-    };
-
-    const handleAddImagePlaceholder = (token: string) => {
+    const handleAddPlaceholder = (token: string) => {
         if (!canvas) return;
         const x = canvas.getWidth() / 2;
         const y = canvas.getHeight() / 2;
         handleCoverElementDrop(
             canvas,
             palette,
-            { type: "image-field", data: { token }, x, y },
+            { type: "merge-field", data: { token }, x, y },
             {
-                addImage: (url, px, py) => {
-                    void handleAddImage(url, px, py);
+                addImage: (url, px, py, path) => {
+                    void handleAddImage(url, px, py, path);
                 },
                 addIcon: handleAddIcon,
             },
@@ -1080,7 +1076,6 @@ export default function CoverPageEditorPage() {
                             presetBgColors={PRESET_BG_COLORS}
                             updateBgColor={updateBgColor}
                             onAddPlaceholder={handleAddPlaceholder}
-                            onAddImagePlaceholder={handleAddImagePlaceholder}
                             onShowShortcuts={() => setShortcutsOpen(true)}
                         />
                     </div>


### PR DESCRIPTION
## Summary
- replace text-based merge fields with custom merge field placeholders
- simplify form field sidebar to always create the same merge field type
- recreate merge field overlays after canvas load

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any and require import issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1a4d867c8333ad6e941185d4e32a