### PR TITLE
feat: support template default color scheme

### DIFF
--- a/src/components/reports/PDFDocument.tsx
+++ b/src/components/reports/PDFDocument.tsx
@@ -89,7 +89,7 @@ const PDFDocument = React.forwardRef<HTMLDivElement, PDFDocumentProps>(
                         colorScheme={
                             report.colorScheme === "custom"
                                 ? report.customColors || undefined
-                                : report.colorScheme
+                                : report.colorScheme && report.colorScheme !== "default"
                                 ? {
                                       primary: COLOR_SCHEMES[report.colorScheme].primary,
                                       secondary: COLOR_SCHEMES[report.colorScheme].secondary,

--- a/src/components/ui/color-scheme-picker.tsx
+++ b/src/components/ui/color-scheme-picker.tsx
@@ -57,7 +57,7 @@ export interface CustomColors {
   bodyText: string;
 }
 
-export type ColorScheme = keyof typeof COLOR_SCHEMES | "custom";
+export type ColorScheme = keyof typeof COLOR_SCHEMES | "custom" | "default";
 
 interface ColorSchemePickerProps {
   value: ColorScheme;
@@ -83,7 +83,12 @@ export function ColorSchemePicker({ value, onChange, disabled, customColors }: C
     if (customColors) setCustom(customColors);
   }, [customColors]);
 
-  const currentScheme = value === "custom" ? { name: "Custom", preview: "" } : COLOR_SCHEMES[value];
+  const currentScheme =
+    value === "custom"
+      ? { name: "Custom", preview: "" }
+      : value === "default"
+      ? { name: "Default", preview: "bg-background border" }
+      : COLOR_SCHEMES[value];
 
   const hslToHex = (hsl: string) => {
     const [h, s, l] = hsl.split(" ").map((v) => parseFloat(v));
@@ -168,6 +173,19 @@ export function ColorSchemePicker({ value, onChange, disabled, customColors }: C
         <div className="space-y-2">
           <h4 className="font-medium text-sm">Color Scheme</h4>
           <div className="grid grid-cols-2 gap-2">
+            <Button
+              variant={value === "default" ? "default" : "outline"}
+              size="sm"
+              className="justify-start gap-2 h-9"
+              onClick={() => {
+                onChange("default");
+                setOpen(false);
+                setShowCustom(false);
+              }}
+            >
+              <div className="w-4 h-4 rounded-full border bg-background" />
+              Default
+            </Button>
             {Object.entries(COLOR_SCHEMES).map(([key, scheme]) => (
               <Button
                 key={key}
@@ -177,6 +195,7 @@ export function ColorSchemePicker({ value, onChange, disabled, customColors }: C
                 onClick={() => {
                   onChange(key as ColorScheme);
                   setOpen(false);
+                  setShowCustom(false);
                 }}
               >
                 <div className={cn("w-4 h-4 rounded-full", scheme.preview)} />
@@ -216,4 +235,4 @@ export function ColorSchemePicker({ value, onChange, disabled, customColors }: C
       </PopoverContent>
     </Popover>
   );
-}
+  }

--- a/src/lib/reportSchemas.ts
+++ b/src/lib/reportSchemas.ts
@@ -59,7 +59,9 @@ export const BaseReportSchema = z.object({
         .enum(["templateOne", "templateTwo", "templateThree", "templateFour", "templateFive"])
         .default("templateOne"),
     previewTemplate: z.enum(["classic", "modern", "minimal"]).default("classic"),
-    colorScheme: z.enum(["blue", "green", "purple", "orange", "red", "slate", "custom"]).default("blue"),
+    colorScheme: z
+        .enum(["default", "blue", "green", "purple", "orange", "red", "slate", "custom"])
+        .default("default"),
     customColors: z
         .object({
             primary: z.string(),

--- a/src/pages/ReportPreview.tsx
+++ b/src/pages/ReportPreview.tsx
@@ -375,7 +375,7 @@ const ReportPreview: React.FC = () => {
             disabled={savingStyleTpl}
           />
           <ColorSchemePicker
-            value={report.colorScheme || "blue"}
+            value={report.colorScheme || "default"}
             customColors={report.customColors}
             onChange={handleColorSchemeChange}
             disabled={savingColorScheme}
@@ -412,7 +412,7 @@ const ReportPreview: React.FC = () => {
               colorScheme={
                 report.colorScheme === "custom"
                   ? report.customColors || undefined
-                  : report.colorScheme
+                  : report.colorScheme && report.colorScheme !== "default"
                   ? {
                       primary: COLOR_SCHEMES[report.colorScheme].primary,
                       secondary: COLOR_SCHEMES[report.colorScheme].secondary,


### PR DESCRIPTION
## Summary
- allow selecting a template's built-in colors via a new "Default" option
- make reports use template default colors unless another scheme is chosen
- update schema and PDF generation to understand the new default scheme

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 183 problems)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b3ae1e69f483339a13c4c8ce14a009