### PR TITLE
Fix merge field overlays not reloading after save

### DIFF
--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -46,6 +46,11 @@ const CUSTOM_PROPS = [
     "name",
 ];
 
+// Ensure Fabric retains custom properties like mergeField and displayToken
+(FabricObject.prototype as any).customProperties = Array.from(
+    new Set([...(FabricObject.prototype as any).customProperties || [], ...CUSTOM_PROPS]),
+);
+
 interface FormValues {
     name: string;
     template: keyof typeof TEMPLATES;
@@ -157,7 +162,7 @@ export default function CoverPageEditorPage() {
 
     // Load existing cover page once data and canvas are ready
     useEffect(() => {
-        if (!ready || !id || loaded.current) return;
+        if (!ready || !id || !canvas || loaded.current) return;
 
         const sid = String(id);
         const cp = coverPages.find((c) => String(c.id) === sid);
@@ -215,7 +220,7 @@ export default function CoverPageEditorPage() {
             void loadDesign();
         }
         loaded.current = true;
-    }, [ready, id, coverPages, form]);
+    }, [ready, id, coverPages, form, canvas]);
 
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure Fabric remembers mergeField and displayToken custom properties
- wait for canvas to be ready before restoring saved designs and overlays

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae26ec011883339dcdb67ebfced94c