### PR TITLE
feat: add scheduling integrations and webhook

### DIFF
--- a/src/components/BookingWidget.tsx
+++ b/src/components/BookingWidget.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+export type BookingService = "calendly" | "acuity" | "setmore";
+
+interface BookingWidgetProps {
+  service: BookingService;
+  link: string;
+}
+
+const BookingWidget: React.FC<BookingWidgetProps> = ({ service, link }) => {
+  if (!link) return null;
+
+  const iframeProps = {
+    className: "w-full min-h-[700px] border-none",
+    src: link,
+    allowFullScreen: true,
+  } as const;
+
+  switch (service) {
+    case "calendly":
+      return (
+        <iframe
+          {...iframeProps}
+          src={`${link}${link.includes("?" ) ? "&" : "?"}embed_domain=${typeof window !== "undefined" ? window.location.hostname : ""}&embed_type=Inline`}
+        />
+      );
+    case "acuity":
+    case "setmore":
+      return <iframe {...iframeProps} />;
+    default:
+      return null;
+  }
+};
+
+export default BookingWidget;

--- a/src/pages/Settings/Integrations.tsx
+++ b/src/pages/Settings/Integrations.tsx
@@ -3,6 +3,8 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import * as googleCalendar from "@/integrations/googleCalendar";
 import * as outlookCalendar from "@/integrations/outlookCalendar";
 import * as appleCalendar from "@/integrations/appleCalendar";
@@ -11,6 +13,16 @@ const Integrations: React.FC = () => {
   const { user } = useAuth();
   const [optimizeRoute, setOptimizeRoute] = useState(
     () => localStorage.getItem("optimizeRoute") === "true"
+  );
+
+  const [calendlyLink, setCalendlyLink] = useState(
+    () => localStorage.getItem("calendlyLink") || ""
+  );
+  const [acuityLink, setAcuityLink] = useState(
+    () => localStorage.getItem("acuityLink") || ""
+  );
+  const [setmoreLink, setSetmoreLink] = useState(
+    () => localStorage.getItem("setmoreLink") || ""
   );
 
   const { data: googleConnected, refetch: refetchGoogle } = useQuery({
@@ -125,6 +137,96 @@ const Integrations: React.FC = () => {
               Connect
             </Button>
           )}
+        </div>
+
+        <div className="flex items-start justify-between border p-4 rounded-md">
+          <div className="space-y-2 flex-1 mr-4">
+            <p className="font-medium">Calendly</p>
+            <p className="text-sm text-muted-foreground">
+              Paste your scheduling link for client bookings.
+            </p>
+            <Label htmlFor="calendly-link" className="sr-only">
+              Calendly Link
+            </Label>
+            <Input
+              id="calendly-link"
+              placeholder="https://calendly.com/your-name/meeting"
+              value={calendlyLink}
+              onChange={(e) => setCalendlyLink(e.target.value)}
+              onBlur={() => localStorage.setItem("calendlyLink", calendlyLink)}
+            />
+            {calendlyLink && (
+              <p className="text-xs text-muted-foreground">
+                Share this link with clients: {calendlyLink}
+              </p>
+            )}
+          </div>
+          <Button
+            variant="outline"
+            onClick={() => localStorage.setItem("calendlyLink", calendlyLink)}
+          >
+            Save
+          </Button>
+        </div>
+
+        <div className="flex items-start justify-between border p-4 rounded-md">
+          <div className="space-y-2 flex-1 mr-4">
+            <p className="font-medium">Acuity Scheduling</p>
+            <p className="text-sm text-muted-foreground">
+              Enter your scheduling link or API key.
+            </p>
+            <Label htmlFor="acuity-link" className="sr-only">
+              Acuity Link
+            </Label>
+            <Input
+              id="acuity-link"
+              placeholder="https://app.acuityscheduling.com/schedule.php?owner=123456"
+              value={acuityLink}
+              onChange={(e) => setAcuityLink(e.target.value)}
+              onBlur={() => localStorage.setItem("acuityLink", acuityLink)}
+            />
+            {acuityLink && (
+              <p className="text-xs text-muted-foreground">
+                Share this link with clients: {acuityLink}
+              </p>
+            )}
+          </div>
+          <Button
+            variant="outline"
+            onClick={() => localStorage.setItem("acuityLink", acuityLink)}
+          >
+            Save
+          </Button>
+        </div>
+
+        <div className="flex items-start justify-between border p-4 rounded-md">
+          <div className="space-y-2 flex-1 mr-4">
+            <p className="font-medium">Setmore</p>
+            <p className="text-sm text-muted-foreground">
+              Provide your booking page link for clients to schedule.
+            </p>
+            <Label htmlFor="setmore-link" className="sr-only">
+              Setmore Link
+            </Label>
+            <Input
+              id="setmore-link"
+              placeholder="https://booking.setmore.com/schedule/yourbusiness"
+              value={setmoreLink}
+              onChange={(e) => setSetmoreLink(e.target.value)}
+              onBlur={() => localStorage.setItem("setmoreLink", setmoreLink)}
+            />
+            {setmoreLink && (
+              <p className="text-xs text-muted-foreground">
+                Share this link with clients: {setmoreLink}
+              </p>
+            )}
+          </div>
+          <Button
+            variant="outline"
+            onClick={() => localStorage.setItem("setmoreLink", setmoreLink)}
+          >
+            Save
+          </Button>
         </div>
       </div>
     </div>

--- a/supabase/functions/booking-webhook/index.ts
+++ b/supabase/functions/booking-webhook/index.ts
@@ -1,0 +1,71 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+    if (!supabaseUrl || !serviceKey) {
+      throw new Error("Server not configured");
+    }
+
+    const supabase = createClient(supabaseUrl, serviceKey);
+
+    const payload = await req.json();
+    const service = payload.service || payload.source || "unknown";
+    const booking = payload.booking || payload.event || payload.payload || payload;
+
+    const appointment = {
+      user_id: booking.user_id || booking.userId,
+      contact_id: booking.contact_id || booking.contactId,
+      title: booking.title || `${service} booking`,
+      appointment_date:
+        booking.appointment_date || booking.start_time || new Date().toISOString(),
+      status: "confirmed",
+    };
+
+    const appointmentsApi = {
+      async create(data: any) {
+        const { data: created, error } = await supabase
+          .from("appointments")
+          .insert(data)
+          .select()
+          .single();
+        if (error) throw error;
+
+        // Track activity to notify users
+        await supabase.from("activities").insert({
+          user_id: data.user_id,
+          activity_type: "appointment_created",
+          title: `Created appointment: ${data.title}`,
+          description: `Scheduled for ${new Date(data.appointment_date).toLocaleDateString()}`,
+          appointment_id: created.id,
+          contact_id: data.contact_id,
+        });
+        return created;
+      },
+    };
+
+    await appointmentsApi.create(appointment);
+
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return new Response(JSON.stringify({ error: message }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add inputs for Calendly, Acuity, and Setmore links in settings
- add shared BookingWidget for embedding scheduler widgets
- handle booking confirmation via Supabase webhook and create appointments

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any...)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b616c8116883339fc59cb4aaa4f32b