### PR TITLE
feat(report-covers): allow className overrides

### DIFF
--- a/src/components/report-covers/CoverTemplateEleven.tsx
+++ b/src/components/report-covers/CoverTemplateEleven.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { cn } from "@/lib/utils";
 import {CoverTemplateProps} from "./types";
 import {formatShortDate} from "../../utils/formatDate";
 import {BadgeCheck, Calendar, Mail, MapPin, Phone, ThermometerSun, User} from "lucide-react";
@@ -30,6 +31,7 @@ const CoverTemplateEleven: React.FC<CoverTemplateProps> = ({
                                                                       inspectionDate,
                                                                       weatherConditions,
                                                                       colorScheme,
+                                                                      className,
                                                                   }) => {
     const scheme = {
         primary: colorScheme?.primary ?? DEFAULT_SCHEME.primary,
@@ -39,7 +41,7 @@ const CoverTemplateEleven: React.FC<CoverTemplateProps> = ({
 
     return (
         <div
-            className="h-full flex flex-col"
+            className={cn('h-full flex flex-col', className)}
             style={
                 {
                     ["--primary" as any]: scheme.primary,

--- a/src/components/report-covers/CoverTemplateFifteen.tsx
+++ b/src/components/report-covers/CoverTemplateFifteen.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { cn } from "@/lib/utils";
 import {CoverTemplateProps} from "./types";
 import {formatShortDate} from "../../utils/formatDate";
 
@@ -29,6 +30,7 @@ const CoverTemplateFifteen: React.FC<CoverTemplateProps> = ({
                                                                     inspectionDate,
                                                                     weatherConditions,
                                                                     colorScheme,
+                                                                    className,
                                                                 }) => {
     const scheme = {
         primary: colorScheme?.primary ?? DEFAULT_SCHEME.primary,
@@ -39,7 +41,7 @@ const CoverTemplateFifteen: React.FC<CoverTemplateProps> = ({
 
     return (
         <div
-            className="h-full flex flex-col relative"
+            className={cn('h-full flex flex-col relative', className)}
             style={
                 {
                     ["--primary" as any]: scheme.primary,

--- a/src/components/report-covers/CoverTemplateFourteen.tsx
+++ b/src/components/report-covers/CoverTemplateFourteen.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { cn } from "@/lib/utils";
 import {CoverTemplateProps} from "./types";
 import {formatShortDate} from "../../utils/formatDate";
 
@@ -29,6 +30,7 @@ const CoverTemplateFourteen: React.FC<CoverTemplateProps> = ({
                                                                    inspectionDate,
                                                                    weatherConditions,
                                                                    colorScheme,
+                                                                   className,
                                                                }) => {
     const scheme = {
         primary: colorScheme?.primary ?? DEFAULT_SCHEME.primary,
@@ -38,7 +40,7 @@ const CoverTemplateFourteen: React.FC<CoverTemplateProps> = ({
 
     return (
         <div
-            className="h-full flex flex-col relative overflow-hidden"
+            className={cn('h-full flex flex-col relative overflow-hidden', className)}
             style={
                 {
                     ["--primary" as any]: scheme.primary,

--- a/src/components/report-covers/CoverTemplateThirteen.tsx
+++ b/src/components/report-covers/CoverTemplateThirteen.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { cn } from "@/lib/utils";
 import {CoverTemplateProps} from "./types";
 import {formatShortDate} from "../../utils/formatDate";
 
@@ -29,6 +30,7 @@ const CoverTemplateThirteen: React.FC<CoverTemplateProps> = ({
                                                                     inspectionDate,
                                                                     weatherConditions,
                                                                     colorScheme,
+                                                                    className,
                                                                 }) => {
     const scheme = {
         primary: colorScheme?.primary ?? DEFAULT_SCHEME.primary,
@@ -38,7 +40,7 @@ const CoverTemplateThirteen: React.FC<CoverTemplateProps> = ({
 
     return (
         <div
-            className="h-full flex flex-col relative overflow-hidden"
+            className={cn('h-full flex flex-col relative overflow-hidden', className)}
             style={
                 {
                     ["--primary" as any]: scheme.primary,

--- a/src/components/report-covers/CoverTemplateTwelve.tsx
+++ b/src/components/report-covers/CoverTemplateTwelve.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { cn } from "@/lib/utils";
 import {CoverTemplateProps} from "./types";
 import {formatShortDate} from "../../utils/formatDate";
 
@@ -29,6 +30,7 @@ const CoverTemplateTwelve: React.FC<CoverTemplateProps> = ({
                                                                    inspectionDate,
                                                                    weatherConditions,
                                                                    colorScheme,
+                                                                   className,
                                                                }) => {
     const scheme = {
         primary: colorScheme?.primary ?? DEFAULT_SCHEME.primary,
@@ -40,7 +42,7 @@ const CoverTemplateTwelve: React.FC<CoverTemplateProps> = ({
 
     return (
         <div
-            className="h-full flex flex-col relative"
+            className={cn('h-full flex flex-col relative', className)}
             style={
                 {
                     ["--primary" as any]: scheme.primary,

--- a/src/components/report-covers/types.ts
+++ b/src/components/report-covers/types.ts
@@ -1,4 +1,5 @@
 export interface CoverTemplateProps {
+  className?: string;
   organizationName?: string;
   organizationAddress?: string;
   organizationPhone?: string;


### PR DESCRIPTION
## Summary
- allow passing `className` to `CoverTemplateProps`
- use `cn` to merge template container classes with incoming `className` in templates 11–15

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, other lint errors)*
- `npx eslint src/components/report-covers/CoverTemplateEleven.tsx src/components/report-covers/CoverTemplateTwelve.tsx src/components/report-covers/CoverTemplateThirteen.tsx src/components/report-covers/CoverTemplateFourteen.tsx src/components/report-covers/CoverTemplateFifteen.tsx src/components/report-covers/types.ts` *(fails: Unexpected any in existing code)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4340a10c48333adb15715c00d9859