### PR TITLE
Maintain merge field labels in cover page editor

### DIFF
--- a/src/components/cover-pages/PropertiesPanel.tsx
+++ b/src/components/cover-pages/PropertiesPanel.tsx
@@ -441,7 +441,14 @@ export function PropertiesPanel({
               </AccordionTrigger>
               <AccordionContent className="space-y-3">
                 <div className="space-y-1">
-                  {layers.map((layer, index) => (
+                  {layers.map((layer, index) => {
+                    const defaultLabel = `${
+                      layer.type === "textbox" ? "Text" : layer.type || "Object"
+                    } ${index + 1}`;
+                    const label = (layer as any).mergeField
+                      ? (layer as any).displayToken ?? "Merge Field"
+                      : layer.name || defaultLabel;
+                    return (
                     <div
                       key={index}
                       draggable
@@ -475,14 +482,7 @@ export function PropertiesPanel({
                         )}
                       </span>
                       <Input
-                        value={
-                          layer.name ||
-                          `${
-                            layer.type === "textbox"
-                              ? "Text"
-                              : layer.type || "Object"
-                          } ${index + 1}`
-                        }
+                        value={label}
                         onClick={(e) => e.stopPropagation()}
                         onChange={(e) =>
                           onUpdateLayer(layer, "name", e.target.value)
@@ -520,7 +520,8 @@ export function PropertiesPanel({
                         <Trash2 className="h-4 w-4" />
                       </span>
                     </div>
-                  ))}
+                    );
+                  })}
                 </div>
               </AccordionContent>
             </AccordionItem>

--- a/src/pages/CoverPageEditorPage.tsx
+++ b/src/pages/CoverPageEditorPage.tsx
@@ -291,6 +291,10 @@ export default function CoverPageEditorPage() {
                 (obj as any).displayToken = token;
             }
 
+            if (mergeField) {
+                (obj as any).set({ name: (obj as any).name ?? "Merge Field" });
+            }
+
             if (mergeField && token) {
                 const text = new FabricText(token, {
                     fontSize: 16,


### PR DESCRIPTION
## Summary
- Ensure merge fields keep a default name when overlays are restored
- Show merge field display tokens or "Merge Field" in the properties panel layer list

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `npm run lint` *(fails: Unexpected any / require style imports)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4138ecec8333bc60c0a303e16666