### PR TITLE
feat: add account deletion edge function

### DIFF
--- a/src/integrations/supabase/accountApi.ts
+++ b/src/integrations/supabase/accountApi.ts
@@ -10,3 +10,9 @@ export async function exportReportData() {
   return data as Blob;
 }
 
+export async function deleteAccount() {
+  const client = supabase as SupabaseClient;
+  const { error } = await client.functions.invoke("delete-account");
+  if (error) throw error;
+}
+

--- a/src/pages/Settings/Data.tsx
+++ b/src/pages/Settings/Data.tsx
@@ -1,10 +1,33 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { toast } from "@/components/ui/use-toast";
-import { exportReportData } from "@/integrations/supabase/accountApi";
+import { exportReportData, deleteAccount } from "@/integrations/supabase/accountApi";
+import { supabase } from "@/integrations/supabase/client";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 
 const Data: React.FC = () => {
   const [loading, setLoading] = React.useState(false);
+  const [open, setOpen] = React.useState(false);
+  const [deleting, setDeleting] = React.useState(false);
+  const [confirmEmail, setConfirmEmail] = React.useState("");
+  const [userEmail, setUserEmail] = React.useState("");
+
+  React.useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      setUserEmail(data.user?.email || "");
+    });
+  }, []);
 
   const handleExport = async () => {
     setLoading(true);
@@ -27,11 +50,64 @@ const Data: React.FC = () => {
     }
   };
 
+  const handleDelete = async () => {
+    setDeleting(true);
+    try {
+      await deleteAccount();
+      toast({ title: "Account deleted" });
+      await supabase.auth.signOut();
+      window.location.href = "/";
+    } catch (err) {
+      console.error(err);
+      toast({ title: "Delete failed", variant: "destructive" });
+    } finally {
+      setDeleting(false);
+      setOpen(false);
+    }
+  };
+
   return (
-    <div className="space-y-4">
-      <Button onClick={handleExport} disabled={loading}>
-        {loading ? "Exporting..." : "Export Data"}
-      </Button>
+    <div className="space-y-8">
+      <div>
+        <Button onClick={handleExport} disabled={loading}>
+          {loading ? "Exporting..." : "Export Data"}
+        </Button>
+      </div>
+      <div className="space-y-2">
+        <h2 className="text-lg font-medium text-destructive">Close Account</h2>
+        <p className="text-sm text-muted-foreground">
+          This will permanently delete your account and all associated data. This action cannot be undone.
+        </p>
+        <AlertDialog open={open} onOpenChange={setOpen}>
+          <AlertDialogTrigger asChild>
+            <Button variant="destructive">Close Account</Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete Account</AlertDialogTitle>
+              <AlertDialogDescription>
+                To confirm, type your email address ({userEmail}) below.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <div className="py-4">
+              <Input
+                placeholder="Enter your email"
+                value={confirmEmail}
+                onChange={(e) => setConfirmEmail(e.target.value)}
+              />
+            </div>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={handleDelete}
+                disabled={confirmEmail !== userEmail || deleting}
+              >
+                {deleting ? "Deleting..." : "Delete"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
     </div>
   );
 };

--- a/supabase/functions/delete-account/index.ts
+++ b/supabase/functions/delete-account/index.ts
@@ -1,0 +1,79 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+    if (!supabaseUrl || !serviceKey) {
+      throw new Error("Server not configured");
+    }
+
+    const supabase = createClient(supabaseUrl, serviceKey, {
+      global: { headers: { Authorization: req.headers.get("Authorization") || "" } },
+    });
+
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser();
+
+    if (userError || !user) {
+      return new Response("Unauthorized", { status: 401, headers: corsHeaders });
+    }
+
+    const userId = user.id;
+
+    // Fetch organizations the user belongs to before deleting memberships
+    const { data: memberships } = await supabase
+      .from("organization_members")
+      .select("organization_id")
+      .eq("user_id", userId);
+
+    // Delete user's reports
+    await supabase.from("reports").delete().eq("user_id", userId);
+
+    // Delete profile
+    await supabase.from("profiles").delete().eq("user_id", userId);
+
+    // Remove from organization members
+    await supabase.from("organization_members").delete().eq("user_id", userId);
+
+    // Delete orphaned organizations
+    if (memberships) {
+      for (const m of memberships) {
+        const { data: remaining } = await supabase
+          .from("organization_members")
+          .select("id")
+          .eq("organization_id", m.organization_id)
+          .limit(1);
+        if (!remaining || remaining.length === 0) {
+          await supabase.from("organizations").delete().eq("id", m.organization_id);
+        }
+      }
+    }
+
+    // Delete user from auth.users
+    await supabase.auth.admin.deleteUser(userId);
+
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    console.error(err);
+    return new Response("Error deleting account", {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});
+


### PR DESCRIPTION
## Summary
- add service-role edge function to remove user profiles, memberships, reports and orphaned organizations
- expose deleteAccount integration for calling the edge function
- add Close Account section with email confirmation dialog in settings

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Unexpected any, no-case-declarations, and other lint errors)


------
https://chatgpt.com/codex/tasks/task_e_68b507c9d9b08333a3e0feb9ea1e343e