### PR TITLE
Log profile update result and add profile RLS policy migration

### DIFF
--- a/src/integrations/supabase/organizationsApi.ts
+++ b/src/integrations/supabase/organizationsApi.ts
@@ -259,7 +259,7 @@ export async function updateMyProfile(data: Partial<Profile>) {
     .eq('user_id', (await supabase.auth.getUser()).data.user!.id)
     .select()
     .single();
-
+  console.log({ error, updated });
   if (error) throw error;
   return updated;
 }

--- a/supabase/migrations/20250814120000_profiles_rls.sql
+++ b/supabase/migrations/20250814120000_profiles_rls.sql
@@ -1,0 +1,14 @@
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Profiles are readable by owner"
+  ON public.profiles FOR SELECT
+  USING (user_id = auth.uid());
+
+CREATE POLICY "Profiles are insertable by owner"
+  ON public.profiles FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "Profiles are updatable by owner"
+  ON public.profiles FOR UPDATE
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- log Supabase profile update responses to surface potential RLS errors
- add migration to enable/define RLS policies on `profiles`

## Testing
- `npx supabase db push` *(fails: Cannot find project ref. Have you run supabase link?)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 285 problems (262 errors, 23 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68af5792c864833389c224b401ce8063