### PR TITLE
Avoid overwriting profile contact info without metadata

### DIFF
--- a/src/lib/upsertProfile.ts
+++ b/src/lib/upsertProfile.ts
@@ -6,23 +6,51 @@ export async function upsertProfile(session: Session | null) {
   const user = session?.user;
   if (!user) return;
 
-  const meta = (user.user_metadata || {}) as Record<string, any>;
+  interface UserMetadata {
+    full_name?: string;
+    name?: string;
+    display_name?: string;
+    avatar_url?: string;
+    picture?: string;
+    phone?: string;
+    license_number?: string;
+    organization_name?: string;
+  }
+
+  const meta = (user.user_metadata || {}) as UserMetadata;
   const full_name = meta.full_name || meta.name || meta.display_name || null;
   const avatar_url = meta.avatar_url || meta.picture || null;
-  const provider = (user.app_metadata as any)?.provider || "email";
+  const provider = (user.app_metadata as { provider?: string })?.provider || "email";
   const email = user.email;
   const last_sign_in_at = new Date().toISOString();
 
-  const payload = {
+  interface ProfilePayload {
+    user_id: string;
+    email: string | null;
+    full_name: string | null;
+    avatar_url: string | null;
+    provider: string;
+    last_sign_in_at: string;
+    phone?: string;
+    license_number?: string;
+  }
+
+  const payload: ProfilePayload = {
     user_id: user.id,
     email,
     full_name,
     avatar_url,
     provider,
     last_sign_in_at,
-    phone: meta.phone || null,
-    license_number: meta.license_number || null,
   };
+
+  if (meta.phone) {
+    payload.phone = meta.phone;
+  }
+
+  if (meta.license_number) {
+    payload.license_number = meta.license_number;
+  }
 
   // Use proper supabase client with correct typing
   const { error } = await supabase
@@ -50,8 +78,8 @@ export async function upsertProfile(session: Session | null) {
           phone: meta.phone || undefined,
           license_number: meta.license_number || undefined,
         });
-      } catch (e: any) {
-        console.error('createOrganization error:', e.message || e);
+      } catch (e) {
+        console.error('createOrganization error:', e instanceof Error ? e.message : e);
       }
     }
   }


### PR DESCRIPTION
## Summary
- Only send `phone` and `license_number` to Supabase when they exist in user metadata
- Type the profile upsert helper to avoid `any` usage and improve error handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Existing lint errors across project)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b04dbf27cc833381ad4a2fde4c0ceb