### PR TITLE
Use report data in cover template selector preview

### DIFF
--- a/src/components/ui/cover-template-selector.tsx
+++ b/src/components/ui/cover-template-selector.tsx
@@ -8,17 +8,20 @@ import {
 import { COVER_TEMPLATES, CoverTemplateId } from "@/constants/coverTemplates";
 import { Check, ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { CoverTemplateProps } from "@/components/report-covers/types";
 
 interface CoverTemplateSelectorProps {
   value: CoverTemplateId;
   onChange: (value: CoverTemplateId) => void;
   disabled?: boolean;
+  data: CoverTemplateProps;
 }
 
 export function CoverTemplateSelector({
   value,
   onChange,
   disabled,
+  data,
 }: CoverTemplateSelectorProps) {
   const [open, setOpen] = React.useState(false);
 
@@ -68,20 +71,7 @@ export function CoverTemplateSelector({
 
                 <div className="h-48 w-full overflow-hidden rounded border bg-white">
                   <div className="scale-[0.25] origin-top-left w-[400%] h-[400%]">
-                    <TemplateComponent
-                      reportTitle="Sample Report"
-                      clientName="John Doe"
-                      organizationName="Sample Inspection Co."
-                      organizationAddress="123 Main St, City, ST 12345"
-                      organizationPhone="(555) 123-4567"
-                      organizationEmail="info@sample.com"
-                      inspectorName="Jane Smith"
-                      inspectorLicenseNumber="LIC123456"
-                      clientAddress="456 Property Ave, City, ST 12345"
-                      inspectionDate="2024-01-15"
-                      weatherConditions="Clear, 72°F"
-                      coverImage=""
-                    />
+                    <TemplateComponent {...data} />
                   </div>
                 </div>
               </div>

--- a/src/pages/ReportPreview.tsx
+++ b/src/pages/ReportPreview.tsx
@@ -22,6 +22,7 @@ import { getMyOrganization, getMyProfile, Organization, Profile } from "@/integr
 import { COVER_TEMPLATES, CoverTemplateId } from "@/constants/coverTemplates";
 import { CoverTemplateSelector } from "@/components/ui/cover-template-selector";
 import { ColorSchemePicker, ColorScheme, COLOR_SCHEMES, CustomColors } from "@/components/ui/color-scheme-picker";
+import { CoverTemplateProps } from "@/components/report-covers/types";
 
 function SeverityBadge({
   severity,
@@ -344,6 +345,43 @@ const ReportPreview: React.FC = () => {
     return acc;
   }, [] as { sectionTitle: string; counts: Record<string, number> }[]);
 
+  const previewColorScheme =
+    report.colorScheme === "custom" && report.customColors
+      ? {
+          primary: report.customColors.primary || "220 87% 56%",
+          secondary: report.customColors.secondary || "220 70% 40%",
+          accent: report.customColors.accent || "220 90% 70%",
+        }
+      : report.colorScheme && report.colorScheme !== "default"
+      ? {
+          primary: COLOR_SCHEMES[report.colorScheme].primary,
+          secondary: COLOR_SCHEMES[report.colorScheme].secondary,
+          accent: COLOR_SCHEMES[report.colorScheme].accent,
+        }
+      : undefined;
+
+  const coverPreviewData: CoverTemplateProps = {
+    reportTitle: report.title,
+    clientName: report.clientName,
+    coverImage: coverUrl,
+    organizationName: organization?.name || "",
+    organizationAddress: organization?.address || "",
+    organizationPhone: organization?.phone || "",
+    organizationEmail: organization?.email || "",
+    organizationWebsite: organization?.website || "",
+    organizationLogo: organization?.logo_url || "",
+    inspectorName: inspector?.full_name || "",
+    inspectorLicenseNumber: inspector?.license_number || "",
+    inspectorPhone: inspector?.phone || "",
+    inspectorEmail: inspector?.email || "",
+    clientAddress: report.address,
+    clientEmail: report.clientEmail || "",
+    clientPhone: report.clientPhone || "",
+    inspectionDate: report.inspectionDate,
+    weatherConditions: report.weatherConditions || "",
+    colorScheme: previewColorScheme,
+  };
+
   return (
     <>
       <Seo
@@ -368,6 +406,7 @@ const ReportPreview: React.FC = () => {
             value={report.coverTemplate}
             onChange={handleCoverTemplateChange}
             disabled={savingCoverTpl}
+            data={coverPreviewData}
           />
           <StyleSelector
             value={report.previewTemplate}


### PR DESCRIPTION
## Summary
- replace sample cover template data with actual report details for accurate previews
- pass report-driven data from ReportPreview into cover template selector

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 209 problems across project)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b438a313748333b974cd89c17e7527