### PR TITLE
chore: use Florida uniform mitigation naming

### DIFF
--- a/src/components/reports/ReportTypeSelector.tsx
+++ b/src/components/reports/ReportTypeSelector.tsx
@@ -12,7 +12,7 @@ const ReportTypeSelector: React.FC = () => {
     <>
       <Seo
         title="Select Report Type | Home Inspection"
-        description="Choose between home inspection and wind mitigation report types"
+        description="Choose between home inspection and uniform mitigation report types"
         canonical={window.location.origin + "/reports/select-type"}
       />
       <section className="max-w-4xl mx-auto px-4 py-10">
@@ -55,9 +55,9 @@ const ReportTypeSelector: React.FC = () => {
               <div className="mx-auto w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mb-4">
                 <Wind className="w-8 h-8 text-primary" />
               </div>
-              <CardTitle>Wind Mitigation</CardTitle>
+              <CardTitle>Uniform Mitigation Verification Inspection</CardTitle>
               <CardDescription>
-                Florida wind mitigation inspection for insurance discounts
+                Florida uniform mitigation verification inspection for insurance discounts
               </CardDescription>
             </CardHeader>
             <CardContent>
@@ -67,11 +67,11 @@ const ReportTypeSelector: React.FC = () => {
                 <li>• Opening protection evaluation</li>
                 <li>• Secondary water resistance check</li>
               </ul>
-              <Button 
-                className="w-full" 
+              <Button
+                className="w-full"
                 onClick={() => navigate("/reports/new/wind-mitigation")}
               >
-                Create Wind Mitigation Report
+                Create Uniform Mitigation Report
               </Button>
             </CardContent>
           </Card>

--- a/src/components/reports/ReportsCardView.tsx
+++ b/src/components/reports/ReportsCardView.tsx
@@ -24,12 +24,17 @@ export const ReportsCardView: React.FC<ReportsCardViewProps> = ({
         <article key={r.id} className="rounded-lg border p-4">
           <div className="flex items-start justify-between mb-2">
             <h2 className="font-medium">{r.title}</h2>
-            {r.archived && (
+            <div className="flex items-center gap-2">
               <Badge variant="outline" className="text-xs">
-                <Archive className="h-3 w-3 mr-1" />
-                Archived
+                {r.reportType === "wind_mitigation" ? "Uniform Mitigation" : "Home Inspection"}
               </Badge>
-            )}
+              {r.archived && (
+                <Badge variant="outline" className="text-xs">
+                  <Archive className="h-3 w-3 mr-1" />
+                  Archived
+                </Badge>
+              )}
+            </div>
           </div>
           <p className="text-sm text-muted-foreground mb-4">
             {/* inspectionDate is ISO; show local date */}

--- a/src/components/reports/ReportsFilterToggle.tsx
+++ b/src/components/reports/ReportsFilterToggle.tsx
@@ -38,7 +38,7 @@ export const ReportsFilterToggle: React.FC<ReportsFilterToggleProps> = ({
             <SelectItem value="wind_mitigation">
               <div className="flex items-center">
                 <Wind className="h-4 w-4 mr-2" />
-                Wind Mitigation
+                Uniform Mitigation
               </div>
             </SelectItem>
           </SelectContent>

--- a/src/components/reports/ReportsListView.tsx
+++ b/src/components/reports/ReportsListView.tsx
@@ -35,7 +35,7 @@ export const ReportsListView: React.FC<ReportsListViewProps> = ({
                   variant="outline" 
                   className="text-xs"
                 >
-                  {report.reportType === "wind_mitigation" ? "Wind Mitigation" : "Home Inspection"}
+                  {report.reportType === "wind_mitigation" ? "Uniform Mitigation" : "Home Inspection"}
                 </Badge>
                 {report.status && (
                   <Badge variant={report.status === "Final" ? "default" : "secondary"} className="text-xs">

--- a/src/components/reports/WindMitigationEditor.tsx
+++ b/src/components/reports/WindMitigationEditor.tsx
@@ -115,10 +115,10 @@ const WindMitigationEditor: React.FC<WindMitigationEditorProps> = ({report, onUp
 
             toast({
                 title: "Report saved",
-                description: "Wind mitigation report has been saved successfully.",
+                description: "Uniform mitigation report has been saved successfully.",
             });
         } catch (error) {
-            console.error("Error saving wind mitigation report:", error);
+            console.error("Error saving uniform mitigation report:", error);
             toast({
                 title: "Save failed",
                 description: error instanceof Error ? error.message : "There was an error saving the report. Please try again.",

--- a/src/components/reports/WindMitigationMainEditor.tsx
+++ b/src/components/reports/WindMitigationMainEditor.tsx
@@ -15,7 +15,7 @@ const WindMitigationMainEditor: React.FC<WindMitigationMainEditorProps> = ({ rep
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
-        <h1 className="text-2xl font-bold">Wind Mitigation Inspection</h1>
+        <h1 className="text-2xl font-bold">Uniform Mitigation Verification Inspection</h1>
         <Button onClick={() => nav(`/reports/${report.id}/preview`)}>Preview Report</Button>
       </div>
       
@@ -28,7 +28,7 @@ const WindMitigationMainEditor: React.FC<WindMitigationMainEditorProps> = ({ rep
             Form OIR-B1-1802 (Rev. 01/12)
           </p>
           <p className="text-muted-foreground">
-            This wind mitigation inspection form will be fully implemented in the next update.
+            This uniform mitigation inspection form will be fully implemented in the next update.
             It will include all 7 questions from the Florida Uniform Mitigation Verification Inspection:
           </p>
           <ul className="mt-4 space-y-2 text-sm">

--- a/src/constants/coverPageEditor.ts
+++ b/src/constants/coverPageEditor.ts
@@ -5,7 +5,7 @@ export const TEMPLATES: Record<string, string> = {
 
 export const REPORT_TYPES = [
   { value: "home_inspection", label: "Home Inspection" },
-  { value: "wind_mitigation", label: "Wind Mitigation" },
+  { value: "wind_mitigation", label: "Uniform Mitigation" },
 ];
 
 export const FONTS = ["Arial", "Times New Roman", "Courier New", "Georgia", "Verdana"];

--- a/src/integrations/supabase/reportsApi.ts
+++ b/src/integrations/supabase/reportsApi.ts
@@ -282,7 +282,7 @@ export async function dbCreateReport(meta: {
     await activitiesApi.trackActivity({
       userId,
       activity_type: 'report_created',
-      title: `Created ${meta.reportType === 'wind_mitigation' ? 'Wind Mitigation' : 'Home Inspection'} report: ${meta.title}`,
+      title: `Created ${meta.reportType === 'wind_mitigation' ? 'Uniform Mitigation' : 'Home Inspection'} report: ${meta.title}`,
       description: `Report for ${meta.clientName} at ${meta.address}`,
       report_id: data.id,
       contact_id: meta.contact_id,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -32,7 +32,7 @@ import { FEATURE_FLAGS } from "@/constants/featureFlags";
 const Index = () => {
   const { user } = useAuth();
   const title = "Home Report Pro | Professional PWA for Home Inspectors";
-  const description = "Modern PWA platform for home inspectors specializing in wind mitigation and home inspections. Works offline, InterNACHI SOP compliant with advanced image annotation.";
+  const description = "Modern PWA platform for home inspectors specializing in uniform mitigation and home inspections. Works offline, InterNACHI SOP compliant with advanced image annotation.";
 
   const jsonLd = {
     "@context": "https://schema.org",
@@ -44,7 +44,7 @@ const Index = () => {
     url: "/",
     features: [
       "Progressive Web App (PWA)",
-      "Wind Mitigation Inspections", 
+      "Uniform Mitigation Inspections",
       "Advanced Image Annotation",
       "Offline Functionality",
       "InterNACHI SOP Compliant Reports",
@@ -147,7 +147,7 @@ const Index = () => {
               InterNACHI SOP compliant reporting with 500+ attorney-vetted templates. Custom branding and digital signatures included.
             </p>
             <div className="space-y-2 text-sm text-muted-foreground">
-              <div>Home & wind mitigation</div>
+              <div>Home & uniform mitigation</div>
               <div>Custom branding</div>
               <div>PDF generation</div>
             </div>
@@ -185,14 +185,14 @@ const Index = () => {
             </div>
           </div>
 
-          {/* Wind Mitigation */}
+          {/* Uniform Mitigation */}
           <div className="group">
             <div className="w-16 h-16 rounded-2xl bg-muted/50 flex items-center justify-center mb-8 group-hover:bg-primary/10 transition-colors">
               <Wind className="h-8 w-8 text-primary" />
             </div>
-            <h3 className="text-2xl font-medium mb-4">Wind Mitigation</h3>
+            <h3 className="text-2xl font-medium mb-4">Uniform Mitigation</h3>
             <p className="text-muted-foreground leading-relaxed mb-6">
-              Specialized wind mitigation forms with OIR-B1-1802 compliance. Automated calculations for insurance discounts.
+              Specialized uniform mitigation forms with OIR-B1-1802 compliance. Automated calculations for insurance discounts.
             </p>
             <div className="space-y-2 text-sm text-muted-foreground">
               <div>OIR-B1-1802 forms</div>

--- a/src/pages/ReportEditor.tsx
+++ b/src/pages/ReportEditor.tsx
@@ -659,7 +659,7 @@ const ReportEditor: React.FC = () => {
   if (report && report.reportType === "wind_mitigation") {
     return (
       <>
-        <Seo title={`${report.title} | Wind Mitigation Editor`} />
+        <Seo title={`${report.title} | Uniform Mitigation Editor`} />
         <div className="max-w-4xl mx-auto px-4 py-6">
           <React.Suspense fallback={<div>Loading...</div>}>
             <WindMitigationEditor 

--- a/src/pages/ReportPreview.tsx
+++ b/src/pages/ReportPreview.tsx
@@ -106,15 +106,15 @@ const ReportPreview: React.FC = () => {
       const url = URL.createObjectURL(pdfBlob);
       const link = document.createElement("a");
       link.href = url;
-      link.download = "wind_mitigation_report.pdf";
+      link.download = "uniform_mitigation_report.pdf";
       link.click();
       URL.revokeObjectURL(url);
-      toast({ title: "PDF Generated", description: "Your Wind Mitigation Report has been generated successfully." });
+      toast({ title: "PDF Generated", description: "Your Uniform Mitigation Report has been generated successfully." });
     } catch (error) {
       console.error(error);
       toast({
         title: "PDF Generation Failed",
-        description: "Could not generate Wind Mitigation Report.",
+        description: "Could not generate Uniform Mitigation Report.",
         variant: "destructive",
       });
     }
@@ -300,11 +300,11 @@ const ReportPreview: React.FC = () => {
           style={{ ...(colorVars ?? {}), color: "var(--body-text-color)" }}
         >
         <h1 className="text-2xl font-bold mb-4" style={{ color: "var(--heading-text-color)" }}>
-          Wind Mitigation Report
+          Uniform Mitigation Report
         </h1>
-        <p className="text-muted-foreground mb-6">Generate your completed Wind Mitigation Report as a PDF.</p>
+        <p className="text-muted-foreground mb-6">Generate your completed Uniform Mitigation Report as a PDF.</p>
         <div className="flex justify-center gap-4">
-          <Button onClick={handleWindMitigationDownload}>Download Wind Mitigation PDF</Button>
+          <Button onClick={handleWindMitigationDownload}>Download Uniform Mitigation PDF</Button>
           <Button variant="outline" onClick={() => nav(`/reports/${report.id}`)}>Back to Editor</Button>
         </div>
       </div>

--- a/src/pages/ReportsList.tsx
+++ b/src/pages/ReportsList.tsx
@@ -117,8 +117,8 @@ const ReportsList: React.FC = () => {
         ) : filteredItems.length === 0 ? (
           <div className="rounded-lg border p-8 text-center">
             <p className="mb-4 text-muted-foreground">
-              {showArchived ? "No archived reports." : 
-               reportTypeFilter !== "all" ? `No ${reportTypeFilter === "wind_mitigation" ? "wind mitigation" : "home inspection"} reports found.` : 
+              {showArchived ? "No archived reports." :
+               reportTypeFilter !== "all" ? `No ${reportTypeFilter === "wind_mitigation" ? "uniform mitigation" : "home inspection"} reports found.` :
                "No reports yet."}
             </p>
             {!showArchived && (

--- a/src/pages/WindMitigationNew.tsx
+++ b/src/pages/WindMitigationNew.tsx
@@ -113,13 +113,13 @@ const WindMitigationNew: React.FC = () => {
           user.id,
           organization?.id
         );
-        toast({ title: "Wind mitigation report created" });
+        toast({ title: "Uniform mitigation report created" });
         nav(`/reports/${report.id}`);
       } else {
-        // For now, wind mitigation reports require authentication
+        // For now, uniform mitigation reports require authentication
         toast({ 
           title: "Authentication required", 
-          description: "Wind mitigation reports require you to be logged in." 
+          description: "Uniform mitigation reports require you to be logged in."
         });
         nav('/auth');
       }
@@ -133,13 +133,13 @@ const WindMitigationNew: React.FC = () => {
   return (
     <>
       <Seo
-        title="New Wind Mitigation Report | Home Inspection"
-        description="Create a new wind mitigation inspection report for Florida insurance discounts."
+        title="New Uniform Mitigation Report | Home Inspection"
+        description="Create a new uniform mitigation verification inspection report for Florida insurance discounts."
         canonical={window.location.origin + "/reports/new/wind-mitigation"}
-        jsonLd={{ "@context": "https://schema.org", "@type": "CreateAction", name: "Create Wind Mitigation Report" }}
+        jsonLd={{ "@context": "https://schema.org", "@type": "CreateAction", name: "Create Uniform Mitigation Report" }}
       />
       <section className="max-w-2xl mx-auto px-4 py-10">
-        <h1 className="text-2xl font-semibold mb-6">New Wind Mitigation Report</h1>
+        <h1 className="text-2xl font-semibold mb-6">New Uniform Mitigation Report</h1>
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
             <FormField
@@ -149,7 +149,7 @@ const WindMitigationNew: React.FC = () => {
                 <FormItem>
                   <FormLabel>Report Title</FormLabel>
                   <FormControl>
-                    <Input placeholder="e.g., 123 Main St Wind Mitigation" {...field} />
+                    <Input placeholder="e.g., 123 Main St Uniform Mitigation" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -302,10 +302,10 @@ const WindMitigationNew: React.FC = () => {
                 <FormItem>
                   <FormLabel>Property Address</FormLabel>
                   <FormControl>
-                    <Textarea 
-                      placeholder="Enter the property address for wind mitigation inspection"
+                    <Textarea
+                      placeholder="Enter the property address for uniform mitigation inspection"
                       className="min-h-[80px]"
-                      {...field} 
+                      {...field}
                     />
                   </FormControl>
                   <FormMessage />

--- a/src/utils/fillWindMitigationPDF.ts
+++ b/src/utils/fillWindMitigationPDF.ts
@@ -492,18 +492,18 @@ export async function downloadWindMitigationReport(reportId: string) {
         const url = URL.createObjectURL(pdfBlob);
         const link = document.createElement("a");
         link.href = url;
-        link.download = "wind_mitigation_report.pdf";
+        link.download = "uniform_mitigation_report.pdf";
         link.click();
         URL.revokeObjectURL(url);
         toast({
             title: "PDF Generated",
-            description: "Your Wind Mitigation Report has been generated successfully.",
+            description: "Your Uniform Mitigation Report has been generated successfully.",
         });
     } catch (error) {
         console.error(error);
         toast({
             title: "PDF Generation Failed",
-            description: "Could not generate Wind Mitigation Report.",
+            description: "Could not generate Uniform Mitigation Report.",
             variant: "destructive",
         });
     }


### PR DESCRIPTION
## Summary
- rename wind mitigation to Uniform Mitigation across report type selector and filters
- update wind-mitigation pages with new titles, metadata, and copy
- refresh homepage, cover editor, and PDF generation messages for Florida naming

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 263 problems, Unexpected any etc.)

------
https://chatgpt.com/codex/tasks/task_e_68b74698643c8333801c4a2c23692458