### PR TITLE
Handle missing org data and preserve merge placeholders

### DIFF
--- a/src/components/reports/PDFDocument.tsx
+++ b/src/components/reports/PDFDocument.tsx
@@ -53,13 +53,13 @@ const PDFDocument = React.forwardRef<HTMLDivElement, PDFDocumentProps>(
               getMyProfile()
             ]);
             let designJson: any = await replaceCoverMergeFields(cp.design_json, {
-              organization,
+              organization: organization ?? null,
               inspector,
               report
             });
-            designJson = await replaceCoverImages(designJson, report, organization);
+            designJson = await replaceCoverImages(designJson, report, organization ?? null);
             canvas.loadFromJSON(designJson as any, () => {
-              console.log("✅ Canvas loaded successfully");
+              console.log("✅ Canvas loaded successfully", canvas.getObjects().length);
               canvas.renderAll();
 
               // Generate image

--- a/src/pages/ReportPreview.tsx
+++ b/src/pages/ReportPreview.tsx
@@ -248,19 +248,20 @@ const ReportPreview: React.FC = () => {
 
                             // First replace merge fields with actual data
                             const mergeFieldsReplaced = await replaceCoverMergeFields(cp.design_json, {
-                                organization,
+                                organization: organization ?? null,
                                 inspector,
                                 report
                             });
                             console.log("after replaceCoverMergeFields", mergeFieldsReplaced);
 
                             // Then replace image placeholders with actual images
-                            const imagesReplaced = await replaceCoverImages(mergeFieldsReplaced, report, organization);
+                            const imagesReplaced = await replaceCoverImages(mergeFieldsReplaced, report, organization ?? null);
                             console.log("after replaceCoverImages", imagesReplaced);
 
                             coverCanvas.loadFromJSON(imagesReplaced as any, () => {
-                                console.log("loadFromJSON success");
+                                console.log("loadFromJSON success", coverCanvas.getObjects().length);
                                 coverCanvas?.renderAll();
+                                setHasCoverPage(true);
                             });
                         }
                     } else if (!cancelled) {

--- a/src/utils/replaceMergeFields.ts
+++ b/src/utils/replaceMergeFields.ts
@@ -7,27 +7,47 @@ interface MergeData {
   report?: Partial<Report> | null;
 }
 
+interface SectionLike {
+  key?: string;
+  info?: Record<string, unknown>;
+}
+
 export function replaceMergeFields(text: string, { organization, inspector, report }: MergeData) {
   if (!text) return "";
 
-  const reportDetails = (report as any)?.sections?.find((s: any) => s.key === "report_details")?.info || {};
-  const replacements: Record<string, string> = {
-    "{{organization.name}}": organization?.name ?? "",
-    "{{organization.address}}": organization?.address ?? "",
-    "{{organization.phone}}": organization?.phone ?? "",
-    "{{organization.email}}": organization?.email ?? "",
-    "{{inspector.name}}": inspector?.full_name ?? "",
-    "{{inspector.license_number}}": inspector?.license_number ?? "",
-    "{{inspector.phone}}": inspector?.phone ?? "",
-    "{{contact.name}}": report?.clientName ?? "",
-    "{{contact.address}}": report?.address ?? "",
-    "{{contact.email}}": (report as any)?.email ?? "",
+  const reportRecord = report as Record<string, unknown> | null;
+  const sections = reportRecord?.sections as SectionLike[] | undefined;
+  const reportDetails = sections?.find((s) => s.key === "report_details")?.info || {};
+
+  const reportData = reportRecord?.reportData as Record<string, unknown> | undefined;
+
+  const rawReplacements: Record<string, string | null | undefined> = {
+    "{{organization.name}}": organization?.name,
+    "{{organization.address}}": organization?.address,
+    "{{organization.phone}}": organization?.phone,
+    "{{organization.email}}": organization?.email,
+    "{{inspector.name}}": inspector?.full_name,
+    "{{inspector.license_number}}": inspector?.license_number,
+    "{{inspector.phone}}": inspector?.phone,
+    "{{contact.name}}": (reportRecord?.clientName as string | undefined),
+    "{{contact.address}}": (reportRecord?.address as string | undefined),
+    "{{contact.email}}": (reportRecord?.email as string | undefined),
     "{{contact.phone}}":
-      (report as any)?.phoneHome || (report as any)?.phoneWork || (report as any)?.phoneCell || "",
-    "{{report.inspection_date}}": (report as any)?.inspectionDate ?? "",
+      (reportRecord?.phoneHome as string | undefined) ||
+      (reportRecord?.phoneWork as string | undefined) ||
+      (reportRecord?.phoneCell as string | undefined),
+    "{{report.inspection_date}}": (reportRecord?.inspectionDate as string | undefined),
     "{{report.weather_conditions}}":
-      reportDetails.weather_conditions || (report as any)?.reportData?.weather_conditions || "",
+      (reportDetails as Record<string, unknown>).weather_conditions as string | undefined ||
+      (reportData?.weather_conditions as string | undefined),
   };
+
+  const replacements: Record<string, string> = {};
+  for (const [token, value] of Object.entries(rawReplacements)) {
+    if (typeof value === "string" && value !== "") {
+      replacements[token] = value;
+    }
+  }
 
   return text.replace(/{{[^}]+}}/g, (match) =>
     Object.prototype.hasOwnProperty.call(replacements, match) ? replacements[match] : match


### PR DESCRIPTION
## Summary
- Avoid creating default organizations; return null if profile is missing organization or fetch unauthorized
- Only replace merge fields when values exist, leaving empty tokens untouched
- Ensure cover page rendering works without organization data and log canvas state

## Testing
- `npm run lint` *(fails: 293 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68af4b6ff16883338d3c70e06ce89070