### PR TITLE
feat: add CORS headers to send-report-email

### DIFF
--- a/supabase/functions/send-report-email/index.ts
+++ b/supabase/functions/send-report-email/index.ts
@@ -8,9 +8,19 @@ interface Recipient {
   name?: string;
 }
 
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
 const resend = new Resend(Deno.env.get("RESEND_API_KEY") ?? "");
 
 Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 200, headers: corsHeaders });
+  }
+
   try {
     const { shareLink, recipients } = (await req.json()) as {
       shareLink?: string;
@@ -22,7 +32,7 @@ Deno.serve(async (req) => {
         JSON.stringify({ error: "Missing shareLink or recipients" }),
         {
           status: 400,
-          headers: { "Content-Type": "application/json" },
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
         }
       );
     }
@@ -47,14 +57,14 @@ Deno.serve(async (req) => {
 
     return new Response(JSON.stringify({ success: true }), {
       status: 200,
-      headers: { "Content-Type": "application/json" },
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
   } catch (err) {
     console.error(err);
     const message = err instanceof Error ? err.message : String(err);
     return new Response(JSON.stringify({ error: message }), {
       status: 500,
-      headers: { "Content-Type": "application/json" },
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
   }
 });


### PR DESCRIPTION
## Summary
- add CORS headers to send-report-email function
- handle OPTIONS requests and include CORS in JSON responses

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 188 errors, 21 warnings)*
- `npx supabase functions deploy send-report-email` *(fails: Access token not provided)*
- `curl -i https://qnrqwapbxnplypdirdiq.supabase.co/functions/v1/send-report-email -H 'Content-Type: application/json' -d '{"shareLink": "https://example.com", "recipients": [{"email":"test@example.com"}]}'` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4dae1ee188333b6c8e378792af464