### PR TITLE
feat: configurable report email sender

### DIFF
--- a/supabase/functions/.env
+++ b/supabase/functions/.env
@@ -1,2 +1,4 @@
 RESEND_API_KEY="re_MZzzaGDm_4WBiNEEW5BrWuiGESXZTkoro"
 SEND_EMAIL_HOOK_SECRET="v1,whsec_nRy/gJctN6+pliYRMXzyf6A31VO5B5UjwwGkMzen8GOmExIHtdPXruLnwDqHW2C/fuddbTyrH5AG/Nlo"
+EMAIL_FROM="Your Name <reports@yourdomain.com>"
+

--- a/supabase/functions/send-report-email/index.ts
+++ b/supabase/functions/send-report-email/index.ts
@@ -15,6 +15,8 @@ const corsHeaders = {
 };
 
 const resend = new Resend(Deno.env.get("RESEND_API_KEY") ?? "");
+const FROM_EMAIL =
+  Deno.env.get("EMAIL_FROM") ?? "reports <onboarding@resend.dev>";
 
 Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
@@ -68,7 +70,7 @@ Deno.serve(async (req) => {
       console.log("Email template rendered successfully");
 
       const emailResult = await resend.emails.send({
-        from: "reports <onboarding@resend.dev>",
+        from: FROM_EMAIL,
         to: [recipient.email],
         subject: "A report has been shared with you",
         html,


### PR DESCRIPTION
## Summary
- allow report email sender to be configured through EMAIL_FROM env var
- add EMAIL_FROM secret to supabase functions env file

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 210 problems (189 errors, 21 warnings))*
- `supabase secrets set --env-file supabase/functions/.env` *(fails: command not found: supabase)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ee22e55c83339581b0a929d8267f