### PR TITLE
feat: apply color schemes to cover templates

### DIFF
--- a/src/components/report-covers/CoverTemplateFive.tsx
+++ b/src/components/report-covers/CoverTemplateFive.tsx
@@ -21,11 +21,21 @@ const CoverTemplateFive: React.FC<CoverTemplateProps> = ({
                                                              clientPhone,
                                                              inspectionDate,
                                                              weatherConditions,
-                                                         }) => (
+                                                             colorScheme,
+                                                         }) => {
+    const primaryColor = colorScheme ? `hsl(${colorScheme.primary})` : 'hsl(210 100% 50%)';
+    const secondaryColor = colorScheme ? `hsl(${colorScheme.secondary})` : 'hsl(210 100% 40%)';
+    const accentColor = colorScheme ? `hsl(${colorScheme.accent})` : 'hsl(210 100% 60%)';
+    const primarySoft = colorScheme ? `hsl(${colorScheme.primary} / 0.05)` : 'hsl(210 100% 50% / 0.05)';
+
+    return (
     <div className="h-full grid lg:grid-cols-[320px_1fr]">
-        <aside className="bg-emerald-700 text-white p-8 flex flex-col items-center justify-center">
+        <aside
+            className="text-white p-8 flex flex-col items-center justify-center"
+            style={{ background: `linear-gradient(180deg, ${primaryColor}, ${secondaryColor})` }}
+        >
             {organizationLogo && <img src={organizationLogo} alt="" className="h-24 mb-4 object-contain"/>}
-            <h2 className="text-xl font-semibold text-center">{organizationName}</h2>
+            <h2 className="text-xl font-semibold text-center" style={{ color: 'white' }}>{organizationName}</h2>
             <div className="mt-4 text-sm text-center opacity-90 space-y-1">
                 {organizationAddress && <p>{organizationAddress}</p>}
                 {organizationPhone && <p>{organizationPhone}</p>}
@@ -44,17 +54,17 @@ const CoverTemplateFive: React.FC<CoverTemplateProps> = ({
             </div>
 
             <div className="p-8 grid gap-6">
-                <h1 className="text-3xl font-bold">{reportTitle}</h1>
+                <h1 className="text-3xl font-bold" style={{ color: primaryColor }}>{reportTitle}</h1>
                 <div className="grid md:grid-cols-2 gap-6">
-                    <div className="bg-gray-50 border rounded p-4">
-                        <h3 className="font-semibold mb-2">Inspector</h3>
+                    <div className="border rounded p-4" style={{ backgroundColor: primarySoft, borderColor: primaryColor }}>
+                        <h3 className="font-semibold mb-2" style={{ color: accentColor }}>Inspector</h3>
                         {inspectorName && <p>Name: {inspectorName}</p>}
                         {inspectorLicenseNumber && <p>License: {inspectorLicenseNumber}</p>}
                         {inspectorPhone && <p>Phone: {inspectorPhone}</p>}
                         {inspectorEmail && <p>Email: {inspectorEmail}</p>}
                     </div>
-                    <div className="bg-gray-50 border rounded p-4">
-                        <h3 className="font-semibold mb-2">Client</h3>
+                    <div className="border rounded p-4" style={{ backgroundColor: primarySoft, borderColor: primaryColor }}>
+                        <h3 className="font-semibold mb-2" style={{ color: accentColor }}>Client</h3>
                         {clientName && <p>Name: {clientName}</p>}
                         {clientAddress && <p>Address: {clientAddress}</p>}
                         {clientPhone && <p>Phone: {clientPhone}</p>}
@@ -62,13 +72,14 @@ const CoverTemplateFive: React.FC<CoverTemplateProps> = ({
                     </div>
                 </div>
 
-                <div className="text-sm text-gray-700">
+                <div className="text-sm" style={{ color: secondaryColor }}>
                     {inspectionDate && <p>Inspection Date: {formatShortDate(inspectionDate)}</p>}
                     {weatherConditions && <p>Weather: {weatherConditions}</p>}
                 </div>
             </div>
         </main>
     </div>
-);
+    );
+};
 
 export default CoverTemplateFive;

--- a/src/components/report-covers/CoverTemplateFour.tsx
+++ b/src/components/report-covers/CoverTemplateFour.tsx
@@ -21,8 +21,15 @@ const CoverTemplateFour: React.FC<CoverTemplateProps> = ({
                                                              clientPhone,
                                                              inspectionDate,
                                                              weatherConditions,
-                                                         }) => (
-    <div className="h-full bg-gray-50 flex items-center justify-center p-6">
+                                                             colorScheme,
+                                                         }) => {
+    const primaryColor = colorScheme ? `hsl(${colorScheme.primary})` : 'hsl(210 100% 50%)';
+    const secondaryColor = colorScheme ? `hsl(${colorScheme.secondary})` : 'hsl(210 100% 40%)';
+    const accentColor = colorScheme ? `hsl(${colorScheme.accent})` : 'hsl(210 100% 60%)';
+    const primarySoft = colorScheme ? `hsl(${colorScheme.primary} / 0.1)` : 'hsl(210 100% 50% / 0.1)';
+
+    return (
+    <div className="h-full flex items-center justify-center p-6" style={{ backgroundColor: primarySoft }}>
         <div className="w-full max-w-4xl bg-white rounded-xl shadow-lg overflow-hidden">
             {coverImage && (
                 <img src={coverImage} alt="" className="w-full h-60 object-cover"/>
@@ -32,21 +39,21 @@ const CoverTemplateFour: React.FC<CoverTemplateProps> = ({
                 <div className="flex items-center gap-4 mb-4">
                     {organizationLogo && <img src={organizationLogo} alt="" className="h-12 object-contain"/>}
                     <div>
-                        <h1 className="text-3xl font-bold">{reportTitle}</h1>
-                        {organizationName && <p className="text-sm text-gray-500">{organizationName}</p>}
+                        <h1 className="text-3xl font-bold" style={{ color: primaryColor }}>{reportTitle}</h1>
+                        {organizationName && <p className="text-sm" style={{ color: secondaryColor }}>{organizationName}</p>}
                     </div>
                 </div>
 
                 <div className="grid md:grid-cols-2 gap-6">
-                    <div className="border rounded-lg p-4">
-                        <h2 className="font-semibold mb-2 text-gray-700">Inspector</h2>
+                    <div className="border rounded-lg p-4" style={{ borderColor: primaryColor }}>
+                        <h2 className="font-semibold mb-2" style={{ color: accentColor }}>Inspector</h2>
                         {inspectorName && <p>Name: {inspectorName}</p>}
                         {inspectorLicenseNumber && <p>License: {inspectorLicenseNumber}</p>}
                         {inspectorPhone && <p>Phone: {inspectorPhone}</p>}
                         {inspectorEmail && <p>Email: {inspectorEmail}</p>}
                     </div>
-                    <div className="border rounded-lg p-4">
-                        <h2 className="font-semibold mb-2 text-gray-700">Client</h2>
+                    <div className="border rounded-lg p-4" style={{ borderColor: primaryColor }}>
+                        <h2 className="font-semibold mb-2" style={{ color: accentColor }}>Client</h2>
                         {clientName && <p>Name: {clientName}</p>}
                         {clientAddress && <p>Address: {clientAddress}</p>}
                         {clientPhone && <p>Phone: {clientPhone}</p>}
@@ -54,12 +61,12 @@ const CoverTemplateFour: React.FC<CoverTemplateProps> = ({
                     </div>
                 </div>
 
-                <div className="mt-6 text-sm text-gray-600">
+                <div className="mt-6 text-sm" style={{ color: secondaryColor }}>
                     {inspectionDate && <p>Inspection Date: {formatShortDate(inspectionDate)}</p>}
                     {weatherConditions && <p>Weather: {weatherConditions}</p>}
                 </div>
 
-                <div className="mt-6 text-sm text-gray-700">
+                <div className="mt-6 text-sm" style={{ color: secondaryColor }}>
                     {organizationAddress && <p>{organizationAddress}</p>}
                     {(organizationPhone || organizationEmail || organizationWebsite) && (
                         <p className="mt-1">
@@ -74,6 +81,7 @@ const CoverTemplateFour: React.FC<CoverTemplateProps> = ({
             </div>
         </div>
     </div>
-);
+    );
+};
 
 export default CoverTemplateFour;

--- a/src/components/report-covers/CoverTemplateThree.tsx
+++ b/src/components/report-covers/CoverTemplateThree.tsx
@@ -22,9 +22,16 @@ const CoverTemplateThree: React.FC<CoverTemplateProps & { className?: string }> 
                                                                                        clientPhone,
                                                                                        inspectionDate,
                                                                                        weatherConditions,
+                                                                                       colorScheme,
                                                                                        className,
                                                                                    }) => {
     const year = inspectionDate ? new Date(inspectionDate).getFullYear() : undefined;
+    const primaryColor = colorScheme ? `hsl(${colorScheme.primary})` : 'hsl(210 100% 50%)';
+    const secondaryColor = colorScheme ? `hsl(${colorScheme.secondary})` : 'hsl(210 100% 40%)';
+    const accentColor = colorScheme ? `hsl(${colorScheme.accent})` : 'hsl(210 100% 60%)';
+    const primarySoft = colorScheme ? `hsl(${colorScheme.primary} / 0.1)` : 'hsl(210 100% 50% / 0.1)';
+    const primaryTrans = colorScheme ? `hsl(${colorScheme.primary} / 0.2)` : 'hsl(210 100% 50% / 0.2)';
+    const accentTrans = colorScheme ? `hsl(${colorScheme.accent} / 0.2)` : 'hsl(210 100% 60% / 0.2)';
 
     return (
         <div
@@ -36,9 +43,13 @@ const CoverTemplateThree: React.FC<CoverTemplateProps & { className?: string }> 
         >
             {/* decor */}
             <div
-                className="pointer-events-none absolute -right-1/3 -top-1/3 w-[900px] h-[900px] rounded-full bg-gradient-to-tr from-sky-200 via-cyan-200 to-white"/>
+                className="pointer-events-none absolute -right-1/3 -top-1/3 w-[900px] h-[900px] rounded-full"
+                style={{ background: `radial-gradient(circle at center, ${primaryTrans}, ${accentTrans}, transparent 70%)` }}
+            />
             <div
-                className="pointer-events-none absolute -right-10 top-10 w-[280px] h-[280px] rounded-full border-[24px] border-sky-400/20"/>
+                className="pointer-events-none absolute -right-10 top-10 w-[280px] h-[280px] rounded-full border-[24px]"
+                style={{ borderColor: primaryTrans }}
+            />
 
             {/* page container */}
             <div className="relative z-10 mx-auto max-w-6xl p-6 md:p-10 flex flex-col min-h-full">
@@ -47,16 +58,22 @@ const CoverTemplateThree: React.FC<CoverTemplateProps & { className?: string }> 
                     <div className="flex items-center gap-3">
                         {organizationLogo && <img src={organizationLogo} alt="" className="h-10 w-10 object-contain"/>}
                         {organizationName && (
-                            <span className="text-sm font-semibold tracking-wide uppercase text-slate-600">
-                {organizationName}
-              </span>
+                            <span
+                                className="text-sm font-semibold tracking-wide uppercase"
+                                style={{ color: secondaryColor }}
+                            >
+                                {organizationName}
+                            </span>
                         )}
                     </div>
                     <div className="ml-auto flex items-center gap-2">
                         {year && (
-                            <span className="px-3 py-1 rounded-full bg-slate-100 text-slate-800 text-sm font-semibold">
-                {year}
-              </span>
+                            <span
+                                className="px-3 py-1 rounded-full text-sm font-semibold"
+                                style={{ backgroundColor: primarySoft, color: primaryColor }}
+                            >
+                                {year}
+                            </span>
                         )}
                     </div>
                 </div>
@@ -64,18 +81,22 @@ const CoverTemplateThree: React.FC<CoverTemplateProps & { className?: string }> 
                 {/* Title + hero image */}
                 <div className="mt-6 grid gap-8 md:grid-cols-[1.25fr_1fr] items-center">
                     <div>
-                        <h1 className="text-4xl md:text-5xl font-extrabold leading-tight">{reportTitle}</h1>
-                        <div className="mt-4 flex flex-wrap gap-2 text-sm text-slate-600">
+                        <h1 className="text-4xl md:text-5xl font-extrabold leading-tight" style={{ color: primaryColor }}>{reportTitle}</h1>
+                        <div className="mt-4 flex flex-wrap gap-2 text-sm" style={{ color: secondaryColor }}>
                             {inspectionDate && (
-                                <span className="px-2 py-1 rounded bg-slate-100">
-                  Date: {formatShortDate(inspectionDate)}
-                </span>
+                                <span className="px-2 py-1 rounded" style={{ backgroundColor: primarySoft }}>
+                                    Date: {formatShortDate(inspectionDate)}
+                                </span>
                             )}
                             {weatherConditions && (
-                                <span className="px-2 py-1 rounded bg-slate-100">Weather: {weatherConditions}</span>
+                                <span className="px-2 py-1 rounded" style={{ backgroundColor: primarySoft }}>
+                                    Weather: {weatherConditions}
+                                </span>
                             )}
                             {clientAddress && (
-                                <span className="px-2 py-1 rounded bg-slate-100">Property: {clientAddress}</span>
+                                <span className="px-2 py-1 rounded" style={{ backgroundColor: primarySoft }}>
+                                    Property: {clientAddress}
+                                </span>
                             )}
                         </div>
                     </div>
@@ -92,8 +113,8 @@ const CoverTemplateThree: React.FC<CoverTemplateProps & { className?: string }> 
                 {/* Cards (Client & Inspector only) */}
                 <div className="mt-8 grid grid-cols-1 md:grid-cols-2 gap-6">
                     {/* Client */}
-                    <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-                        <div className="text-xs font-semibold tracking-wide text-sky-700 uppercase">Client</div>
+                    <div className="rounded-xl border bg-white p-5 shadow-sm" style={{ borderColor: primarySoft }}>
+                        <div className="text-xs font-semibold tracking-wide uppercase" style={{ color: primaryColor }}>Client</div>
                         <dl className="mt-2 grid grid-cols-[88px_1fr] gap-y-1.5 text-sm">
                             {clientName && (
                                 <>
@@ -117,8 +138,8 @@ const CoverTemplateThree: React.FC<CoverTemplateProps & { className?: string }> 
                     </div>
 
                     {/* Inspector */}
-                    <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-                        <div className="text-xs font-semibold tracking-wide text-emerald-700 uppercase">Inspector</div>
+                    <div className="rounded-xl border bg-white p-5 shadow-sm" style={{ borderColor: primarySoft }}>
+                        <div className="text-xs font-semibold tracking-wide uppercase" style={{ color: accentColor }}>Inspector</div>
                         <dl className="mt-2 grid grid-cols-[88px_1fr] gap-y-1.5 text-sm">
                             {inspectorName && (
                                 <>
@@ -153,19 +174,27 @@ const CoverTemplateThree: React.FC<CoverTemplateProps & { className?: string }> 
 
                 {/* Footer: Organization details */}
                 {(organizationAddress || organizationPhone || organizationEmail || organizationWebsite) && (
-                    <footer className="mt-10 border-t border-slate-200 pt-4">
-                        <div className="flex flex-wrap items-center justify-center gap-2 text-sm">
+                    <footer className="mt-10 pt-4" style={{ borderTop: `1px solid ${primarySoft}` }}>
+                        <div className="flex flex-wrap items-center justify-center gap-2 text-sm" style={{ color: secondaryColor }}>
                             {organizationAddress && (
-                                <span className="px-3 py-1 rounded-full bg-slate-100">{organizationAddress}</span>
+                                <span className="px-3 py-1 rounded-full" style={{ backgroundColor: primarySoft }}>
+                                    {organizationAddress}
+                                </span>
                             )}
                             {organizationPhone && (
-                                <span className="px-3 py-1 rounded-full bg-slate-100">{organizationPhone}</span>
+                                <span className="px-3 py-1 rounded-full" style={{ backgroundColor: primarySoft }}>
+                                    {organizationPhone}
+                                </span>
                             )}
                             {organizationEmail && (
-                                <span className="px-3 py-1 rounded-full bg-slate-100">{organizationEmail}</span>
+                                <span className="px-3 py-1 rounded-full" style={{ backgroundColor: primarySoft }}>
+                                    {organizationEmail}
+                                </span>
                             )}
                             {organizationWebsite && (
-                                <span className="px-3 py-1 rounded-full bg-slate-100">{organizationWebsite}</span>
+                                <span className="px-3 py-1 rounded-full" style={{ backgroundColor: primarySoft }}>
+                                    {organizationWebsite}
+                                </span>
                             )}
                         </div>
                     </footer>

--- a/src/components/report-covers/CoverTemplateTwo.tsx
+++ b/src/components/report-covers/CoverTemplateTwo.tsx
@@ -22,8 +22,20 @@ const CoverTemplateTwo: React.FC<CoverTemplateProps> = ({
                                                             clientPhone,
                                                             inspectionDate,
                                                             weatherConditions,
-                                                        }) => (
-    <div className="h-full bg-slate-900 text-white flex flex-col">
+                                                            colorScheme,
+                                                         }) => {
+    const primaryColor = colorScheme ? `hsl(${colorScheme.primary})` : 'hsl(210 100% 50%)';
+    const secondaryColor = colorScheme ? `hsl(${colorScheme.secondary})` : 'hsl(210 100% 40%)';
+    const accentColor = colorScheme ? `hsl(${colorScheme.accent})` : 'hsl(210 100% 60%)';
+
+    return (
+        <div
+            className="h-full flex flex-col"
+            style={{
+                background: `linear-gradient(135deg, ${primaryColor}, ${secondaryColor})`,
+                color: 'white',
+            }}
+        >
         {/* Header: logo + title */}
         <header className="px-6 pt-10 flex flex-col items-center text-center">
             {organizationLogo && (
@@ -38,10 +50,13 @@ const CoverTemplateTwo: React.FC<CoverTemplateProps> = ({
                 {coverImage ? (
                     <img src={coverImage} alt="" className="w-full h-full object-cover"/>
                 ) : (
-                    <div className="w-full h-full bg-slate-700"/>
+                    <div className="w-full h-full bg-black/20"/>
                 )}
                 {/* Subtle overlay to normalize poor images */}
-                <div className="absolute inset-0 bg-black/35"/>
+                <div
+                    className="absolute inset-0"
+                    style={{ backgroundColor: `hsl(${colorScheme?.secondary || '210 100% 40%'} / 0.35)` }}
+                />
             </div>
         </section>
 
@@ -49,14 +64,14 @@ const CoverTemplateTwo: React.FC<CoverTemplateProps> = ({
         <main className="flex-1 px-6 py-8 flex flex-col items-center">
             <div className="grid gap-6 md:grid-cols-2 w-full max-w-5xl">
                 <div className="bg-white/10 rounded-lg p-5">
-                    <h2 className="font-semibold mb-2 uppercase tracking-wide">Inspector</h2>
+                    <h2 className="font-semibold mb-2 uppercase tracking-wide" style={{ color: accentColor }}>Inspector</h2>
                     {inspectorName && <p>Name: {inspectorName}</p>}
                     {inspectorLicenseNumber && <p>License: {inspectorLicenseNumber}</p>}
                     {inspectorPhone && <p>Phone: {inspectorPhone}</p>}
                     {inspectorEmail && <p>Email: {inspectorEmail}</p>}
                 </div>
                 <div className="bg-white/10 rounded-lg p-5">
-                    <h2 className="font-semibold mb-2 uppercase tracking-wide">Client</h2>
+                    <h2 className="font-semibold mb-2 uppercase tracking-wide" style={{ color: accentColor }}>Client</h2>
                     {clientName && <p>Name: {clientName}</p>}
                     {clientAddress && <p>Address: {clientAddress}</p>}
                     {clientPhone && <p>Phone: {clientPhone}</p>}
@@ -84,7 +99,8 @@ const CoverTemplateTwo: React.FC<CoverTemplateProps> = ({
                 </p>
             )}
         </footer>
-    </div>
-);
+        </div>
+    );
+};
 
 export default CoverTemplateTwo;


### PR DESCRIPTION
## Summary
- allow color picker control for cover templates two through five
- style headings and backgrounds using selected scheme
- support gradient and soft accents for consistent theming

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 183 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3196a30e48333ad2a911aefffb926