### PR TITLE
Fix merge-field overlay layering issues

### DIFF
--- a/src/lib/fabricShapes.ts
+++ b/src/lib/fabricShapes.ts
@@ -250,6 +250,8 @@ export function addMergeField(canvas: FabricCanvas, token: string, x = 120, y = 
         evented: false,
         excludeFromExport: true,
     });
+    (rect as any)._overlay = text;
+    (text as any)._overlayParent = rect;
     const center = rect.getCenterPoint();
     text.set({ left: center.x, top: center.y });
     const updateText = () => {


### PR DESCRIPTION
## Summary
- Link merge-field text overlays to their rectangles
- Filter overlays out of layer management and move them with their base objects
- Keep overlay visibility and deletion in sync with parent objects

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 273 problems)


------
https://chatgpt.com/codex/tasks/task_e_68ae394adc8c833386c1da470e107ecf