### PR TITLE
feat: expand cover templates

### DIFF
--- a/src/components/report-covers/CoverTemplateEight.tsx
+++ b/src/components/report-covers/CoverTemplateEight.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { CoverTemplateProps } from "./types";
+import { formatShortDate } from "../../utils/formatDate";
+
+// Geometric template with diagonal stripes
+
+const CoverTemplateEight: React.FC<CoverTemplateProps> = ({
+  reportTitle,
+  coverImage,
+  organizationName,
+  organizationAddress,
+  organizationPhone,
+  organizationEmail,
+  organizationWebsite,
+  organizationLogo,
+  inspectorName,
+  inspectorLicenseNumber,
+  inspectorPhone,
+  inspectorEmail,
+  clientName,
+  clientAddress,
+  clientEmail,
+  clientPhone,
+  inspectionDate,
+  weatherConditions,
+  colorScheme,
+}) => {
+  const primaryColor = colorScheme ? `hsl(${colorScheme.primary})` : "hsl(340 80% 50%)";
+  const secondaryColor = colorScheme ? `hsl(${colorScheme.secondary})` : "hsl(340 80% 40%)";
+  const accentColor = colorScheme ? `hsl(${colorScheme.accent})` : "hsl(340 80% 60%)";
+
+  return (
+    <div className="h-full flex flex-col text-white" style={{ backgroundColor: primaryColor }}>
+      <div className="relative flex-1 p-10 flex flex-col items-center text-center">
+        <div
+          className="absolute inset-0 opacity-20"
+          style={{
+            backgroundImage:
+              "repeating-linear-gradient(45deg, white 0, white 20px, transparent 20px, transparent 40px)",
+          }}
+        />
+        {coverImage && (
+          <img
+            src={coverImage}
+            alt=""
+            className="w-full max-h-64 object-cover rounded border-4 border-white/20"
+          />
+        )}
+        <h1 className="mt-6 text-4xl font-bold drop-shadow-lg">{reportTitle}</h1>
+        {organizationLogo && (
+          <img src={organizationLogo} alt="" className="h-16 mt-4 object-contain bg-white/10 p-2 rounded" />
+        )}
+        <div className="mt-2 text-sm space-y-1">
+          {organizationName && <p className="font-semibold">{organizationName}</p>}
+          {organizationAddress && <p>{organizationAddress}</p>}
+          {organizationPhone && <p>{organizationPhone}</p>}
+          {organizationEmail && <p>{organizationEmail}</p>}
+          {organizationWebsite && <p>{organizationWebsite}</p>}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 p-8" style={{ backgroundColor: secondaryColor }}>
+        <div>
+          <h2 className="font-semibold mb-2" style={{ color: accentColor }}>Inspector</h2>
+          {inspectorName && <p>Name: {inspectorName}</p>}
+          {inspectorLicenseNumber && <p>License: {inspectorLicenseNumber}</p>}
+          {inspectorPhone && <p>Phone: {inspectorPhone}</p>}
+          {inspectorEmail && <p>Email: {inspectorEmail}</p>}
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2" style={{ color: accentColor }}>Client</h2>
+          {clientName && <p>Name: {clientName}</p>}
+          {clientAddress && <p>Address: {clientAddress}</p>}
+          {clientPhone && <p>Phone: {clientPhone}</p>}
+          {clientEmail && <p>Email: {clientEmail}</p>}
+        </div>
+      </div>
+
+      <div className="text-sm text-center p-4" style={{ backgroundColor: accentColor }}>
+        {inspectionDate && <p>Inspection Date: {formatShortDate(inspectionDate)}</p>}
+        {weatherConditions && <p>Weather: {weatherConditions}</p>}
+      </div>
+    </div>
+  );
+};
+
+export default CoverTemplateEight;

