### PR TITLE
Format inspection date on report cover pages

### DIFF
--- a/src/components/report-covers/CoverTemplateFive.tsx
+++ b/src/components/report-covers/CoverTemplateFive.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {CoverTemplateProps} from "./types";
+import { formatShortDate } from "../../utils/formatDate";
 
 const CoverTemplateFive: React.FC<CoverTemplateProps> = ({
                                                              reportTitle,
@@ -62,7 +63,7 @@ const CoverTemplateFive: React.FC<CoverTemplateProps> = ({
                 </div>
 
                 <div className="text-sm text-gray-700">
-                    {inspectionDate && <p>Inspection Date: {inspectionDate}</p>}
+                    {inspectionDate && <p>Inspection Date: {formatShortDate(inspectionDate)}</p>}
                     {weatherConditions && <p>Weather: {weatherConditions}</p>}
                 </div>
             </div>

--- a/src/components/report-covers/CoverTemplateFour.tsx
+++ b/src/components/report-covers/CoverTemplateFour.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {CoverTemplateProps} from "./types";
+import { formatShortDate } from "../../utils/formatDate";
 
 const CoverTemplateFour: React.FC<CoverTemplateProps> = ({
                                                              reportTitle,
@@ -54,7 +55,7 @@ const CoverTemplateFour: React.FC<CoverTemplateProps> = ({
                 </div>
 
                 <div className="mt-6 text-sm text-gray-600">
-                    {inspectionDate && <p>Inspection Date: {inspectionDate}</p>}
+                    {inspectionDate && <p>Inspection Date: {formatShortDate(inspectionDate)}</p>}
                     {weatherConditions && <p>Weather: {weatherConditions}</p>}
                 </div>
 

--- a/src/components/report-covers/CoverTemplateOne.tsx
+++ b/src/components/report-covers/CoverTemplateOne.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {CoverTemplateProps} from "./types";
+import { formatShortDate } from "../../utils/formatDate";
 
 const CoverTemplateOne: React.FC<CoverTemplateProps> = ({
                                                             reportTitle,
@@ -65,7 +66,7 @@ const CoverTemplateOne: React.FC<CoverTemplateProps> = ({
             </div>
 
             <div className="text-sm text-center mt-6">
-                {inspectionDate && <p>Inspection Date: {inspectionDate}</p>}
+                {inspectionDate && <p>Inspection Date: {formatShortDate(inspectionDate)}</p>}
                 {weatherConditions && <p>Weather: {weatherConditions}</p>}
             </div>
         </div>

--- a/src/components/report-covers/CoverTemplateThree.tsx
+++ b/src/components/report-covers/CoverTemplateThree.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {CoverTemplateProps} from "./types";
+import { formatShortDate } from "../../utils/formatDate";
 
 const CoverTemplateThree: React.FC<CoverTemplateProps> = ({
                                                                      reportTitle,
@@ -57,7 +58,7 @@ const CoverTemplateThree: React.FC<CoverTemplateProps> = ({
             </div>
 
             <div className="mt-6 text-sm">
-                {inspectionDate && <p>Inspection Date: {inspectionDate}</p>}
+                {inspectionDate && <p>Inspection Date: {formatShortDate(inspectionDate)}</p>}
                 {weatherConditions && <p>Weather: {weatherConditions}</p>}
             </div>
 

--- a/src/components/report-covers/CoverTemplateTwo.tsx
+++ b/src/components/report-covers/CoverTemplateTwo.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { CoverTemplateProps } from "./types";
+import { formatShortDate } from "../../utils/formatDate";
 
 /** ========= Template 2: Full-bleed background with overlay ========= */
 const CoverTemplateTwo: React.FC<CoverTemplateProps> = ({
@@ -55,7 +56,7 @@ const CoverTemplateTwo: React.FC<CoverTemplateProps> = ({
       </div>
 
       <div className="mt-6 text-sm text-center">
-        {inspectionDate && <p>Inspection Date: {inspectionDate}</p>}
+        {inspectionDate && <p>Inspection Date: {formatShortDate(inspectionDate)}</p>}
         {weatherConditions && <p>Weather: {weatherConditions}</p>}
       </div>
 

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,9 @@
+import { format, parseISO } from "date-fns";
+
+export function formatShortDate(dateStr: string): string {
+  try {
+    return format(parseISO(dateStr), "MM/dd/yyyy");
+  } catch {
+    return dateStr;
+  }
+}


### PR DESCRIPTION
## Summary
- format inspection date on report cover templates
- add shared `formatShortDate` helper

## Testing
- `npm run lint` *(fails: numerous existing lint errors)*
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/components/report-covers/CoverTemplateOne.tsx src/components/report-covers/CoverTemplateTwo.tsx src/components/report-covers/CoverTemplateThree.tsx src/components/report-covers/CoverTemplateFour.tsx src/components/report-covers/CoverTemplateFive.tsx src/utils/formatDate.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b1ed5d86908333bb02a63213573ab8