### PR TITLE
feat: add calendar OAuth callbacks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ import React from "react";
 import { AuthProvider } from "./contexts/AuthContext";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import GoogleCallback from "./pages/oauth/GoogleCallback";
+import OutlookCallback from "./pages/oauth/OutlookCallback";
+import AppleCallback from "./pages/oauth/AppleCallback";
 
 const queryClient = new QueryClient();
 
@@ -36,6 +38,8 @@ const App = () => (
           <BrowserRouter>
             <Routes>
               <Route path="/oauth/google" element={<GoogleCallback />} />
+              <Route path="/oauth/outlook" element={<OutlookCallback />} />
+              <Route path="/oauth/apple" element={<AppleCallback />} />
               <Route element={<RootLayout />}>
                 <Route path="/" element={<Index />} />
               <Route path="/dashboard" element={lazyLoad(() => import("./pages/Dashboard"))} />

--- a/src/integrations/appleCalendar.ts
+++ b/src/integrations/appleCalendar.ts
@@ -42,6 +42,17 @@ async function saveToken(userId: string, token: {
   });
 }
 
+export async function handleOAuthCallback(
+  userId: string,
+  token: {
+    access_token: string;
+    refresh_token: string;
+    expires_in: number;
+  },
+) {
+  await saveToken(userId, token);
+}
+
 async function refreshAccessToken(refreshToken: string) {
   const res = await fetch("https://appleid.apple.com/auth/token", {
     method: "POST",
@@ -198,5 +209,6 @@ export default {
   disconnect,
   isConnected,
   refreshEvents,
+  handleOAuthCallback,
 };
 

--- a/src/integrations/outlookCalendar.ts
+++ b/src/integrations/outlookCalendar.ts
@@ -42,6 +42,17 @@ async function saveToken(userId: string, token: {
   });
 }
 
+export async function handleOAuthCallback(
+  userId: string,
+  token: {
+    access_token: string;
+    refresh_token: string;
+    expires_in: number;
+  },
+) {
+  await saveToken(userId, token);
+}
+
 async function refreshAccessToken(refreshToken: string) {
   const res = await fetch(
     "https://login.microsoftonline.com/common/oauth2/v2.0/token",
@@ -205,5 +216,6 @@ export default {
   disconnect,
   isConnected,
   refreshEvents,
+  handleOAuthCallback,
 };
 

--- a/src/pages/oauth/AppleCallback.tsx
+++ b/src/pages/oauth/AppleCallback.tsx
@@ -1,0 +1,49 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import * as appleCalendar from "@/integrations/appleCalendar";
+
+const AppleCallback = () => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get("code");
+    const state = params.get("state");
+
+    if (!code || !state) {
+      navigate("/settings/integrations");
+      return;
+    }
+
+    (async () => {
+      try {
+        const res = await fetch("https://appleid.apple.com/auth/token", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams({
+            code,
+            client_id: import.meta.env.VITE_APPLE_CLIENT_ID || "",
+            client_secret: import.meta.env.VITE_APPLE_CLIENT_SECRET || "",
+            redirect_uri: `${window.location.origin}/oauth/apple`,
+            grant_type: "authorization_code",
+          }),
+        });
+        if (res.ok) {
+          const token = await res.json();
+          await appleCalendar.handleOAuthCallback(state, token);
+          queryClient.invalidateQueries({
+            queryKey: ["apple-calendar-connected", state],
+          });
+        }
+      } finally {
+        navigate("/settings/integrations");
+      }
+    })();
+  }, [navigate, queryClient]);
+
+  return null;
+};
+
+export default AppleCallback;

--- a/src/pages/oauth/OutlookCallback.tsx
+++ b/src/pages/oauth/OutlookCallback.tsx
@@ -1,0 +1,52 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import * as outlookCalendar from "@/integrations/outlookCalendar";
+
+const OutlookCallback = () => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get("code");
+    const state = params.get("state");
+
+    if (!code || !state) {
+      navigate("/settings/integrations");
+      return;
+    }
+
+    (async () => {
+      try {
+        const res = await fetch(
+          "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: new URLSearchParams({
+              code,
+              client_id: import.meta.env.VITE_OUTLOOK_CLIENT_ID || "",
+              client_secret: import.meta.env.VITE_OUTLOOK_CLIENT_SECRET || "",
+              redirect_uri: `${window.location.origin}/oauth/outlook`,
+              grant_type: "authorization_code",
+            }),
+          },
+        );
+        if (res.ok) {
+          const token = await res.json();
+          await outlookCalendar.handleOAuthCallback(state, token);
+          queryClient.invalidateQueries({
+            queryKey: ["outlook-calendar-connected", state],
+          });
+        }
+      } finally {
+        navigate("/settings/integrations");
+      }
+    })();
+  }, [navigate, queryClient]);
+
+  return null;
+};
+
+export default OutlookCallback;


### PR DESCRIPTION
## Summary
- add Outlook and Apple OAuth callback pages that exchange codes for tokens
- expose handleOAuthCallback helpers in Outlook and Apple integrations
- register Google, Outlook and Apple OAuth callback routes in the app

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5d0358ad88333867ce6c7391f938f