--- a/src/components/report-covers/CoverTemplateNine.tsx
+++ b/src/components/report-covers/CoverTemplateNine.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { CoverTemplateProps } from "./types";
+import { formatShortDate } from "../../utils/formatDate";
+
+// Free-flow template with wave overlays
+
+const CoverTemplateNine: React.FC<CoverTemplateProps> = ({
+  reportTitle,
+  coverImage,
+  organizationName,
+  organizationAddress,
+  organizationPhone,
+  organizationEmail,
+  organizationWebsite,
+  organizationLogo,
+  inspectorName,
+  inspectorLicenseNumber,
+  inspectorPhone,
+  inspectorEmail,
+  clientName,
+  clientAddress,
+  clientEmail,
+  clientPhone,
+  inspectionDate,
+  weatherConditions,
+  colorScheme,
+}) => {
+  const primaryColor = colorScheme ? `hsl(${colorScheme.primary})` : "hsl(190 80% 40%)";
+  const secondaryColor = colorScheme ? `hsl(${colorScheme.secondary})` : "hsl(190 80% 30%)";
+  const accentColor = colorScheme ? `hsl(${colorScheme.accent})` : "hsl(190 80% 50%)";
+
+  return (
+    <div className="h-full flex flex-col text-white" style={{ backgroundColor: primaryColor }}>
+      <div className="relative flex-1 p-10 flex flex-col items-center text-center overflow-hidden">
+        <svg className="absolute top-0 left-0 w-full" viewBox="0 0 1440 320" preserveAspectRatio="none">
+          <path fill={secondaryColor} d="M0,32L48,58.7C96,85,192,139,288,165.3C384,192,480,192,576,186.7C672,181,768,171,864,165.3C960,160,1056,160,1152,154.7C1248,149,1344,139,1392,133.3L1440,128L1440,0L1392,0C1344,0,1248,0,1152,0C1056,0,960,0,864,0C768,0,672,0,576,0C480,0,384,0,288,0C192,0,96,0,48,0L0,0Z" />
+        </svg>
+        <svg className="absolute bottom-0 left-0 w-full" viewBox="0 0 1440 320" preserveAspectRatio="none">
+          <path fill={secondaryColor} d="M0,288L48,272C96,256,192,224,288,197.3C384,171,480,149,576,133.3C672,117,768,107,864,128C960,149,1056,203,1152,229.3C1248,256,1344,256,1392,256L1440,256L1440,320L1392,320C1344,320,1248,320,1152,320C1056,320,960,320,864,320C768,320,672,320,576,320C480,320,384,320,288,320C192,320,96,320,48,320L0,320Z" />
+        </svg>
+        {coverImage && (
+          <img
+            src={coverImage}
+            alt=""
+            className="w-full max-h-64 object-cover rounded border-4 border-white/20 z-10"
+          />
+        )}
+        <h1 className="mt-6 text-4xl font-bold drop-shadow-lg z-10">{reportTitle}</h1>
+        {organizationLogo && (
+          <img src={organizationLogo} alt="" className="h-16 mt-4 object-contain bg-white/10 p-2 rounded z-10" />
+        )}
+        <div className="mt-2 text-sm space-y-1 z-10">
+          {organizationName && <p className="font-semibold">{organizationName}</p>}
+          {organizationAddress && <p>{organizationAddress}</p>}
+          {organizationPhone && <p>{organizationPhone}</p>}
+          {organizationEmail && <p>{organizationEmail}</p>}
+          {organizationWebsite && <p>{organizationWebsite}</p>}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 p-8" style={{ backgroundColor: secondaryColor }}>
+        <div>
+          <h2 className="font-semibold mb-2" style={{ color: accentColor }}>Inspector</h2>
+          {inspectorName && <p>Name: {inspectorName}</p>}
+          {inspectorLicenseNumber && <p>License: {inspectorLicenseNumber}</p>}
+          {inspectorPhone && <p>Phone: {inspectorPhone}</p>}
+          {inspectorEmail && <p>Email: {inspectorEmail}</p>}
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2" style={{ color: accentColor }}>Client</h2>
+          {clientName && <p>Name: {clientName}</p>}
+          {clientAddress && <p>Address: {clientAddress}</p>}
+          {clientPhone && <p>Phone: {clientPhone}</p>}
+          {clientEmail && <p>Email: {clientEmail}</p>}
+        </div>
+      </div>
+
+      <div className="text-sm text-center p-4" style={{ backgroundColor: accentColor }}>
+        {inspectionDate && <p>Inspection Date: {formatShortDate(inspectionDate)}</p>}
+        {weatherConditions && <p>Weather: {weatherConditions}</p>}
+      </div>
+    </div>
+  );
+};
+
+export default CoverTemplateNine;

