### PR TITLE
feat: add contact multi-select

### DIFF
--- a/src/components/contacts/ContactMultiSelect.tsx
+++ b/src/components/contacts/ContactMultiSelect.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
+import { X } from "lucide-react";
+
+import { useAuth } from "@/contexts/AuthContext";
+import { contactsApi } from "@/integrations/supabase/crmApi";
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import type { Contact } from "@/lib/crmSchemas";
+
+interface ContactMultiSelectProps {
+  contacts?: Contact[];
+  value: string[];
+  onChange: (ids: string[]) => void;
+}
+
+export const ContactMultiSelect: React.FC<ContactMultiSelectProps> = ({ contacts: contactsProp, value, onChange }) => {
+  const { user } = useAuth();
+  const { data: fetchedContacts = [] } = useQuery({
+    queryKey: ["contacts", user?.id],
+    queryFn: () => contactsApi.list(user!.id),
+    enabled: !contactsProp && !!user,
+  });
+
+  const contacts = contactsProp ?? fetchedContacts;
+
+  const toggle = (id: string) => {
+    if (value.includes(id)) {
+      onChange(value.filter((v) => v !== id));
+    } else {
+      onChange([...value, id]);
+    }
+  };
+
+  const selectedContacts = contacts.filter((c) => value.includes(c.id));
+
+  return (
+    <Command className="h-auto max-h-60 overflow-visible">
+      <CommandInput placeholder="Search contacts..." />
+      {selectedContacts.length > 0 && (
+        <div className="flex flex-wrap gap-1 p-2">
+          {selectedContacts.map((c) => (
+            <Badge key={c.id} variant="secondary" className="flex items-center gap-1">
+              {c.first_name} {c.last_name}
+              <X
+                className="h-3 w-3 cursor-pointer"
+                onClick={() => toggle(c.id)}
+              />
+            </Badge>
+          ))}
+        </div>
+      )}
+      <CommandList>
+        <CommandEmpty>No contacts found.</CommandEmpty>
+        <CommandGroup>
+          {contacts.map((c) => {
+            const isSelected = value.includes(c.id);
+            return (
+              <CommandItem
+                key={c.id}
+                value={`${c.first_name} ${c.last_name} ${c.email ?? ""}`}
+                onSelect={() => toggle(c.id)}
+                disabled={!c.email}
+                className="flex items-center gap-2"
+              >
+                <Checkbox
+                  checked={isSelected}
+                  aria-hidden
+                  className="pointer-events-none"
+                  disabled={!c.email}
+                />
+                <span>
+                  {c.first_name} {c.last_name}
+                  {c.email ? ` (${c.email})` : " (no email)"}
+                </span>
+              </CommandItem>
+            );
+          })}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  );
+};
+
+export default ContactMultiSelect;
+

--- a/src/pages/ReportEditor.tsx
+++ b/src/pages/ReportEditor.tsx
@@ -31,8 +31,7 @@ import { useCustomSections } from "@/hooks/useCustomSections";
 import { CustomSectionDialog } from "@/components/reports/CustomSectionDialog";
 import { Plus } from "lucide-react";
 import { Label } from "@/components/ui/label";
-import { Checkbox } from "@/components/ui/checkbox";
-import type { Contact } from "@/lib/crmSchemas";
+import ContactMultiSelect from "@/components/contacts/ContactMultiSelect";
 
 // Lazy load wind mitigation editor at module level
 const WindMitigationEditor = React.lazy(() => import("@/components/reports/WindMitigationEditor"));
@@ -1227,29 +1226,12 @@ const ReportEditor: React.FC = () => {
               <DialogHeader>
                 <DialogTitle>Select recipients</DialogTitle>
               </DialogHeader>
-              <div className="space-y-2 py-2">
-                {recipientOptions.length === 0 ? (
-                  <p className="text-sm text-muted-foreground">No contacts available</p>
-                ) : (
-                  recipientOptions.map((c) => (
-                    <div key={c.id} className="flex items-center gap-2">
-                      <Checkbox
-                        id={`recipient-${c.id}`}
-                        checked={selectedRecipients.includes(c.id)}
-                        onCheckedChange={(checked) => {
-                          setSelectedRecipients((prev) =>
-                            checked === true ? [...prev, c.id] : prev.filter((id) => id !== c.id)
-                          );
-                        }}
-                        disabled={!c.email}
-                      />
-                      <label htmlFor={`recipient-${c.id}`} className="text-sm">
-                        {c.first_name} {c.last_name}
-                        {c.email ? ` (${c.email})` : " (no email)"}
-                      </label>
-                    </div>
-                  ))
-                )}
+              <div className="py-2">
+                <ContactMultiSelect
+                  contacts={recipientOptions}
+                  value={selectedRecipients}
+                  onChange={setSelectedRecipients}
+                />
               </div>
               <DialogFooter>
                 <Button onClick={sendReportEmail} disabled={sendingReport || selectedRecipients.length === 0}>


### PR DESCRIPTION
## Summary
- add reusable ContactMultiSelect component using command palette
- integrate ContactMultiSelect into report email dialog to pick recipients

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 187 errors, 21 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b49f2aea84833387f397002c472936