### PR TITLE
Add Google OAuth callback handling and route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,10 +32,14 @@ const App = () => (
       <Toaster />
       <Sonner />
       <AuthProvider>
-        <BrowserRouter>
-          <Routes>
-            <Route element={<RootLayout />}>
-              <Route path="/" element={<Index />} />
+          <BrowserRouter>
+            <Routes>
+              <Route
+                path="/oauth/google"
+                element={lazyLoad(() => import("./pages/oauth/GoogleCallback"))}
+              />
+              <Route element={<RootLayout />}>
+                <Route path="/" element={<Index />} />
               <Route path="/dashboard" element={lazyLoad(() => import("./pages/Dashboard"))} />
               <Route path="/auth" element={lazyLoad(() => import("./pages/Auth"))} />
               <Route path="/reports" element={lazyLoad(() => import("./pages/ReportsList"))} />

--- a/src/integrations/googleCalendar.ts
+++ b/src/integrations/googleCalendar.ts
@@ -42,6 +42,23 @@ async function saveToken(userId: string, token: {
   });
 }
 
+export async function handleOAuthCallback(code: string, userId: string) {
+  const res = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      code,
+      client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID || "",
+      client_secret: import.meta.env.VITE_GOOGLE_CLIENT_SECRET || "",
+      redirect_uri: `${window.location.origin}/oauth/google`,
+      grant_type: "authorization_code",
+    }),
+  });
+  if (!res.ok) throw new Error("Token exchange failed");
+  const data = await res.json();
+  await saveToken(userId, data);
+}
+
 async function refreshAccessToken(refreshToken: string) {
   const res = await fetch("https://oauth2.googleapis.com/token", {
     method: "POST",

--- a/src/pages/oauth/GoogleCallback.tsx
+++ b/src/pages/oauth/GoogleCallback.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { handleOAuthCallback } from "@/integrations/googleCalendar";
+
+const GoogleCallback = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get("code");
+    const state = params.get("state");
+
+    if (code && state) {
+      handleOAuthCallback(code, state).finally(() => {
+        navigate("/settings/integrations");
+      });
+    } else {
+      navigate("/settings/integrations");
+    }
+  }, [navigate]);
+
+  return null;
+};
+
+export default GoogleCallback;


### PR DESCRIPTION
## Summary
- add Google OAuth callback page to exchange code and store tokens
- factor token storage into reusable `handleOAuthCallback` helper
- register new `/oauth/google` route in App router

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 212 problems, example: Unexpected any in various files)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b863e8e48333848c553c46da568b