### PR TITLE
Remove duplicated parameters from CoverTemplateOne

### DIFF
--- a/src/components/report-covers/CoverTemplateOne.tsx
+++ b/src/components/report-covers/CoverTemplateOne.tsx
@@ -60,19 +60,10 @@ const CoverTemplateOne: React.FC<CoverTemplateProps> = ({
         {clientEmail && <p>Email: {clientEmail}</p>}
       </div>
     </div>
-    <div className="text-sm">
-      {inspectionDate && <p>Inspection Date: {inspectionDate}</p>}
-      {weatherConditions && <p>Weather: {weatherConditions}</p>}
-    </div>
-  clientName,
-  coverImage,
-  organizationName,
-}) => (
-  <div className="flex flex-col items-center justify-center text-center p-10">
-    {coverImage && <img src={coverImage} alt="" className="max-h-96 mb-6 object-contain rounded" />}
-    <h1 className="text-4xl font-bold mb-2">{reportTitle}</h1>
-    {clientName && <p className="text-xl mb-4">{clientName}</p>}
-    {organizationName && <p className="text-sm text-muted-foreground">{organizationName}</p>}
+  <div className="text-sm">
+    {inspectionDate && <p>Inspection Date: {inspectionDate}</p>}
+    {weatherConditions && <p>Weather: {weatherConditions}</p>}
+  </div>
   </div>
 );
 


### PR DESCRIPTION
## Summary
- tidy CoverTemplateOne by removing duplicate parameters and extra arrow-function block
- ensure component closes with a single div and arrow function

## Testing
- `npx tsc --noEmit`
- `npx eslint src/components/report-covers/CoverTemplateOne.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b1e47bea7c83339e98108d3de1fe27