### PR TITLE
feat(settings): add integrations tab

### DIFF
--- a/src/pages/Settings/Integrations.tsx
+++ b/src/pages/Settings/Integrations.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+
+const Integrations: React.FC = () => {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-medium">Integrations</h2>
+      <p className="text-sm text-muted-foreground">
+        Manage your third-party integrations here.
+      </p>
+    </div>
+  );
+};
+
+export default Integrations;

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -12,6 +12,7 @@ import Account from "./Account";
 import Organization from "./Organization";
 import Members from "./Members";
 import Data from "./Data";
+import Integrations from "./Integrations";
 import Advanced from "./Advanced";
 
 const Settings: React.FC = () => {
@@ -46,6 +47,7 @@ const Settings: React.FC = () => {
           {isAdminOrOwner && <TabsTrigger value="members">Members</TabsTrigger>}
           <TabsTrigger value="email-template">Email Template</TabsTrigger>
           <TabsTrigger value="data">Data</TabsTrigger>
+          <TabsTrigger value="integrations">Integrations</TabsTrigger>
           {isAdminOrOwner && <TabsTrigger value="advanced">Advanced</TabsTrigger>}
         </TabsList>
       </Tabs>
@@ -56,6 +58,7 @@ const Settings: React.FC = () => {
         {isAdminOrOwner && <Route path="members" element={<Members />} />}
         <Route path="email-template" element={<EmailTemplate />} />
         <Route path="data" element={<Data />} />
+        <Route path="integrations" element={<Integrations />} />
         {isAdminOrOwner && <Route path="advanced" element={<Advanced />} />}
       </Routes>
     </div>


### PR DESCRIPTION
## Summary
- add new Integrations tab within settings
- render placeholder Integrations page and route

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 212 problems (191 errors, 21 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b5abac151c83339fe2d16c77c869d3