### PR TITLE
feat: add merge field insertion dropdown

### DIFF
--- a/src/utils/replaceMergeFields.ts
+++ b/src/utils/replaceMergeFields.ts
@@ -12,21 +12,23 @@ interface SectionLike {
   info?: Record<string, unknown>;
 }
 
-export const MERGE_FIELDS = [
-  "{{organization.name}}",
-  "{{organization.address}}",
-  "{{organization.phone}}",
-  "{{organization.email}}",
-  "{{inspector.name}}",
-  "{{inspector.license_number}}",
-  "{{inspector.phone}}",
-  "{{contact.name}}",
-  "{{contact.address}}",
-  "{{contact.email}}",
-  "{{contact.phone}}",
-  "{{report.inspection_date}}",
-  "{{report.weather_conditions}}",
-] as const;
+export const MERGE_FIELD_MAP = {
+  "{{organization.name}}": "Organization name",
+  "{{organization.address}}": "Organization address",
+  "{{organization.phone}}": "Organization phone",
+  "{{organization.email}}": "Organization email",
+  "{{inspector.name}}": "Inspector name",
+  "{{inspector.license_number}}": "Inspector license number",
+  "{{inspector.phone}}": "Inspector phone",
+  "{{contact.name}}": "Contact name",
+  "{{contact.address}}": "Contact address",
+  "{{contact.email}}": "Contact email",
+  "{{contact.phone}}": "Contact phone",
+  "{{report.inspection_date}}": "Report inspection date",
+  "{{report.weather_conditions}}": "Report weather conditions",
+} as const;
+
+export const MERGE_FIELDS = Object.keys(MERGE_FIELD_MAP) as (keyof typeof MERGE_FIELD_MAP)[];
 
 export function replaceMergeFields(text: string, { organization, inspector, report }: MergeData) {
   if (!text) return "";


### PR DESCRIPTION
## Summary
- add merge-field map for email tokens
- support inserting merge fields into subject and body

## Testing
- `npm run lint` (fails: Unexpected any etc.)
- `npx eslint src/pages/Settings/EmailTemplate.tsx src/utils/replaceMergeFields.ts` (pass)
- `npm run build` (fails: Rollup failed to resolve import "sanitize-html")


------
https://chatgpt.com/codex/tasks/task_e_68b50c26fd748333ba8f0233495288bd