### PR TITLE
Handle Supabase errors in calendar connection checks

### DIFF
--- a/src/integrations/appleCalendar.ts
+++ b/src/integrations/appleCalendar.ts
@@ -166,12 +166,18 @@ export async function deleteEvent(userId: string, appointmentId: string) {
 }
 
 export async function isConnected(userId: string) {
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("calendar_tokens")
-    .select("id")
+    .select("user_id")
     .eq("user_id", userId)
     .eq("provider", PROVIDER)
     .maybeSingle();
+
+  if (error) {
+    console.error("Error checking Apple calendar connection", error);
+    return false;
+  }
+
   return !!data;
 }
 

--- a/src/integrations/googleCalendar.ts
+++ b/src/integrations/googleCalendar.ts
@@ -175,12 +175,18 @@ export async function deleteEvent(userId: string, appointmentId: string) {
 }
 
 export async function isConnected(userId: string) {
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("calendar_tokens")
-    .select("id")
+    .select("user_id")
     .eq("user_id", userId)
     .eq("provider", PROVIDER)
     .maybeSingle();
+
+  if (error) {
+    console.error("Error checking Google calendar connection", error);
+    return false;
+  }
+
   return !!data;
 }
 

--- a/src/integrations/outlookCalendar.ts
+++ b/src/integrations/outlookCalendar.ts
@@ -173,12 +173,18 @@ export async function deleteEvent(userId: string, appointmentId: string) {
 }
 
 export async function isConnected(userId: string) {
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("calendar_tokens")
-    .select("id")
+    .select("user_id")
     .eq("user_id", userId)
     .eq("provider", PROVIDER)
     .maybeSingle();
+
+  if (error) {
+    console.error("Error checking Outlook calendar connection", error);
+    return false;
+  }
+
   return !!data;
 }
 


### PR DESCRIPTION
## Summary
- Use existing `user_id` column when checking calendar token connections
- Handle Supabase errors and return `true` when a token record exists

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 213 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d1a380e88333a965faac12e7b453