### PR TITLE
feat: skip already fitted images

### DIFF
--- a/src/utils/fabricCoverLoader.ts
+++ b/src/utils/fabricCoverLoader.ts
@@ -244,6 +244,7 @@ export async function loadCoverDesignToCanvas(
                     await waitForImagesReady(imgs);
 
                     imgs.forEach((img: any) => {
+                        if (img?.data?.__fitDone) return;
                         // Frame from data first (authoritative), then legacy
                         const frame = img?.data?.__frame || {};
                         const frameW = Number.isFinite(frame.width) ? frame.width : (Number.isFinite(img._frameW) ? img._frameW : (img.width ?? 0));
@@ -288,6 +289,8 @@ export async function loadCoverDesignToCanvas(
                         } else {
                             fitImageDirect(img, frameLeft, frameTop, frameW, frameH, iw, ih, fit, debug);
                         }
+                        img.data = img.data || {};
+                        img.data.__fitDone = true;
                     });
 
                     canvas.requestRenderAll();


### PR DESCRIPTION
## Summary
- skip image fitting if it was already processed
- mark images as fitted after wrapping or direct fitting

## Testing
- ⚠️ `npm test` (missing script)
- ❌ `npm run lint` (332 problems)


------
https://chatgpt.com/codex/tasks/task_e_68b0e8af04f083339b376d0f6ffd8e99