### PR TITLE
feat: handle Google OAuth callback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import RootLayout from "./layouts/RootLayout";
 import React from "react";
 import { AuthProvider } from "./contexts/AuthContext";
 import ErrorBoundary from "@/components/ErrorBoundary";
+import GoogleCallback from "./pages/oauth/GoogleCallback";
 
 const queryClient = new QueryClient();
 
@@ -34,10 +35,7 @@ const App = () => (
       <AuthProvider>
           <BrowserRouter>
             <Routes>
-              <Route
-                path="/oauth/google"
-                element={lazyLoad(() => import("./pages/oauth/GoogleCallback"))}
-              />
+              <Route path="/oauth/google" element={<GoogleCallback />} />
               <Route element={<RootLayout />}>
                 <Route path="/" element={<Index />} />
               <Route path="/dashboard" element={lazyLoad(() => import("./pages/Dashboard"))} />

--- a/src/integrations/googleCalendar.ts
+++ b/src/integrations/googleCalendar.ts
@@ -42,21 +42,15 @@ async function saveToken(userId: string, token: {
   });
 }
 
-export async function handleOAuthCallback(code: string, userId: string) {
-  const res = await fetch("https://oauth2.googleapis.com/token", {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({
-      code,
-      client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID || "",
-      client_secret: import.meta.env.VITE_GOOGLE_CLIENT_SECRET || "",
-      redirect_uri: `${window.location.origin}/oauth/google`,
-      grant_type: "authorization_code",
-    }),
-  });
-  if (!res.ok) throw new Error("Token exchange failed");
-  const data = await res.json();
-  await saveToken(userId, data);
+export async function handleOAuthCallback(
+  userId: string,
+  token: {
+    access_token: string;
+    refresh_token: string;
+    expires_in: number;
+  },
+) {
+  await saveToken(userId, token);
 }
 
 async function refreshAccessToken(refreshToken: string) {
@@ -226,5 +220,6 @@ export default {
   disconnect,
   isConnected,
   refreshEvents,
+  handleOAuthCallback,
 };
 

--- a/src/pages/oauth/GoogleCallback.tsx
+++ b/src/pages/oauth/GoogleCallback.tsx
@@ -1,23 +1,47 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { handleOAuthCallback } from "@/integrations/googleCalendar";
+import { useQueryClient } from "@tanstack/react-query";
+import * as googleCalendar from "@/integrations/googleCalendar";
 
 const GoogleCallback = () => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const code = params.get("code");
     const state = params.get("state");
 
-    if (code && state) {
-      handleOAuthCallback(code, state).finally(() => {
-        navigate("/settings/integrations");
-      });
-    } else {
+    if (!code || !state) {
       navigate("/settings/integrations");
+      return;
     }
-  }, [navigate]);
+
+    (async () => {
+      try {
+        const res = await fetch("https://oauth2.googleapis.com/token", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams({
+            code,
+            client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID || "",
+            client_secret: import.meta.env.VITE_GOOGLE_CLIENT_SECRET || "",
+            redirect_uri: `${window.location.origin}/oauth/google`,
+            grant_type: "authorization_code",
+          }),
+        });
+        if (res.ok) {
+          const token = await res.json();
+          await googleCalendar.handleOAuthCallback(state, token);
+          queryClient.invalidateQueries({
+            queryKey: ["google-calendar-connected", state],
+          });
+        }
+      } finally {
+        navigate("/settings/integrations");
+      }
+    })();
+  }, [navigate, queryClient]);
 
   return null;
 };


### PR DESCRIPTION
## Summary
- add OAuth callback page to exchange code and save tokens
- store Google tokens via new helper and invalidate cache
- wire callback route directly in app routing

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 212 problems)

------
https://chatgpt.com/codex/tasks/task_e_68b5bbff3044833389ff020200ce16be