### PR TITLE
refactor: use cover design loader

### DIFF
--- a/src/components/reports/PDFDocument.tsx
+++ b/src/components/reports/PDFDocument.tsx
@@ -36,20 +36,6 @@ const PDFDocument = React.forwardRef<HTMLDivElement, PDFDocumentProps>(
             // helper: wait for a couple of rAFs to ensure images are painted
             const raf = () => new Promise<void>((res) => requestAnimationFrame(() => requestAnimationFrame(() => res())));
 
-            // helper: promisified loadFromJSON
-            function loadFabricFromJSON(canvas: FabricCanvas, json: any) {
-                return new Promise<void>((resolve, reject) => {
-                    try {
-                        canvas.loadFromJSON(
-                            json as any,
-                            () => resolve()
-                        );
-                    } catch (e) {
-                        reject(e);
-                    }
-                });
-            }
-
             (async () => {
                 let canvas: FabricCanvas | null = null;
                 let canvasEl: HTMLCanvasElement | null = null;

--- a/src/utils/fabricCoverLoader.ts
+++ b/src/utils/fabricCoverLoader.ts
@@ -28,7 +28,10 @@ function unwrapDesignRoot(design: any) {
 }
 
 function isProbablyUrl(s?: string) {
-    return typeof s === "string" && /^(https?:\/\/|data:image\/)/i.test(s.trim());
+    return (
+        typeof s === "string" &&
+        /^(https?:\/\/|supabase:\/\/|data:image\/)/i.test(s.trim())
+    );
 }
 
 function getIntrinsicSize(o: any) {
@@ -276,6 +279,19 @@ export async function loadCoverDesignToCanvas(
                     }
 
                     const objsAfter = canvas.getObjects();
+
+                    // Warn if any text nodes still contain a URL after replacements
+                    for (const obj of objsAfter) {
+                        const type = obj?.type?.toLowerCase?.() ?? "";
+                        if (type === "text" || type === "textbox" || type === "i-text") {
+                            const text = (obj as any).text;
+                            const url = typeof text === "string" ? text.trim() : "";
+                            if (isProbablyUrl(url)) {
+                                console.warn("[cover-fit] text object still contains URL after replacement", obj);
+                            }
+                        }
+                    }
+
                     const imgs = objsAfter.filter((o: any) => (o?.type?.toLowerCase?.() ?? "") === "image");
                     if (debug) {
                         console.groupCollapsed(

--- a/src/utils/fillWindMitigationPDF.ts
+++ b/src/utils/fillWindMitigationPDF.ts
@@ -11,6 +11,7 @@ import {getMyOrganization, getMyProfile} from "@/integrations/supabase/organizat
 import {replaceMergeFields} from "@/utils/replaceMergeFields";
 import { replaceCoverImages } from "@/utils/replaceCoverImages";
 import { Canvas as FabricCanvas } from "fabric";
+import { loadCoverDesignToCanvas } from "@/utils/fabricCoverLoader";
 
 // Keys that are handled manually elsewhere in the code (e.g. custom logic
 // for building code options) and should be ignored when reporting unmapped
@@ -505,12 +506,12 @@ export async function fillWindMitigationPDF(report: any): Promise<Blob> {
             const canvasEl = document.createElement("canvas");
             const fabricCanvas = new FabricCanvas(canvasEl, {width, height});
             const replaced = await replaceCoverImages(assignedCoverPage.design_json, report, organization);
-            await new Promise<void>((resolve) => {
-                fabricCanvas.loadFromJSON(replaced as any, () => {
-                    fabricCanvas.renderAll();
-                    resolve();
-                });
+            await loadCoverDesignToCanvas(fabricCanvas, replaced, {
+                debug: false,
+                wrapInFrameGroup: true,
+                defaultFit: "contain",
             });
+            fabricCanvas.renderAll();
             const dataUrl = fabricCanvas.toDataURL({format: "png", multiplier: 1});
             fabricCanvas.dispose();
             const imgBytes = await fetch(dataUrl).then(res => res.arrayBuffer());

--- a/src/utils/replaceCoverImages.ts
+++ b/src/utils/replaceCoverImages.ts
@@ -19,7 +19,7 @@ function isDataUrl(s?: string) {
 }
 
 function isProbablyUrl(s?: string) {
-    return isHttpUrl(s) || isDataUrl(s);
+    return isHttpUrl(s) || isDataUrl(s) || isSupabaseUrl(s ?? "");
 }
 
 function nodeType(o: any): string {
@@ -34,8 +34,8 @@ function nodeType(o: any): string {
 // find the first url-ish substring anywhere in text
 function firstUrl(s?: string): string | null {
     if (typeof s !== "string") return null;
-    // http(s) or data:image
-    const m = s.match(/https?:\/\/\S+|data:image\/\S+/i);
+    // http(s), supabase:// or data:image
+    const m = s.match(/https?:\/\/\S+|supabase:\/\/\S+|data:image\/\S+/i);
     if (m) return m[0];
 
     // fallback: relative-ish path with common image extensions


### PR DESCRIPTION
## Summary
- handle supabase:// URLs and warn on leftover text URLs when loading covers
- resolve supabase URLs in cover image token replacement
- load cover designs via `loadCoverDesignToCanvas` for generated PDFs

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 328 problems)


------
https://chatgpt.com/codex/tasks/task_e_68b1cd5f79e4833399867da4fb926766