--- a/src/components/report-covers/CoverTemplateOne.tsx
+++ b/src/components/report-covers/CoverTemplateOne.tsx
@@ -23,9 +23,9 @@ const CoverTemplateOne: React.FC<CoverTemplateProps> = ({
                                                              weatherConditions,
                                                              colorScheme,
                                                          }) => {
-    const primaryColor = colorScheme ? `hsl(${colorScheme.primary})` : 'hsl(210 100% 50%)';
-    const secondaryColor = colorScheme ? `hsl(${colorScheme.secondary})` : 'hsl(210 100% 40%)';
-    const accentColor = colorScheme ? `hsl(${colorScheme.accent})` : 'hsl(210 100% 60%)';
+    const primaryColor = colorScheme ? `hsl(${colorScheme.primary})` : 'hsl(150 100% 40%)';
+    const secondaryColor = colorScheme ? `hsl(${colorScheme.secondary})` : 'hsl(150 100% 30%)';
+    const accentColor = colorScheme ? `hsl(${colorScheme.accent})` : 'hsl(150 100% 50%)';
 
     return (
     <div className="h-full flex flex-col p-10" style={{ background: `linear-gradient(135deg, ${primaryColor}, ${accentColor})`, color: 'white' }}>

--- a/src/components/report-covers/CoverTemplateSeven.tsx
+++ b/src/components/report-covers/CoverTemplateSeven.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { CoverTemplateProps } from "./types";
+import { formatShortDate } from "../../utils/formatDate";
+
+// Geometric template with grid pattern
+
+const CoverTemplateSeven: React.FC<CoverTemplateProps> = ({
+  reportTitle,
+  coverImage,
+  organizationName,
+  organizationAddress,
+  organizationPhone,
+  organizationEmail,
+  organizationWebsite,
+  organizationLogo,
+  inspectorName,
+  inspectorLicenseNumber,
+  inspectorPhone,
+  inspectorEmail,
+  clientName,
+  clientAddress,
+  clientEmail,
+  clientPhone,
+  inspectionDate,
+  weatherConditions,
+  colorScheme,
+}) => {
+  const primaryColor = colorScheme ? `hsl(${colorScheme.primary})` : "hsl(280 70% 50%)";
+  const secondaryColor = colorScheme ? `hsl(${colorScheme.secondary})` : "hsl(280 70% 40%)";
+  const accentColor = colorScheme ? `hsl(${colorScheme.accent})` : "hsl(280 70% 60%)";
+
+  return (
+    <div className="h-full flex flex-col text-white" style={{ backgroundColor: primaryColor }}>
+      <div className="relative flex-1 p-10 flex flex-col items-center text-center">
+        <div
+          className="absolute inset-0 opacity-20"
+          style={{
+            backgroundImage:
+              "linear-gradient(to right, white 1px, transparent 1px), linear-gradient(to bottom, white 1px, transparent 1px)",
+            backgroundSize: "40px 40px",
+          }}
+        />
+        {coverImage && (
+          <img
+            src={coverImage}
+            alt=""
+            className="w-full max-h-64 object-cover rounded border-4 border-white/20"
+          />
+        )}
+        <h1 className="mt-6 text-4xl font-bold drop-shadow-lg">{reportTitle}</h1>
+        {organizationLogo && (
+          <img src={organizationLogo} alt="" className="h-16 mt-4 object-contain bg-white/10 p-2 rounded" />
+        )}
+        <div className="mt-2 text-sm space-y-1">
+          {organizationName && <p className="font-semibold">{organizationName}</p>}
+          {organizationAddress && <p>{organizationAddress}</p>}
+          {organizationPhone && <p>{organizationPhone}</p>}
+          {organizationEmail && <p>{organizationEmail}</p>}
+          {organizationWebsite && <p>{organizationWebsite}</p>}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 p-8" style={{ backgroundColor: secondaryColor }}>
+        <div>
+          <h2 className="font-semibold mb-2" style={{ color: accentColor }}>Inspector</h2>
+          {inspectorName && <p>Name: {inspectorName}</p>}
+          {inspectorLicenseNumber && <p>License: {inspectorLicenseNumber}</p>}
+          {inspectorPhone && <p>Phone: {inspectorPhone}</p>}
+          {inspectorEmail && <p>Email: {inspectorEmail}</p>}
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2" style={{ color: accentColor }}>Client</h2>
+          {clientName && <p>Name: {clientName}</p>}
+          {clientAddress && <p>Address: {clientAddress}</p>}
+          {clientPhone && <p>Phone: {clientPhone}</p>}
+          {clientEmail && <p>Email: {clientEmail}</p>}
+        </div>
+      </div>
+
+      <div className="text-sm text-center p-4" style={{ backgroundColor: accentColor }}>
+        {inspectionDate && <p>Inspection Date: {formatShortDate(inspectionDate)}</p>}
+        {weatherConditions && <p>Weather: {weatherConditions}</p>}
+      </div>
+    </div>
+  );
+};
+
+export default CoverTemplateSeven;

--- a/src/components/report-covers/CoverTemplateSix.tsx
+++ b/src/components/report-covers/CoverTemplateSix.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { CoverTemplateProps } from "./types";
+import { formatShortDate } from "../../utils/formatDate";
+
+// Geometric template with corner diamonds
+
+const CoverTemplateSix: React.FC<CoverTemplateProps> = ({
+  reportTitle,
+  coverImage,
+  organizationName,
+  organizationAddress,
+  organizationPhone,
+  organizationEmail,
+  organizationWebsite,
+  organizationLogo,
+  inspectorName,
+  inspectorLicenseNumber,
+  inspectorPhone,
+  inspectorEmail,
+  clientName,
+  clientAddress,
+  clientEmail,
+  clientPhone,
+  inspectionDate,
+  weatherConditions,
+  colorScheme,
+}) => {
+  const primaryColor = colorScheme ? `hsl(${colorScheme.primary})` : "hsl(24 85% 55%)";
+  const secondaryColor = colorScheme ? `hsl(${colorScheme.secondary})` : "hsl(24 85% 45%)";
+  const accentColor = colorScheme ? `hsl(${colorScheme.accent})` : "hsl(24 85% 65%)";
+
+  return (
+    <div className="h-full flex flex-col text-white" style={{ backgroundColor: primaryColor }}>
+      <div className="relative flex-1 p-10 flex flex-col items-center text-center">
+        <div className="absolute inset-0 overflow-hidden">
+          <div className="absolute w-64 h-64 bg-white/10 rotate-45 -left-16 -top-16" />
+          <div className="absolute w-64 h-64 bg-white/10 rotate-45 right-16 bottom-16" />
+        </div>
+        {coverImage && (
+          <img
+            src={coverImage}
+            alt=""
+            className="w-full max-h-64 object-cover rounded border-4 border-white/20"
+          />
+        )}
+        <h1 className="mt-6 text-4xl font-bold drop-shadow-lg">{reportTitle}</h1>
+        {organizationLogo && (
+          <img src={organizationLogo} alt="" className="h-16 mt-4 object-contain bg-white/10 p-2 rounded" />
+        )}
+        <div className="mt-2 text-sm space-y-1">
+          {organizationName && <p className="font-semibold">{organizationName}</p>}
+          {organizationAddress && <p>{organizationAddress}</p>}
+          {organizationPhone && <p>{organizationPhone}</p>}
+          {organizationEmail && <p>{organizationEmail}</p>}
+          {organizationWebsite && <p>{organizationWebsite}</p>}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 p-8" style={{ backgroundColor: secondaryColor }}>
+        <div>
+          <h2 className="font-semibold mb-2" style={{ color: accentColor }}>Inspector</h2>
+          {inspectorName && <p>Name: {inspectorName}</p>}
+          {inspectorLicenseNumber && <p>License: {inspectorLicenseNumber}</p>}
+          {inspectorPhone && <p>Phone: {inspectorPhone}</p>}
+          {inspectorEmail && <p>Email: {inspectorEmail}</p>}
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2" style={{ color: accentColor }}>Client</h2>
+          {clientName && <p>Name: {clientName}</p>}
+          {clientAddress && <p>Address: {clientAddress}</p>}
+          {clientPhone && <p>Phone: {clientPhone}</p>}
+          {clientEmail && <p>Email: {clientEmail}</p>}
+        </div>
+      </div>
+
+      <div className="text-sm text-center p-4" style={{ backgroundColor: accentColor }}>
+        {inspectionDate && <p>Inspection Date: {formatShortDate(inspectionDate)}</p>}
+        {weatherConditions && <p>Weather: {weatherConditions}</p>}
+      </div>
+    </div>
+  );
+};
+
+export default CoverTemplateSix;

--- a/src/components/report-covers/CoverTemplateTen.tsx
+++ b/src/components/report-covers/CoverTemplateTen.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { CoverTemplateProps } from "./types";
+import { formatShortDate } from "../../utils/formatDate";
+
+// Free-flow template with blurred blob shapes
+
+const CoverTemplateTen: React.FC<CoverTemplateProps> = ({
+  reportTitle,
+  coverImage,
+  organizationName,
+  organizationAddress,
+  organizationPhone,
+  organizationEmail,
+  organizationWebsite,
+  organizationLogo,
+  inspectorName,
+  inspectorLicenseNumber,
+  inspectorPhone,
+  inspectorEmail,
+  clientName,
+  clientAddress,
+  clientEmail,
+  clientPhone,
+  inspectionDate,
+  weatherConditions,
+  colorScheme,
+}) => {
+  const primaryColor = colorScheme ? `hsl(${colorScheme.primary})` : "hsl(40 90% 45%)";
+  const secondaryColor = colorScheme ? `hsl(${colorScheme.secondary})` : "hsl(40 90% 35%)";
+  const accentColor = colorScheme ? `hsl(${colorScheme.accent})` : "hsl(40 90% 55%)";
+
+  return (
+    <div className="h-full flex flex-col text-white" style={{ backgroundColor: primaryColor }}>
+      <div className="relative flex-1 p-10 flex flex-col items-center text-center overflow-hidden">
+        <div className="absolute -top-20 -left-20 w-96 h-96 bg-white/20 rounded-[60%] blur-3xl" />
+        <div className="absolute bottom-0 right-0 w-96 h-96 bg-white/20 rounded-[70%] blur-3xl" />
+        {coverImage && (
+          <img
+            src={coverImage}
+            alt=""
+            className="w-full max-h-64 object-cover rounded border-4 border-white/20"
+          />
+        )}
+        <h1 className="mt-6 text-4xl font-bold drop-shadow-lg">{reportTitle}</h1>
+        {organizationLogo && (
+          <img src={organizationLogo} alt="" className="h-16 mt-4 object-contain bg-white/10 p-2 rounded" />
+        )}
+        <div className="mt-2 text-sm space-y-1">
+          {organizationName && <p className="font-semibold">{organizationName}</p>}
+          {organizationAddress && <p>{organizationAddress}</p>}
+          {organizationPhone && <p>{organizationPhone}</p>}
+          {organizationEmail && <p>{organizationEmail}</p>}
+          {organizationWebsite && <p>{organizationWebsite}</p>}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 p-8" style={{ backgroundColor: secondaryColor }}>
+        <div>
+          <h2 className="font-semibold mb-2" style={{ color: accentColor }}>Inspector</h2>
+          {inspectorName && <p>Name: {inspectorName}</p>}
+          {inspectorLicenseNumber && <p>License: {inspectorLicenseNumber}</p>}
+          {inspectorPhone && <p>Phone: {inspectorPhone}</p>}
+          {inspectorEmail && <p>Email: {inspectorEmail}</p>}
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2" style={{ color: accentColor }}>Client</h2>
+          {clientName && <p>Name: {clientName}</p>}
+          {clientAddress && <p>Address: {clientAddress}</p>}
+          {clientPhone && <p>Phone: {clientPhone}</p>}
+          {clientEmail && <p>Email: {clientEmail}</p>}
+        </div>
+      </div>
+
+      <div className="text-sm text-center p-4" style={{ backgroundColor: accentColor }}>
+        {inspectionDate && <p>Inspection Date: {formatShortDate(inspectionDate)}</p>}
+        {weatherConditions && <p>Weather: {weatherConditions}</p>}
+      </div>
+    </div>
+  );
+};
+
+export default CoverTemplateTen;

--- a/src/constants/coverTemplates.ts
+++ b/src/constants/coverTemplates.ts
@@ -3,6 +3,11 @@ import CoverTemplateTwo from "@/components/report-covers/CoverTemplateTwo";
 import CoverTemplateThree from "@/components/report-covers/CoverTemplateThree";
 import CoverTemplateFour from "@/components/report-covers/CoverTemplateFour";
 import CoverTemplateFive from "@/components/report-covers/CoverTemplateFive";
+import CoverTemplateSix from "@/components/report-covers/CoverTemplateSix";
+import CoverTemplateSeven from "@/components/report-covers/CoverTemplateSeven";
+import CoverTemplateEight from "@/components/report-covers/CoverTemplateEight";
+import CoverTemplateNine from "@/components/report-covers/CoverTemplateNine";
+import CoverTemplateTen from "@/components/report-covers/CoverTemplateTen";
 
 export const COVER_TEMPLATES = {
   templateOne: { label: "Template One", component: CoverTemplateOne },
@@ -10,6 +15,11 @@ export const COVER_TEMPLATES = {
   templateThree: { label: "Template Three", component: CoverTemplateThree },
   templateFour: { label: "Template Four", component: CoverTemplateFour },
   templateFive: { label: "Template Five", component: CoverTemplateFive },
+  templateSix: { label: "Template Six", component: CoverTemplateSix },
+  templateSeven: { label: "Template Seven", component: CoverTemplateSeven },
+  templateEight: { label: "Template Eight", component: CoverTemplateEight },
+  templateNine: { label: "Template Nine", component: CoverTemplateNine },
+  templateTen: { label: "Template Ten", component: CoverTemplateTen },
 } as const;
 
 export type CoverTemplateId = keyof typeof COVER_TEMPLATES;


### PR DESCRIPTION
## Summary
- switch CoverTemplateOne default palette to green
- register five new cover templates featuring geometric and free-flow shapes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b31c3b8aa083339ad5c1b52f872442