### PR TITLE
Enable React Router v7 features and async Maps loading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,9 @@ const App = () => (
       <Toaster />
       <Sonner />
       <AuthProvider>
-          <BrowserRouter>
+          <BrowserRouter
+            future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+          >
             <Routes>
               <Route path="/oauth/google" element={<GoogleCallback />} />
               <Route path="/oauth/outlook" element={<OutlookCallback />} />

--- a/src/components/maps/GooglePlacesAutocomplete.tsx
+++ b/src/components/maps/GooglePlacesAutocomplete.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState, forwardRef } from 'react';
 import { MapPin, Loader2 } from 'lucide-react';
+import { Loader } from '@googlemaps/js-api-loader';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { reportIfMapsJsBlocked } from './loadGoogleMapsApi';
@@ -49,31 +50,14 @@ export const GooglePlacesAutocomplete = forwardRef<any, GooglePlacesAutocomplete
             throw new Error('Failed to get Google Maps API key');
           }
 
-          if (!window.google?.maps?.importLibrary) {
-            await new Promise<void>((resolve, reject) => {
-              const script = document.createElement('script');
-              script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKeyData.apiKey}&v=weekly&libraries=places`;
-              script.async = true;
-              script.onload = () => resolve();
-              script.onerror = () => reject(new Error('Failed to load Google Maps script'));
-              document.head.appendChild(script);
-            });
-          }
-
-          if (!window.google?.maps?.importLibrary) {
-            await new Promise<void>((resolve, reject) => {
-              const script = document.createElement('script');
-              script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKeyData.apiKey}&v=weekly&libraries=places`;
-              script.async = true;
-              script.onload = () => resolve();
-              script.onerror = () => reject(new Error('Failed to load Google Maps script'));
-              document.head.appendChild(script);
-            });
-          }
-
-          if (window.google?.maps?.importLibrary) {
-            await window.google.maps.importLibrary('places');
-          }
+          const loader = new Loader({
+            apiKey: apiKeyData.apiKey,
+            version: 'weekly',
+            libraries: ['places'],
+            url: 'https://maps.googleapis.com/maps/api/js?loading=async'
+          });
+          await loader.load();
+          await window.google.maps.importLibrary('places');
 
           if (!isMounted || !elementRef.current) return;
 

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -5,7 +5,7 @@ import {appointmentsApi, contactsApi} from "@/integrations/supabase/crmApi";
 import {Button} from "@/components/ui/button";
 import {Card, CardContent, CardHeader, CardTitle} from "@/components/ui/card";
 import {Badge} from "@/components/ui/badge";
-import {Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger} from "@/components/ui/dialog";
+import {Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger, DialogDescription} from "@/components/ui/dialog";
 import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage} from "@/components/ui/form";
 import {Input} from "@/components/ui/input";
 import {Textarea} from "@/components/ui/textarea";
@@ -321,11 +321,17 @@ const Calendar: React.FC = () => {
                                         New Appointment
                                     </Button>
                                 </DialogTrigger>
-                                <DialogContent className="sm:max-w-[700px]">
+                                <DialogContent
+                                    aria-describedby="appointment-dialog-desc"
+                                    className="sm:max-w-[700px]"
+                                >
                                     <DialogHeader>
                                         <DialogTitle>
                                             {editingAppointment ? "Edit Appointment" : "Create Appointment"}
                                         </DialogTitle>
+                                        <DialogDescription id="appointment-dialog-desc">
+                                            Provide details for the appointment.
+                                        </DialogDescription>
                                     </DialogHeader>
                                     <Form {...form}>
                                         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">


### PR DESCRIPTION
## Summary
- enable upcoming React Router v7 behavior via BrowserRouter future flags
- add accessible description to calendar appointment dialog
- load Google Maps JavaScript API asynchronously using Loader

## Testing
- `npm run lint` (fails: Unexpected any. Specify a different type)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6083892a08333939e5eb88b73bb4e