### PR TITLE
Expose existing report share links

### DIFF
--- a/supabase/migrations/20250909000000_add_report_shares_select_policy.sql
+++ b/supabase/migrations/20250909000000_add_report_shares_select_policy.sql
@@ -1,0 +1,12 @@
+-- Allow report owners to view their share links
+create policy "Users can view report shares for their own reports"
+  on public.report_shares
+  for select
+  to authenticated
+  using (
+    exists (
+      select 1 from public.reports
+      where reports.id = report_shares.report_id
+        and reports.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## Summary
- allow report owners to view their share links via a new RLS policy
- surface active share tokens when fetching or updating reports

## Testing
- `npm run lint` *(fails: many pre-existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4aa7bab448333afd93accfea141f4