### PR TITLE
feat: support custom report email templates

### DIFF
--- a/supabase/functions/send-report-email/index.ts
+++ b/supabase/functions/send-report-email/index.ts
@@ -1,6 +1,10 @@
 import React from "npm:react@18.3.1";
 import { Resend } from "npm:resend@4.0.0";
 import { renderAsync } from "npm:@react-email/render@1.2.1";
+import { Html, Head, Preview, Body } from "npm:@react-email/components@0.0.22";
+import { Markdown } from "npm:@react-email/markdown@0.0.15";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { replaceMergeFields } from "../../../src/utils/replaceMergeFields.ts";
 import ReportShareEmail from "./_templates/report-share.tsx";
 
 interface Recipient {
@@ -33,19 +37,21 @@ Deno.serve(async (req) => {
     console.log("Edge function started");
     const body = await req.json();
     console.log("Received request body:", JSON.stringify(body, null, 2));
-    
-    const { shareLink, recipients } = body as {
+
+    const { reportId, shareLink, recipients } = body as {
+      reportId?: string;
       shareLink?: string;
       recipients?: Recipient[];
     };
 
+    console.log("Parsed reportId:", reportId);
     console.log("Parsed shareLink:", shareLink);
     console.log("Parsed recipients:", recipients);
 
-    if (!shareLink || !recipients || recipients.length === 0) {
+    if (!reportId || !shareLink || !recipients || recipients.length === 0) {
       console.log("Missing required fields");
       return new Response(
-        JSON.stringify({ error: "Missing shareLink or recipients" }),
+        JSON.stringify({ error: "Missing reportId, shareLink or recipients" }),
         {
           status: 400,
           headers: { ...corsHeaders, "Content-Type": "application/json" },
@@ -63,25 +69,115 @@ Deno.serve(async (req) => {
       throw new Error("RESEND_API_KEY environment variable not set");
     }
 
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+    if (!supabaseUrl || !serviceRoleKey) {
+      throw new Error("Supabase environment variables not set");
+    }
+
+    const supabase = createClient(supabaseUrl, serviceRoleKey, {
+      global: { headers: { Authorization: req.headers.get("Authorization") || "" } },
+    });
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) throw new Error("Unauthorized");
+
+    const { data: report, error: reportError } = await supabase
+      .from("reports")
+      .select(
+        "organization_id, client_name, address, email, phone_home, phone_work, phone_cell, inspection_date, sections, report_data"
+      )
+      .eq("id", reportId)
+      .single();
+    if (reportError || !report) throw reportError || new Error("Report not found");
+
+    const { data: organization } = await supabase
+      .from("organizations")
+      .select("id, name, address, phone, email")
+      .eq("id", report.organization_id)
+      .single();
+
+    const { data: inspector } = await supabase
+      .from("profiles")
+      .select("full_name, phone, license_number")
+      .eq("user_id", user.id)
+      .single();
+
+    const { data: template } = await supabase
+      .from("email_templates")
+      .select("report_email_subject, report_email_body")
+      .eq("organization_id", report.organization_id)
+      .maybeSingle();
+
+    const mergeData = {
+      organization,
+      inspector,
+      report: {
+        clientName: report.client_name,
+        address: report.address,
+        email: report.email,
+        phoneHome: report.phone_home,
+        phoneWork: report.phone_work,
+        phoneCell: report.phone_cell,
+        inspectionDate: report.inspection_date,
+        sections: report.sections,
+        reportData: report.report_data,
+      },
+    } as const;
+
     for (const recipient of recipients) {
       console.log(`Sending email to: ${recipient.email}`);
 
-      const templateProps = {
-        link: shareLink,
-        name: recipient.name,
-        organizationName: ORGANIZATION_NAME,
-        organizationAddress: ORGANIZATION_ADDRESS,
-        organizationUrl: ORGANIZATION_URL,
-        unsubscribeUrl: UNSUBSCRIBE_URL,
-      };
+      let html: string;
+      let text: string;
+      let subject: string;
 
-      const html = await renderAsync(
-        React.createElement(ReportShareEmail, templateProps)
-      );
-      const text = await renderAsync(
-        React.createElement(ReportShareEmail, templateProps),
-        { plainText: true }
-      );
+      if (template) {
+        const mergedSubject = replaceMergeFields(
+          template.report_email_subject,
+          mergeData
+        );
+        let mergedBody = replaceMergeFields(
+          template.report_email_body,
+          mergeData
+        );
+        mergedBody = mergedBody.replace(/{{\s*(link|shareLink)\s*}}/g, shareLink);
+
+        const email = React.createElement(
+          Html,
+          null,
+          React.createElement(Head, null),
+          React.createElement(Preview, null, mergedSubject),
+          React.createElement(
+            Body,
+            null,
+            React.createElement(Markdown, null, mergedBody)
+          )
+        );
+        html = await renderAsync(email);
+        text = await renderAsync(email, { plainText: true });
+        subject = mergedSubject;
+      } else {
+        const templateProps = {
+          link: shareLink,
+          name: recipient.name,
+          organizationName: ORGANIZATION_NAME,
+          organizationAddress: ORGANIZATION_ADDRESS,
+          organizationUrl: ORGANIZATION_URL,
+          unsubscribeUrl: UNSUBSCRIBE_URL,
+        };
+
+        html = await renderAsync(
+          React.createElement(ReportShareEmail, templateProps)
+        );
+        text = await renderAsync(
+          React.createElement(ReportShareEmail, templateProps),
+          { plainText: true }
+        );
+        subject = `Inspection report from ${ORGANIZATION_NAME}`;
+      }
 
       console.log("Email template rendered successfully");
 
@@ -94,7 +190,7 @@ Deno.serve(async (req) => {
       const emailResult = await resend.emails.send({
         from: FROM_EMAIL,
         to: [recipient.email],
-        subject: `Inspection report from ${ORGANIZATION_NAME}`,
+        subject,
         html,
         text,
         reply_to: REPLY_TO,


### PR DESCRIPTION
## Summary
- query Supabase for organization report email template and merge fields
- render custom Markdown template or fall back to default ReportShareEmail

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 211 problems)*
- `npx eslint supabase/functions/send-report-email/index.ts`

------
https://chatgpt.com/codex/tasks/task_e_68b4fa362ee08333a2daf587ec6251ea