### PR TITLE
feat: allow custom report color scheme

### DIFF
--- a/src/components/reports/PDFDocument.tsx
+++ b/src/components/reports/PDFDocument.tsx
@@ -72,17 +72,23 @@ const PDFDocument = React.forwardRef<HTMLDivElement, PDFDocumentProps>(
         return (
             <div ref={ref} className="pdf-document">
                 <section className="pdf-page-break">
-                    <CoverComponent 
+                    <CoverComponent
                         reportTitle={report.title}
                         clientName={report.clientName}
                         coverImage={coverUrl}
                         organizationName={company}
                         inspectionDate={report.inspectionDate}
-                        colorScheme={report.colorScheme ? {
-                            primary: COLOR_SCHEMES[report.colorScheme].primary,
-                            secondary: COLOR_SCHEMES[report.colorScheme].secondary,
-                            accent: COLOR_SCHEMES[report.colorScheme].accent
-                        } : undefined}
+                        colorScheme={
+                            report.colorScheme === "custom"
+                                ? report.customColors || undefined
+                                : report.colorScheme
+                                ? {
+                                      primary: COLOR_SCHEMES[report.colorScheme].primary,
+                                      secondary: COLOR_SCHEMES[report.colorScheme].secondary,
+                                      accent: COLOR_SCHEMES[report.colorScheme].accent,
+                                  }
+                                : undefined
+                        }
                     />
                 </section>
 

--- a/src/components/ui/color-scheme-picker.tsx
+++ b/src/components/ui/color-scheme-picker.tsx
@@ -49,33 +49,114 @@ export const COLOR_SCHEMES = {
   }
 } as const;
 
-export type ColorScheme = keyof typeof COLOR_SCHEMES;
+export interface CustomColors {
+  primary: string;
+  secondary: string;
+  accent: string;
+}
+
+export type ColorScheme = keyof typeof COLOR_SCHEMES | "custom";
 
 interface ColorSchemePickerProps {
   value: ColorScheme;
-  onChange: (scheme: ColorScheme) => void;
+  onChange: (scheme: ColorScheme, customColors?: CustomColors) => void;
   disabled?: boolean;
+  customColors?: CustomColors;
 }
 
-export function ColorSchemePicker({ value, onChange, disabled }: ColorSchemePickerProps) {
+export function ColorSchemePicker({ value, onChange, disabled, customColors }: ColorSchemePickerProps) {
   const [open, setOpen] = React.useState(false);
-  
-  const currentScheme = COLOR_SCHEMES[value];
+  const [showCustom, setShowCustom] = React.useState(false);
+  const [custom, setCustom] = React.useState<CustomColors>(
+    customColors || { primary: "210 100% 50%", secondary: "210 100% 40%", accent: "210 100% 60%" }
+  );
 
   React.useEffect(() => {
-    // Remove global CSS variable setting - we'll pass colors as props instead
-  }, [value]);
+    if (customColors) setCustom(customColors);
+  }, [customColors]);
+
+  const currentScheme = value === "custom" ? { name: "Custom", preview: "" } : COLOR_SCHEMES[value];
+
+  const hslToHex = (hsl: string) => {
+    const [h, s, l] = hsl.split(" ").map((v) => parseFloat(v));
+    const sDec = s / 100;
+    const lDec = l / 100;
+    const c = (1 - Math.abs(2 * lDec - 1)) * sDec;
+    const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+    const m = lDec - c / 2;
+    let r = 0,
+      g = 0,
+      b = 0;
+    if (h < 60) {
+      r = c;
+      g = x;
+    } else if (h < 120) {
+      r = x;
+      g = c;
+    } else if (h < 180) {
+      g = c;
+      b = x;
+    } else if (h < 240) {
+      g = x;
+      b = c;
+    } else if (h < 300) {
+      r = x;
+      b = c;
+    } else {
+      r = c;
+      b = x;
+    }
+    const toHex = (n: number) => Math.round((n + m) * 255).toString(16).padStart(2, "0");
+    return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+  };
+
+  const hexToHsl = (hex: string) => {
+    const r = parseInt(hex.slice(1, 3), 16) / 255;
+    const g = parseInt(hex.slice(3, 5), 16) / 255;
+    const b = parseInt(hex.slice(5, 7), 16) / 255;
+    const max = Math.max(r, g, b);
+    const min = Math.min(r, g, b);
+    let h = 0,
+      s = 0;
+    const l = (max + min) / 2;
+    if (max !== min) {
+      const d = max - min;
+      s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+      switch (max) {
+        case r:
+          h = (g - b) / d + (g < b ? 6 : 0);
+          break;
+        case g:
+          h = (b - r) / d + 2;
+          break;
+        case b:
+          h = (r - g) / d + 4;
+          break;
+      }
+      h *= 60;
+    }
+    return `${Math.round(h)} ${Math.round(s * 100)}% ${Math.round(l * 100)}%`;
+  };
+
+  const handleApplyCustom = () => {
+    onChange("custom", custom);
+    setOpen(false);
+    setShowCustom(false);
+  };
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button variant="outline" className="w-[200px] justify-start gap-2" disabled={disabled}>
           <Palette className="h-4 w-4" />
-          <div className={cn("w-4 h-4 rounded-full", currentScheme.preview)} />
+          <div
+            className={cn("w-4 h-4 rounded-full", value === "custom" ? "" : currentScheme.preview)}
+            style={value === "custom" ? { backgroundColor: `hsl(${custom.primary})` } : undefined}
+          />
           {currentScheme.name}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[280px] p-3" align="start">
+      <PopoverContent className="w-[300px] p-3" align="start">
         <div className="space-y-2">
           <h4 className="font-medium text-sm">Color Scheme</h4>
           <div className="grid grid-cols-2 gap-2">
@@ -94,7 +175,33 @@ export function ColorSchemePicker({ value, onChange, disabled }: ColorSchemePick
                 {scheme.name}
               </Button>
             ))}
