### PR TITLE
refactor: rename report email template route

### DIFF
--- a/src/pages/Settings/EmailTemplate.tsx
+++ b/src/pages/Settings/EmailTemplate.tsx
@@ -27,7 +27,7 @@ const sampleReport = {
   inspectionDate: new Date().toISOString(),
 };
 
-const ReportEmailTemplate: React.FC = () => {
+const EmailTemplate: React.FC = () => {
   const { user } = useAuth();
 
   const { data: organization } = useQuery({
@@ -152,4 +152,4 @@ const ReportEmailTemplate: React.FC = () => {
   );
 };
 
-export default ReportEmailTemplate;
+export default EmailTemplate;

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -7,7 +7,7 @@ import {
   getMyOrganization,
   getOrganizationMembers,
 } from "@/integrations/supabase/organizationsApi";
-import ReportEmailTemplate from "./ReportEmailTemplate";
+import EmailTemplate from "./EmailTemplate";
 import Account from "./Account";
 import Organization from "./Organization";
 import Members from "./Members";
@@ -53,7 +53,7 @@ const Settings: React.FC = () => {
         <Route path="account" element={<Account />} />
         <Route path="organization" element={<Organization />} />
         {canManageMembers && <Route path="members" element={<Members />} />}
-        <Route path="email-template" element={<ReportEmailTemplate />} />
+        <Route path="email-template" element={<EmailTemplate />} />
         <Route path="data" element={<Data />} />
       </Routes>
     </div>


### PR DESCRIPTION
## Summary
- rename report email template page to EmailTemplate
- update settings route to use EmailTemplate component

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 215 problems)

------
https://chatgpt.com/codex/tasks/task_e_68b5058f8d308333a4827e53a073b107