### PR TITLE
feat: add report sharing link

### DIFF
--- a/src/lib/reportSchemas.ts
+++ b/src/lib/reportSchemas.ts
@@ -73,6 +73,7 @@ export const BaseReportSchema = z.object({
             bodyText: z.string().optional(),
         })
         .optional(),
+    shareToken: z.string().optional(),
     reportType: z.enum(["home_inspection", "wind_mitigation"]),
 });
 


### PR DESCRIPTION
## Summary
- call Supabase RPC to generate share token during report finalization
- track shareToken on report schema
- show share link with copy, regenerate, and revoke actions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 211 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b4970a14e083338dd230d795c10990