### PR TITLE
feat: add report data export

### DIFF
--- a/src/integrations/supabase/accountApi.ts
+++ b/src/integrations/supabase/accountApi.ts
@@ -1,0 +1,12 @@
+import { supabase } from "./client";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export async function exportReportData() {
+  const client = supabase as SupabaseClient;
+  const { data, error } = await client.functions.invoke("export-report-data", {
+    responseType: "blob",
+  });
+  if (error) throw error;
+  return data as Blob;
+}
+

--- a/src/pages/Settings/Data.tsx
+++ b/src/pages/Settings/Data.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/use-toast";
+import { exportReportData } from "@/integrations/supabase/accountApi";
+
+const Data: React.FC = () => {
+  const [loading, setLoading] = React.useState(false);
+
+  const handleExport = async () => {
+    setLoading(true);
+    try {
+      const blob = await exportReportData();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "report-data.zip";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(url);
+      toast({ title: "Export started", description: "Your data has been downloaded." });
+    } catch (err) {
+      console.error(err);
+      toast({ title: "Export failed", variant: "destructive" });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <Button onClick={handleExport} disabled={loading}>
+        {loading ? "Exporting..." : "Export Data"}
+      </Button>
+    </div>
+  );
+};
+
+export default Data;
+

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -11,8 +11,7 @@ import EmailTemplate from "./EmailTemplate";
 import Account from "./Account";
 import Organization from "./Organization";
 import Members from "./Members";
-
-const Data = () => <div>Data settings</div>;
+import Data from "./Data";
 
 const Settings: React.FC = () => {
   const location = useLocation();
@@ -33,7 +32,7 @@ const Settings: React.FC = () => {
   });
 
   const canManageMembers = React.useMemo(() => {
-    const membership = members.find((m: any) => m.user_id === user?.id);
+    const membership = members.find((m) => m.user_id === user?.id);
     return membership?.role === "owner" || membership?.role === "admin";
   }, [members, user]);
 

--- a/supabase/functions/export-report-data/index.ts
+++ b/supabase/functions/export-report-data/index.ts
@@ -1,0 +1,84 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import JSZip from "https://esm.sh/jszip@3.10.1";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+    if (!supabaseUrl || !serviceKey) {
+      throw new Error("Server not configured");
+    }
+
+    const supabase = createClient(supabaseUrl, serviceKey, {
+      global: { headers: { Authorization: req.headers.get("Authorization") || "" } },
+    });
+
+    // get current user
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+    if (userError || !user) {
+      return new Response("Unauthorized", {
+        status: 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const userId = user.id;
+
+    // fetch data scoped to user
+    const { data: reports = [] } = await supabase
+      .from("reports")
+      .select("*")
+      .eq("user_id", userId);
+
+    const { data: contacts = [] } = await supabase
+      .from("contacts")
+      .select("*")
+      .eq("user_id", userId);
+
+    const { data: activities = [] } = await supabase
+      .from("activities")
+      .select("*")
+      .eq("user_id", userId);
+
+    // gather media from storage
+    const media: Record<string, unknown[]> = {};
+    for (const report of reports) {
+      const path = `${userId}/${report.id}`;
+      const { data: files } = await supabase.storage
+        .from("report-media")
+        .list(path, { limit: 1000 });
+      if (files && files.length) {
+        media[report.id] = files.map((f) => ({ path: `${path}/${f.name}`, ...f }));
+      }
+    }
+
+    const payload = { reports, contacts, activities, media };
+    const zip = new JSZip();
+    zip.file("data.json", JSON.stringify(payload, null, 2));
+    const zipped = await zip.generateAsync({ type: "uint8array" });
+
+    return new Response(zipped, {
+      headers: {
+        ...corsHeaders,
+        "Content-Type": "application/zip",
+        "Content-Disposition": "attachment; filename=report-data.zip",
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return new Response(message, { status: 500, headers: corsHeaders });
+  }
+});
+


### PR DESCRIPTION
## Summary
- add Supabase edge function to bundle user reports, contacts, activities, and media into a zip
- expose `exportReportData` API and hook it to settings data tab
- add download button to export user data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 217 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b50699cb508333835e3ce8a0b1103e