### PR TITLE
Fix binary export function

### DIFF
--- a/src/integrations/supabase/accountApi.ts
+++ b/src/integrations/supabase/accountApi.ts
@@ -5,7 +5,15 @@ export async function exportReportData() {
   const client = supabase as SupabaseClient;
   
   try {
-    const response = await client.functions.invoke("export-report-data");
+    // Request the edge function and explicitly ask for binary data.
+    // Without specifying the response type, supabase-js attempts to
+    // parse the body as JSON which results in an "Invalid response
+    // format" error when the function returns a zip file.
+    const response = await client.functions.invoke("export-report-data", {
+      // The function returns a Uint8Array/ArrayBuffer representing the
+      // zipped data export, so we need the raw array buffer here.
+      responseType: "arrayBuffer",
+    });
     
     if (response.error) {
       console.error('Edge function error:', response.error);


### PR DESCRIPTION
## Summary
- ensure export-report-data edge function returns binary without JSON parsing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type; A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b72ab189548333bcffdeae37701a4e