### PR TITLE
Use membership instead of profile organization ID

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -515,10 +515,8 @@ export type Database = {
           email: string
           full_name: string | null
           id: string
-          is_individual: boolean
           last_sign_in_at: string | null
           license_number: string | null
-          organization_id: string | null
           phone: string | null
           provider: string | null
           updated_at: string
@@ -530,10 +528,8 @@ export type Database = {
           email: string
           full_name?: string | null
           id?: string
-          is_individual?: boolean
           last_sign_in_at?: string | null
           license_number?: string | null
-          organization_id?: string | null
           phone?: string | null
           provider?: string | null
           updated_at?: string
@@ -545,24 +541,14 @@ export type Database = {
           email?: string
           full_name?: string | null
           id?: string
-          is_individual?: boolean
           last_sign_in_at?: string | null
           license_number?: string | null
-          organization_id?: string | null
           phone?: string | null
           provider?: string | null
           updated_at?: string
           user_id?: string
         }
-        Relationships: [
-          {
-            foreignKeyName: "profiles_organization_id_fkey"
-            columns: ["organization_id"]
-            isOneToOne: false
-            referencedRelation: "organizations"
-            referencedColumns: ["id"]
-          },
-        ]
+        Relationships: []
       }
       reports: {
         Row: {

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -11,7 +11,6 @@ import { CheckCircle, AlertCircle } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
 import { toast } from "@/components/ui/use-toast";
-import { createOrganization, acceptInvitation } from "@/integrations/supabase/organizationsApi";
 
 const AuthPage: React.FC = () => {
   const nav = useNavigate();

--- a/src/pages/HomeInspectionNew.tsx
+++ b/src/pages/HomeInspectionNew.tsx
@@ -15,7 +15,7 @@ import { toast } from "@/components/ui/use-toast";
 import { useAuth } from "@/contexts/AuthContext";
 import { dbCreateReport } from "@/integrations/supabase/reportsApi";
 import { contactsApi } from "@/integrations/supabase/crmApi";
-import { supabase } from "@/integrations/supabase/client";
+import { getMyOrganization } from "@/integrations/supabase/organizationsApi";
 
 const schema = z.object({
   title: z.string().min(1, "Required"),
@@ -73,13 +73,7 @@ const HomeInspectionNew: React.FC = () => {
   const onSubmit = async (values: Values) => {
     try {
       if (user) {
-        // Get user's organization if they have one
-        const { data: profile } = await supabase
-          .from('profiles')
-          .select('organization_id')
-          .eq('user_id', user.id)
-          .single();
-
+        const organization = await getMyOrganization();
         const report = await dbCreateReport(
           {
             title: values.title,
@@ -90,7 +84,7 @@ const HomeInspectionNew: React.FC = () => {
             reportType: "home_inspection",
           },
           user.id,
-          profile?.organization_id || undefined
+          organization?.id
         );
         toast({ title: "Home inspection report created" });
         nav(`/reports/${report.id}`);

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -492,8 +492,8 @@ const ProfilePage: React.FC = () => {
                                 </div>
 
                                 <div className="flex items-center gap-2">
-                                    <Badge variant={profile.is_individual ? "default" : "secondary"}>
-                                        {profile.is_individual ? "Individual Inspector" : "Organization Member"}
+                                    <Badge variant={!organization ? "default" : "secondary"}>
+                                        {!organization ? "Individual Inspector" : "Organization Member"}
                                     </Badge>
                                     {organization && (
                                         <Badge variant="outline">{organization.name}</Badge>

--- a/src/pages/ReportNew.tsx
+++ b/src/pages/ReportNew.tsx
@@ -15,7 +15,7 @@ import { toast } from "@/components/ui/use-toast";
 import { useAuth } from "@/contexts/AuthContext";
 import { dbCreateReport } from "@/integrations/supabase/reportsApi";
 import { contactsApi } from "@/integrations/supabase/crmApi";
-import { supabase } from "@/integrations/supabase/client";
+import { getMyOrganization } from "@/integrations/supabase/organizationsApi";
 
 const schema = z.object({
   title: z.string().min(1, "Required"),
@@ -77,13 +77,7 @@ const ReportNew: React.FC = () => {
   const onSubmit = async (values: Values) => {
     try {
       if (user) {
-        // Get user's organization if they have one
-        const { data: profile } = await supabase
-          .from('profiles')
-          .select('organization_id')
-          .eq('user_id', user.id)
-          .single();
-
+        const organization = await getMyOrganization();
         const report = await dbCreateReport(
           {
             title: values.title,
@@ -94,7 +88,7 @@ const ReportNew: React.FC = () => {
             reportType: "home_inspection",
           },
           user.id,
-          profile?.organization_id || undefined
+          organization?.id
         );
         toast({ title: "Report created" });
         nav(`/reports/${report.id}`);

--- a/src/pages/WindMitigationNew.tsx
+++ b/src/pages/WindMitigationNew.tsx
@@ -14,7 +14,7 @@ import { toast } from "@/components/ui/use-toast";
 import { useAuth } from "@/contexts/AuthContext";
 import { dbCreateReport } from "@/integrations/supabase/reportsApi";
 import { contactsApi } from "@/integrations/supabase/crmApi";
-import { supabase } from "@/integrations/supabase/client";
+import { getMyOrganization } from "@/integrations/supabase/organizationsApi";
 
 const schema = z.object({
   title: z.string().min(1, "Required"),
@@ -92,13 +92,7 @@ const WindMitigationNew: React.FC = () => {
   const onSubmit = async (values: Values) => {
     try {
       if (user) {
-        // Get user's organization if they have one
-        const { data: profile } = await supabase
-          .from('profiles')
-          .select('organization_id')
-          .eq('user_id', user.id)
-          .single();
-
+        const organization = await getMyOrganization();
         const report = await dbCreateReport(
           {
             title: values.title,
@@ -117,7 +111,7 @@ const WindMitigationNew: React.FC = () => {
             email: values.email,
           },
           user.id,
-          profile?.organization_id || undefined
+          organization?.id
         );
         toast({ title: "Wind mitigation report created" });
         nav(`/reports/${report.id}`);

--- a/supabase/migrations/20250828120000_drop_profile_orgid.sql
+++ b/supabase/migrations/20250828120000_drop_profile_orgid.sql
@@ -1,0 +1,76 @@
+-- Backfill organization_members from existing profiles and drop organization_id/is_individual
+
+-- Backfill membership for profiles with organization_id
+INSERT INTO public.organization_members (organization_id, user_id, role)
+SELECT p.organization_id, p.user_id, 'owner'::organization_role
+FROM public.profiles p
+WHERE p.organization_id IS NOT NULL
+ON CONFLICT (user_id, organization_id) DO NOTHING;
+
+-- Remove duplicate memberships, keeping the earliest record per user
+DELETE FROM public.organization_members om
+USING public.organization_members om2
+WHERE om.user_id = om2.user_id
+  AND om.created_at > om2.created_at;
+
+-- Add unique constraint to ensure a user belongs to at most one organization
+ALTER TABLE public.organization_members
+ADD CONSTRAINT organization_members_user_id_key UNIQUE (user_id);
+
+-- Drop legacy columns from profiles
+ALTER TABLE public.profiles
+  DROP COLUMN IF EXISTS organization_id,
+  DROP COLUMN IF EXISTS is_individual;
+
+-- Update handle_new_user trigger function
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO public.profiles (
+    user_id,
+    email,
+    full_name,
+    avatar_url,
+    provider,
+    last_sign_in_at,
+    phone,
+    license_number
+  )
+  VALUES (
+    NEW.id,
+    NEW.email,
+    COALESCE(NEW.raw_user_meta_data->>'full_name', NEW.raw_user_meta_data->>'name'),
+    COALESCE(NEW.raw_user_meta_data->>'avatar_url', NEW.raw_user_meta_data->>'picture'),
+    COALESCE(NEW.raw_app_meta_data->>'provider', 'email'),
+    NEW.last_sign_in_at,
+    NEW.raw_user_meta_data->>'phone',
+    NEW.raw_user_meta_data->>'license_number'
+  );
+
+  IF NEW.raw_user_meta_data->>'organization_name' IS NOT NULL THEN
+    INSERT INTO public.organizations (
+      name,
+      email,
+      phone,
+      license_number
+    ) VALUES (
+      NEW.raw_user_meta_data->>'organization_name',
+      NEW.email,
+      NEW.raw_user_meta_data->>'phone',
+      NEW.raw_user_meta_data->>'license_number'
+    );
+
+    INSERT INTO public.organization_members (
+      organization_id,
+      user_id,
+      role
+    ) VALUES (
+      (SELECT id FROM public.organizations WHERE name = NEW.raw_user_meta_data->>'organization_name' AND email = NEW.email ORDER BY created_at DESC LIMIT 1),
+      NEW.id,
+      'owner'::organization_role
+    );
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary
- backfill `organization_members`, add unique constraint, and drop `organization_id`/`is_individual` from profiles
- switch organization APIs to rely on membership, removing profile mutations
- derive organization membership on frontend and ensure signup creates an organization

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 286 problems)*
- `npm run build` *(fails: "fabric" is not exported...)*

------
https://chatgpt.com/codex/tasks/task_e_68af96690ea08333a727dc70d1502ade