### PR TITLE
fix: enforce light background for CoverTemplateThree

### DIFF
--- a/src/components/report-covers/CoverTemplateThree.tsx
+++ b/src/components/report-covers/CoverTemplateThree.tsx
@@ -44,10 +44,10 @@ const CoverTemplateThree: React.FC<CoverTemplateProps & { className?: string }> 
     return (
         <div
             className={[
+                className || "",
                 // Default to white; pass className="bg-slate-50" for a very light silver canvas.
                 "relative isolate bg-white text-slate-900",
                 "h-full min-h-full overflow-hidden",
-                className || "",
             ].join(" ")}
         >
             {/* ultra-soft decor kept away from text areas */}


### PR DESCRIPTION
## Summary
- ensure CoverTemplateThree's default white background takes precedence over external classes

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `npm run lint` *(fails: 186 problems (166 errors, 20 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b3b55517e483339d2ca872571ae3fa