### PR TITLE
Add advanced settings tab for admin links

### DIFF
--- a/src/pages/Settings/Advanced.tsx
+++ b/src/pages/Settings/Advanced.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+const Advanced: React.FC = () => {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-medium">Advanced Settings</h2>
+      <ul className="list-disc pl-4 space-y-2">
+        <li>
+          <Link to="/section-manager" className="text-primary underline">
+            Section Manager
+          </Link>
+        </li>
+        <li>
+          <Link to="/defects-admin" className="text-primary underline">
+            Defects Admin
+          </Link>
+        </li>
+      </ul>
+    </div>
+  );
+};
+
+export default Advanced;

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -12,6 +12,7 @@ import Account from "./Account";
 import Organization from "./Organization";
 import Members from "./Members";
 import Data from "./Data";
+import Advanced from "./Advanced";
 
 const Settings: React.FC = () => {
   const location = useLocation();
@@ -31,7 +32,7 @@ const Settings: React.FC = () => {
     enabled: !!organization,
   });
 
-  const canManageMembers = React.useMemo(() => {
+  const isAdminOrOwner = React.useMemo(() => {
     const membership = members.find((m) => m.user_id === user?.id);
     return membership?.role === "owner" || membership?.role === "admin";
   }, [members, user]);
@@ -42,18 +43,20 @@ const Settings: React.FC = () => {
         <TabsList>
           <TabsTrigger value="account">Account</TabsTrigger>
           <TabsTrigger value="organization">Organization</TabsTrigger>
-          {canManageMembers && <TabsTrigger value="members">Members</TabsTrigger>}
+          {isAdminOrOwner && <TabsTrigger value="members">Members</TabsTrigger>}
           <TabsTrigger value="email-template">Email Template</TabsTrigger>
           <TabsTrigger value="data">Data</TabsTrigger>
+          {isAdminOrOwner && <TabsTrigger value="advanced">Advanced</TabsTrigger>}
         </TabsList>
       </Tabs>
       <Routes>
         <Route index element={<Navigate to="account" replace />} />
         <Route path="account" element={<Account />} />
         <Route path="organization" element={<Organization />} />
-        {canManageMembers && <Route path="members" element={<Members />} />}
+        {isAdminOrOwner && <Route path="members" element={<Members />} />}
         <Route path="email-template" element={<EmailTemplate />} />
         <Route path="data" element={<Data />} />
+        {isAdminOrOwner && <Route path="advanced" element={<Advanced />} />}
       </Routes>
     </div>
   );


### PR DESCRIPTION
## Summary
- add Advanced settings page linking to Section Manager and Defects Admin
- show Advanced tab only to admin/owner members by checking organization membership

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 214 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b509456b3083338f4f4cee692c68eb