+            <Button
+              variant={value === "custom" ? "default" : "outline"}
+              size="sm"
+              className="justify-start gap-2 h-9"
+              onClick={() => setShowCustom(!showCustom)}
+            >
+              <div className="w-4 h-4 rounded-full" style={{ backgroundColor: `hsl(${custom.primary})` }} />
+              Custom
+            </Button>
           </div>
+          {showCustom && (
+            <div className="mt-4 space-y-3">
+              {(["primary", "secondary", "accent"] as const).map((key) => (
+                <div key={key} className="flex items-center justify-between gap-2">
+                  <label className="text-xs capitalize w-16">{key}</label>
+                  <input
+                    type="color"
+                    value={hslToHex(custom[key])}
+                    onChange={(e) => setCustom((prev) => ({ ...prev, [key]: hexToHsl(e.target.value) }))}
+                  />
+                </div>
+              ))}
+              <Button size="sm" onClick={handleApplyCustom} className="w-full">
+                Apply
+              </Button>
+            </div>
+          )}
         </div>
       </PopoverContent>
     </Popover>

--- a/src/lib/reportSchemas.ts
+++ b/src/lib/reportSchemas.ts
@@ -59,7 +59,14 @@ export const BaseReportSchema = z.object({
         .enum(["templateOne", "templateTwo", "templateThree", "templateFour", "templateFive"])
         .default("templateOne"),
     previewTemplate: z.enum(["classic", "modern", "minimal"]).default("classic"),
-    colorScheme: z.enum(["blue", "green", "purple", "orange", "red", "slate"]).default("blue"),
+    colorScheme: z.enum(["blue", "green", "purple", "orange", "red", "slate", "custom"]).default("blue"),
+    customColors: z
+        .object({
+            primary: z.string(),
+            secondary: z.string(),
+            accent: z.string(),
+        })
+        .optional(),
     reportType: z.enum(["home_inspection", "wind_mitigation"]),
 });
 

--- a/src/pages/ReportPreview.tsx
+++ b/src/pages/ReportPreview.tsx
@@ -21,7 +21,7 @@ import { fillWindMitigationPDF } from "@/utils/fillWindMitigationPDF";
 import { getMyOrganization, getMyProfile, Organization, Profile } from "@/integrations/supabase/organizationsApi";
 import { COVER_TEMPLATES, CoverTemplateId } from "@/constants/coverTemplates";
 import { CoverTemplateSelector } from "@/components/ui/cover-template-selector";
-import { ColorSchemePicker, ColorScheme, COLOR_SCHEMES } from "@/components/ui/color-scheme-picker";
+import { ColorSchemePicker, ColorScheme, COLOR_SCHEMES, CustomColors } from "@/components/ui/color-scheme-picker";
 
 function SeverityBadge({
   severity,
@@ -179,11 +179,15 @@ const ReportPreview: React.FC = () => {
     }
   };
 
-  const handleColorSchemeChange = async (scheme: ColorScheme) => {
+  const handleColorSchemeChange = async (scheme: ColorScheme, colors?: CustomColors) => {
     if (!report) return;
     setSavingColorScheme(true);
     try {
-      const next = { ...report, colorScheme: scheme } as Report;
+      const next = {
+        ...report,
+        colorScheme: scheme,
+        customColors: scheme === "custom" ? colors : undefined,
+      } as Report;
       if (user) {
         await dbUpdateReport(next);
         setReport(next);
@@ -191,7 +195,10 @@ const ReportPreview: React.FC = () => {
         saveLocalReport(next);
         setReport(next);
       }
-      toast({ title: "Color scheme updated", description: `Applied ${scheme}` });
+      toast({
+        title: "Color scheme updated",
+        description: scheme === "custom" ? "Applied custom scheme" : `Applied ${scheme}`,
+      });
     } catch (e) {
       console.error(e);
       toast({ title: "Failed to update color scheme", description: "Please try again.", variant: "destructive" });
@@ -359,6 +366,7 @@ const ReportPreview: React.FC = () => {
           />
           <ColorSchemePicker
             value={report.colorScheme || "blue"}
+            customColors={report.customColors}
             onChange={handleColorSchemeChange}
             disabled={savingColorScheme}
           />
@@ -391,11 +399,17 @@ const ReportPreview: React.FC = () => {
               clientPhone={report.clientPhone || ""}
               inspectionDate={report.inspectionDate}
               weatherConditions={report.weatherConditions || ""}
-              colorScheme={report.colorScheme ? {
-                primary: COLOR_SCHEMES[report.colorScheme].primary,
-                secondary: COLOR_SCHEMES[report.colorScheme].secondary,
-                accent: COLOR_SCHEMES[report.colorScheme].accent
-              } : undefined}
+              colorScheme={
+                report.colorScheme === "custom"
+                  ? report.customColors || undefined
+                  : report.colorScheme
+                  ? {
+                      primary: COLOR_SCHEMES[report.colorScheme].primary,
+                      secondary: COLOR_SCHEMES[report.colorScheme].secondary,
+                      accent: COLOR_SCHEMES[report.colorScheme].accent,
+                    }
+                  : undefined
+              }
               className={tpl.cover}
             />
           </div>


### PR DESCRIPTION
## Summary
- add advanced color scheme picker supporting custom colors
- save custom colors on report and apply to preview and PDF

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors)*
- `npx eslint src/components/ui/color-scheme-picker.tsx src/lib/reportSchemas.ts src/pages/ReportPreview.tsx src/components/reports/PDFDocument.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b320abfddc8333b7b9fe31104685ce