### PR TITLE
Process cover page template data and fix canvas cleanup

### DIFF
--- a/src/components/reports/PDFDocument.tsx
+++ b/src/components/reports/PDFDocument.tsx
@@ -47,7 +47,17 @@ const PDFDocument = React.forwardRef<HTMLDivElement, PDFDocumentProps>(
             });
             
             console.log("📐 Loading design JSON...");
-            canvas.loadFromJSON(cp.design_json as any, () => {
+            const [organization, inspector] = await Promise.all([
+              getMyOrganization(),
+              getMyProfile()
+            ]);
+            let designJson: any = await replaceCoverMergeFields(cp.design_json, {
+              organization,
+              inspector,
+              report
+            });
+            designJson = await replaceCoverImages(designJson, report, organization);
+            canvas.loadFromJSON(designJson as any, () => {
               console.log("✅ Canvas loaded successfully");
               canvas.renderAll();
               
@@ -66,7 +76,7 @@ const PDFDocument = React.forwardRef<HTMLDivElement, PDFDocumentProps>(
               
               // Clean up
               canvas.dispose();
-              document.body.removeChild(canvasEl);
+              canvasEl.remove();
             });
           } else {
             console.log("❌ No cover page template found");


### PR DESCRIPTION
## Summary
- Replace cover page template merge fields and images before rendering
- Avoid NotFoundError by using `canvasEl.remove()` during cleanup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68af4577f4c0833386b3fb10ecc9eac3