### PR TITLE
Add update tracking and reset option for report email template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "react-to-print": "^3.1.1",
         "recharts": "^2.15.4",
         "resend": "^6.0.2",
+        "sanitize-html": "^2.17.0",
         "sonner": "^1.7.4",
         "standardwebhooks": "^1.0.0",
         "tailwind-merge": "^2.6.0",
@@ -5880,7 +5881,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -7027,6 +7027,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -8607,6 +8616,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -10344,6 +10359,20 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/sanitize-html": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.0.tgz",
+      "integrity": "sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^8.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react-to-print": "^3.1.1",
     "recharts": "^2.15.4",
     "resend": "^6.0.2",
+    "sanitize-html": "^2.17.0",
     "sonner": "^1.7.4",
     "standardwebhooks": "^1.0.0",
     "tailwind-merge": "^2.6.0",

--- a/src/constants/emailTemplates.ts
+++ b/src/constants/emailTemplates.ts
@@ -1,0 +1,9 @@
+export const DEFAULT_REPORT_EMAIL_SUBJECT =
+  "Inspection report from {{organization.name}}";
+
+export const DEFAULT_REPORT_EMAIL_BODY = `Hello {{contact.name}},
+
+Your inspection report is ready. You can view it using the link below.
+
+Thanks,
+{{organization.name}}`;

--- a/src/pages/Settings/ReportEmailTemplate.tsx
+++ b/src/pages/Settings/ReportEmailTemplate.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Seo from "@/components/Seo";
 import { useAuth } from "@/contexts/AuthContext";
-import { useQuery, useMutation } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
@@ -10,6 +10,7 @@ import {
   getMyOrganization,
   getMyProfile,
   getReportEmailTemplate,
+  getProfileByUserId,
   saveReportEmailTemplate,
 } from "@/integrations/supabase/organizationsApi";
 import { MERGE_FIELDS, replaceMergeFields } from "@/utils/replaceMergeFields";
@@ -18,6 +19,7 @@ import { Markdown } from "@react-email/markdown";
 import { renderAsync } from "@react-email/render";
 import ReactQuill from "react-quill";
 import "react-quill/dist/quill.snow.css";
+import { DEFAULT_REPORT_EMAIL_BODY, DEFAULT_REPORT_EMAIL_SUBJECT } from "@/constants/emailTemplates";
 
 const sampleReport = {
   clientName: "Sample Client",
@@ -46,9 +48,16 @@ const ReportEmailTemplate: React.FC = () => {
     enabled: !!organization?.id,
   });
 
+  const { data: updatedBy } = useQuery({
+    queryKey: ["profile", template?.updated_by],
+    queryFn: () => getProfileByUserId(template!.updated_by!),
+    enabled: !!template?.updated_by,
+  });
+
   const [subject, setSubject] = React.useState("");
   const [body, setBody] = React.useState("");
   const [preview, setPreview] = React.useState("");
+  const queryClient = useQueryClient();
 
   React.useEffect(() => {
     if (template) {
@@ -77,10 +86,18 @@ const ReportEmailTemplate: React.FC = () => {
   }, [subject, body, organization, profile]);
 
   const saveMutation = useMutation({
-    mutationFn: () => saveReportEmailTemplate(organization!.id, subject, body),
-    onSuccess: () => toast({ title: "Template saved" }),
+    mutationFn: () => saveReportEmailTemplate(organization!.id, subject, body, user!.id),
+    onSuccess: () => {
+      toast({ title: "Template saved" });
+      queryClient.invalidateQueries({ queryKey: ["report-email-template", organization!.id] });
+    },
     onError: (e: any) => toast({ title: "Failed to save template", description: e.message }),
   });
+
+  const handleReset = () => {
+    setSubject(DEFAULT_REPORT_EMAIL_SUBJECT);
+    setBody(DEFAULT_REPORT_EMAIL_BODY);
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -92,6 +109,11 @@ const ReportEmailTemplate: React.FC = () => {
     <div className="container mx-auto p-4 space-y-8">
       <Seo title="Report Email Template" />
       <h1 className="text-2xl font-bold">Report Email Template</h1>
+      {template?.updated_at && (
+        <p className="text-sm text-muted-foreground">
+          Last edited {new Date(template.updated_at).toLocaleString()} {updatedBy ? `by ${updatedBy.full_name || updatedBy.email}` : ""}
+        </p>
+      )}
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
           <Label htmlFor="subject">Subject</Label>
@@ -101,9 +123,14 @@ const ReportEmailTemplate: React.FC = () => {
           <Label className="mb-2 block">Body</Label>
           <ReactQuill theme="snow" value={body} onChange={setBody} />
         </div>
-        <Button type="submit" disabled={saveMutation.isPending}>
-          Save Template
-        </Button>
+        <div className="flex gap-2">
+          <Button type="submit" disabled={saveMutation.isPending}>
+            Save Template
+          </Button>
+          <Button type="button" variant="outline" onClick={handleReset} disabled={saveMutation.isPending}>
+            Reset to default
+          </Button>
+        </div>
       </form>
       <div>
         <h2 className="text-xl font-semibold mb-2">Preview</h2>

--- a/supabase/migrations/20250912000000_add_updated_fields_to_email_templates.sql
+++ b/supabase/migrations/20250912000000_add_updated_fields_to_email_templates.sql
@@ -1,0 +1,4 @@
+-- Add updated_at and updated_by columns to email_templates for tracking edits
+ALTER TABLE public.email_templates
+  ADD COLUMN updated_at TIMESTAMPTZ DEFAULT now(),
+  ADD COLUMN updated_by UUID REFERENCES auth.users(id);


### PR DESCRIPTION
## Summary
- sanitize and size-check report email template bodies before storing
- allow resetting the report email template to its seeded default
- record last editor metadata for report email templates

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, no-case-declarations, and more)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fc85e3fc83339e2eb6d35918ab9a