### PR TITLE
feat: add report share tokens

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -664,6 +664,38 @@ export type Database = {
           },
         ]
       }
+      report_shares: {
+        Row: {
+          id: string
+          report_id: string
+          token: string
+          created_at: string
+          expires_at: string | null
+        }
+        Insert: {
+          id?: string
+          report_id: string
+          token: string
+          created_at?: string
+          expires_at?: string | null
+        }
+        Update: {
+          id?: string
+          report_id?: string
+          token?: string
+          created_at?: string
+          expires_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "report_shares_report_id_fkey"
+            columns: ["report_id"]
+            isOneToOne: false
+            referencedRelation: "reports"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       section_guidance: {
         Row: {
           created_at: string

--- a/supabase/migrations/20250906000000_create_report_shares_table.sql
+++ b/supabase/migrations/20250906000000_create_report_shares_table.sql
@@ -1,0 +1,39 @@
+-- 1) Create report_shares table
+create table if not exists public.report_shares (
+  id uuid primary key default gen_random_uuid(),
+  report_id uuid not null references public.reports(id) on delete cascade,
+  token text not null unique,
+  created_at timestamptz not null default now(),
+  expires_at timestamptz
+);
+
+-- Helpful index for lookups by token
+create unique index if not exists report_shares_token_idx on public.report_shares(token);
+
+-- 2) Enable row level security
+alter table public.report_shares enable row level security;
+
+-- 3) Allow anonymous users to check tokens
+create policy "Anonymous users can select by token"
+  on public.report_shares
+  for select
+  to anon
+  using (
+    token = current_setting('request.headers', true)::json->>'x-report-share-token'
+    and (expires_at is null or expires_at > now())
+  );
+
+-- 4) Allow anonymous access to reports via share token
+create policy if not exists "Anonymous users can view shared reports"
+  on public.reports
+  for select
+  to anon
+  using (
+    exists (
+      select 1
+      from public.report_shares rs
+      where rs.report_id = public.reports.id
+        and rs.token = current_setting('request.headers', true)::json->>'x-report-share-token'
+        and (rs.expires_at is null or rs.expires_at > now())
+    )
+  );


### PR DESCRIPTION
## Summary
- add `report_shares` table and token-based RLS
- expose `report_shares` in generated Supabase types

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68b4943aca088333abc5772439bc8e59