### PR TITLE
Fix layer selection styling and enable drag reordering

### DIFF
--- a/src/components/cover-pages/PropertiesPanel.tsx
+++ b/src/components/cover-pages/PropertiesPanel.tsx
@@ -41,6 +41,7 @@ interface PropertiesPanelProps {
   layers: FabricObject[];
   onSelectLayer: (object: FabricObject) => void;
   onUpdateLayer: (layer: FabricObject, property: string, value: any) => void;
+  onReorderLayer: (fromIndex: number, toIndex: number) => void;
 }
 
 const FONTS = [
@@ -64,6 +65,7 @@ export function PropertiesPanel({
   layers,
   onSelectLayer,
   onUpdateLayer,
+  onReorderLayer,
 }: PropertiesPanelProps) {
   const multipleSelection = selectedObjects.length > 1;
   const isTextObject = !multipleSelection && selectedObject?.type === "textbox";
@@ -81,6 +83,7 @@ export function PropertiesPanel({
   const hasSkewY = !multipleSelection && selectedObject && "skewY" in selectedObject;
 
   const [value, setValue] = React.useState<string>("layers");
+  const [draggedIndex, setDraggedIndex] = React.useState<number | null>(null);
 
   return (
     <div className="w-80 h-full border-l bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -441,8 +444,18 @@ export function PropertiesPanel({
                   {layers.map((layer, index) => (
                     <div
                       key={index}
+                      draggable
+                      onDragStart={() => setDraggedIndex(index)}
+                      onDragOver={(e) => e.preventDefault()}
+                      onDrop={() => {
+                        if (draggedIndex !== null && draggedIndex !== index) {
+                          onReorderLayer(draggedIndex, index);
+                        }
+                        setDraggedIndex(null);
+                      }}
+                      onDragEnd={() => setDraggedIndex(null)}
                       onClick={() => onSelectLayer(layer)}
-                      className={`flex items-center gap-2 p-2 rounded cursor-pointer ${
+                      className={`flex items-center gap-2 p-2 rounded cursor-move ${
                         layer === selectedObject
                           ? "bg-primary text-primary-foreground"
                           : "hover:bg-accent"
@@ -474,7 +487,11 @@ export function PropertiesPanel({
                         onChange={(e) =>
                           onUpdateLayer(layer, "name", e.target.value)
                         }
-                        className="h-7 text-xs flex-1"
+                        className={`h-7 text-xs flex-1 ${
+                          layer === selectedObject
+                            ? "bg-primary text-primary-foreground placeholder:text-primary-foreground border-primary-foreground"
+                            : ""
+                        }`}
                       />
                       <div
                         className="flex items-center gap-2 w-32"

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -874,6 +874,19 @@ export default function CoverPageEditorPage() {
         pushHistory();
     };
 
+    const handleReorderLayers = (from: number, to: number) => {
+        if (!canvas) return;
+        const updated = [...layers];
+        const [moved] = updated.splice(from, 1);
+        updated.splice(to, 0, moved);
+        updated.forEach((layer, idx) => {
+            canvas.moveTo(layer, idx);
+        });
+        setLayers(updated);
+        canvas.renderAll();
+        pushHistory();
+    };
+
     const handleBringForward = () => {
         if (!canvas || selectedObjects.length === 0) return;
 
@@ -1125,6 +1138,7 @@ export default function CoverPageEditorPage() {
                             layers={layers}
                             onSelectLayer={handleSelectLayer}
                             onUpdateLayer={handleUpdateLayerProperty}
+                            onReorderLayer={handleReorderLayers}
                         />
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- keep layer name input readable when selected
- enable dragging to reorder layers in the properties panel

## Testing
- `npm run lint` (fails: Unexpected any...)
- `npm run build` (fails: LUCIDE_VERSION already declared)


------
https://chatgpt.com/codex/tasks/task_e_68ae2738f05083339ab8dee514200a0e