### PR TITLE
feat: add report share policies

### DIFF
--- a/supabase/migrations/20250908000000_add_report_shares_policies.sql
+++ b/supabase/migrations/20250908000000_add_report_shares_policies.sql
@@ -1,0 +1,24 @@
+-- Grant insert and delete on report_shares to report owners
+create policy "Users can create report shares for their own reports"
+  on public.report_shares
+  for insert
+  to authenticated
+  with check (
+    exists (
+      select 1 from public.reports
+      where reports.id = report_shares.report_id
+        and reports.user_id = auth.uid()
+    )
+  );
+
+create policy "Users can delete report shares for their own reports"
+  on public.report_shares
+  for delete
+  to authenticated
+  using (
+    exists (
+      select 1 from public.reports
+      where reports.id = report_shares.report_id
+        and reports.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## Summary
- add RLS policies allowing authenticated users to create and delete share tokens for their own reports

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: lint errors)*
- `npx supabase migration up` *(fails: failed to connect to local database)*

------
https://chatgpt.com/codex/tasks/task_e_68b49b6cf89083339609a64d83e0341e