### PR TITLE
feat: add calendar sync tables

### DIFF
--- a/supabase/migrations/20250913000000_add_calendar_sync_tables.sql
+++ b/supabase/migrations/20250913000000_add_calendar_sync_tables.sql
@@ -1,0 +1,24 @@
+-- Create calendar_tokens table for storing calendar provider tokens
+create table if not exists public.calendar_tokens (
+  user_id uuid not null,
+  provider text not null,
+  access_token text not null,
+  refresh_token text,
+  expires_at timestamptz,
+  primary key (user_id, provider)
+);
+
+-- Index for quick lookups by user
+create index if not exists calendar_tokens_user_id_idx on public.calendar_tokens(user_id);
+
+-- Create calendar_events table for mapping appointments to calendar events
+create table if not exists public.calendar_events (
+  user_id uuid not null,
+  provider text not null,
+  appointment_id uuid not null,
+  event_id text not null,
+  primary key (appointment_id, provider)
+);
+
+-- Index for quick lookups by user
+create index if not exists calendar_events_user_id_idx on public.calendar_events(user_id);


### PR DESCRIPTION
## Summary
- add migration for calendar_tokens and calendar_events tables
- include indexes on user_id for faster lookups

## Testing
- `npx supabase db push` *(fails: Cannot find project ref)*
- `npm run lint` *(fails: 213 problems (191 errors, 22 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b5d2f6f2b88333be49340cdf6be8fe