### PR TITLE
feat: add Florida 4-point report type

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,8 +54,9 @@ const App = () => (
               <Route path="/reports/select-type" element={lazyLoad(() => import("./components/reports/ReportTypeSelector"))} />
               <Route path="/reports/new" element={lazyLoad(() => import("./pages/ReportNew"))} />
               <Route path="/reports/new/home-inspection" element={lazyLoad(() => import("./pages/HomeInspectionNew"))} />
-              <Route path="/reports/new/wind-mitigation" element={lazyLoad(() => import("./pages/WindMitigationNew"))} />
-              <Route path="/reports/new/:reportType" element={lazyLoad(() => import("./pages/GenericReportNew"))} />
+                <Route path="/reports/new/wind-mitigation" element={lazyLoad(() => import("./pages/WindMitigationNew"))} />
+                <Route path="/reports/new/fl-four-point" element={lazyLoad(() => import("./pages/FlFourPointNew"))} />
+                <Route path="/reports/new/:reportType" element={lazyLoad(() => import("./pages/GenericReportNew"))} />
               <Route path="/reports/:id" element={lazyLoad(() => import("./pages/ReportEditor"))} />
               <Route path="/reports/:id/preview" element={lazyLoad(() => import("./pages/ReportPreview"))} />
               <Route path="/reports/:reportId/findings/:findingId/media/:mediaId/annotate" element={lazyLoad(() => import("./pages/ImageAnnotation"))} />

--- a/src/components/reports/FlFourPointEditor.tsx
+++ b/src/components/reports/FlFourPointEditor.tsx
@@ -1,0 +1,145 @@
+import React from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { FL_FOUR_POINT_QUESTIONS } from "@/constants/flFourPointQuestions";
+import { Form, FormField } from "@/components/ui/form";
+import InfoFieldWidget from "./InfoFieldWidget";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { uploadFindingFiles, getSignedUrlFromSupabaseUrl, isSupabaseUrl } from "@/integrations/supabase/storage";
+import { useAuth } from "@/contexts/AuthContext";
+import { dbUpdateReport } from "@/integrations/supabase/reportsApi";
+import { toast } from "@/components/ui/use-toast";
+import type { FlFourPointCitizensReport } from "@/lib/reportSchemas";
+import { z } from "zod";
+
+interface EditorProps {
+  report: FlFourPointCitizensReport;
+  onUpdate: (r: FlFourPointCitizensReport) => void;
+}
+
+const sectionSchema = FL_FOUR_POINT_QUESTIONS.sections.reduce((acc, section) => {
+  acc[section.name] = z.record(z.any()).optional();
+  return acc;
+}, {} as Record<string, any>);
+const FormSchema = z.object(sectionSchema);
+
+const FlFourPointEditor: React.FC<EditorProps> = ({ report, onUpdate }) => {
+  const { user } = useAuth();
+  const [coverPreviewUrl, setCoverPreviewUrl] = React.useState<string>("");
+
+  React.useEffect(() => {
+    if (!report.coverImage) return;
+    if (!user || !isSupabaseUrl(report.coverImage)) {
+      setCoverPreviewUrl(report.coverImage);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const signed = await getSignedUrlFromSupabaseUrl(report.coverImage);
+        if (!cancelled) setCoverPreviewUrl(signed);
+      } catch (e) {
+        console.error("Failed to sign cover image", e);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, report.coverImage]);
+
+  const form = useForm<any>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: report.reportData || {},
+  });
+
+  const handleCoverImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (user) {
+      try {
+        const uploaded = await uploadFindingFiles({
+          userId: user.id,
+          reportId: report.id,
+          findingId: "cover",
+          files: [file],
+        });
+        if (uploaded[0]) {
+          const updated = { ...report, coverImage: uploaded[0].url };
+          onUpdate(updated);
+          const signed = await getSignedUrlFromSupabaseUrl(uploaded[0].url);
+          setCoverPreviewUrl(signed);
+          await dbUpdateReport(updated);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    } else {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const url = reader.result as string;
+        const updated = { ...report, coverImage: url };
+        onUpdate(updated);
+        setCoverPreviewUrl(url);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const handleSave = async () => {
+    try {
+      const current = form.getValues();
+      const updated = { ...report, reportData: current } as FlFourPointCitizensReport;
+      await dbUpdateReport(updated);
+      onUpdate(updated);
+      toast({ title: "Report saved" });
+    } catch (e) {
+      console.error(e);
+      toast({ title: "Save failed", variant: "destructive" });
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{FL_FOUR_POINT_QUESTIONS.title}</h1>
+        <Button onClick={handleSave}>Save Report</Button>
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-sm font-medium">Cover Image</Label>
+        {coverPreviewUrl && (
+          <img src={coverPreviewUrl} alt="Cover" className="h-40 w-auto rounded border" />
+        )}
+        <Input type="file" accept="image/*" onChange={handleCoverImageUpload} />
+      </div>
+
+      <Form {...form}>
+        <div className="space-y-8">
+          {FL_FOUR_POINT_QUESTIONS.sections.map((section) => (
+            <div key={section.name} className="space-y-4">
+              <h2 className="text-xl font-semibold capitalize">{section.name.replace(/_/g, " ")}</h2>
+              {section.fields.map((field) => (
+                <FormField
+                  key={field.name}
+                  control={form.control}
+                  name={`${section.name}.${field.name}`}
+                  render={({ field: f }) => (
+                    <InfoFieldWidget
+                      field={{ ...field, widget: field.widget === "radio" ? "select" : field.widget }}
+                      value={f.value || ""}
+                      onChange={(val) => f.onChange(val)}
+                    />
+                  )}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </Form>
+    </div>
+  );
+};
+
+export default FlFourPointEditor;

--- a/src/components/reports/PDFDocument.tsx
+++ b/src/components/reports/PDFDocument.tsx
@@ -7,6 +7,7 @@ import ReportDetailsSection from "./ReportDetailsSection";
 import SectionInfoDisplay from "./SectionInfoDisplay";
 import { isSupabaseUrl } from "@/integrations/supabase/storage";
 import { COVER_TEMPLATES } from "@/constants/coverTemplates";
+import { FL_FOUR_POINT_QUESTIONS } from "@/constants/flFourPointQuestions";
 
 
 interface PDFDocumentProps {
@@ -18,11 +19,44 @@ interface PDFDocumentProps {
 
 const PDFDocument = React.forwardRef<HTMLDivElement, PDFDocumentProps>(
     ({report, mediaUrlMap, coverUrl, company}, ref) => {
-        // Only render PDFs for home inspection reports for now
+        if (report.reportType === "fl_four_point_citizens") {
+            const sections = FL_FOUR_POINT_QUESTIONS.sections;
+            return (
+                <div ref={ref} className="pdf-document">
+                    <section className="pdf-page-break">
+                        <div className="text-center p-8">
+                            {coverUrl && <img src={coverUrl} alt="Cover" className="mx-auto mb-6 h-40 w-auto" />}
+                            <h1 className="text-2xl font-bold mb-2">{report.title}</h1>
+                            <p className="mb-1">{report.clientName}</p>
+                            <p className="mb-1">{report.address}</p>
+                            <p className="mb-1">Inspection Date: {report.inspectionDate}</p>
+                        </div>
+                    </section>
+                    {sections.map((section) => (
+                        <section key={section.name} className="pdf-page-break p-8">
+                            <h2 className="text-xl font-semibold mb-4 capitalize">{section.name.replace(/_/g, " ")}</h2>
+                            <table className="w-full text-sm border-collapse">
+                                <tbody>
+                                {section.fields.map((field) => (
+                                    <tr key={field.name}>
+                                        <td className="border p-2 font-medium w-1/2">{field.label}</td>
+                                        <td className="border p-2">
+                                            {String((report.reportData?.[section.name] || {})[field.name] || "")}
+                                        </td>
+                                    </tr>
+                                ))}
+                                </tbody>
+                            </table>
+                        </section>
+                    ))}
+                </div>
+            );
+        }
+
         if (report.reportType !== "home_inspection") {
             return (
                 <div className="p-8 text-center">
-                    <p>PDF generation for wind mitigation reports is coming soon.</p>
+                    <p>PDF generation for this report type is coming soon.</p>
                 </div>
             );
         }

--- a/src/components/reports/ReportTypeSelector.tsx
+++ b/src/components/reports/ReportTypeSelector.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import Seo from "@/components/Seo";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Home, Wind } from "lucide-react";
+import { Home, Wind, ClipboardList } from "lucide-react";
 
 const ReportTypeSelector: React.FC = () => {
   const navigate = useNavigate();
@@ -23,7 +23,7 @@ const ReportTypeSelector: React.FC = () => {
           </p>
         </div>
         
-        <div className="grid md:grid-cols-2 gap-6">
+        <div className="grid md:grid-cols-3 gap-6">
           <Card className="cursor-pointer hover:shadow-lg transition-shadow border-2 hover:border-primary/20">
             <CardHeader className="text-center">
               <div className="mx-auto w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mb-4">
@@ -72,6 +72,30 @@ const ReportTypeSelector: React.FC = () => {
                 onClick={() => navigate("/reports/new/wind-mitigation")}
               >
                 Create Uniform Mitigation Report
+              </Button>
+            </CardContent>
+          </Card>
+
+          <Card className="cursor-pointer hover:shadow-lg transition-shadow border-2 hover:border-primary/20">
+            <CardHeader className="text-center">
+              <div className="mx-auto w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mb-4">
+                <ClipboardList className="w-8 h-8 text-primary" />
+              </div>
+              <CardTitle>Florida 4-Point (Citizens)</CardTitle>
+              <CardDescription>
+                Florida 4-point inspection for underwriting older homes
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-2 text-sm text-muted-foreground mb-6">
+                <li>• Roof, electrical, plumbing, HVAC overview</li>
+                <li>• Photos and signatures</li>
+              </ul>
+              <Button
+                className="w-full"
+                onClick={() => navigate("/reports/new/fl-four-point")}
+              >
+                Create FL 4-Point Report
               </Button>
             </CardContent>
           </Card>

--- a/src/constants/flFourPointQuestions.ts
+++ b/src/constants/flFourPointQuestions.ts
@@ -1,0 +1,179 @@
+export const FL_FOUR_POINT_QUESTIONS = {
+  id: "fl_four_point_citizens",
+  title: "Florida 4-Point (Citizens-style)",
+  jurisdiction: "FL",
+  use_case: "Underwriting for older homes",
+  sections: [
+    {
+      name: "general",
+      fields: [
+        {
+          name: "inspection_date",
+          label: "Inspection Date",
+          widget: "date",
+          required: true
+        },
+        {
+          name: "property_address",
+          label: "Property Address",
+          widget: "textarea",
+          required: true
+        },
+        {
+          name: "year_built",
+          label: "Year Built",
+          widget: "number",
+          required: true
+        }
+      ]
+    },
+    {
+      name: "roof",
+      fields: [
+        {
+          name: "covering_type",
+          label: "Covering Type",
+          widget: "select",
+          options: [
+            "Asphalt Shingle",
+            "Metal",
+            "Tile",
+            "Flat/BUR/Mod Bit",
+            "Other"
+          ],
+          required: true
+        },
+        {
+          name: "year_installed",
+          label: "Year Installed",
+          widget: "number",
+          required: false
+        },
+        {
+          name: "remaining_life_years",
+          label: "Remaining Useful Life (yrs)",
+          widget: "number",
+          required: true
+        },
+        {
+          name: "active_leaks",
+          label: "Any Active Leaks?",
+          widget: "radio",
+          options: ["Yes", "No"],
+          required: true
+        }
+      ]
+    },
+    {
+      name: "electrical",
+      fields: [
+        {
+          name: "service_amperage",
+          label: "Main Service Amperage",
+          widget: "number",
+          required: true
+        },
+        {
+          name: "panel_brand",
+          label: "Panel Brand/Type",
+          widget: "text",
+          required: true
+        },
+        {
+          name: "aluminum_branch_wiring",
+          label: "Aluminum Branch Wiring Present",
+          widget: "radio",
+          options: ["Yes", "No", "Unknown"],
+          required: true
+        },
+        {
+          name: "knob_tube_present",
+          label: "Knob & Tube Present",
+          widget: "radio",
+          options: ["Yes", "No", "Unknown"],
+          required: true
+        },
+        {
+          name: "hazards",
+          label: "Observed Hazards/Deficiencies",
+          widget: "textarea",
+          required: false
+        }
+      ]
+    },
+    {
+      name: "plumbing",
+      fields: [
+        {
+          name: "supply_piping",
+          label: "Supply Piping Material",
+          widget: "select",
+          options: [
+            "COPPER",
+            "CPVC",
+            "PEX",
+            "GALVANIZED",
+            "POLYBUTYLENE",
+            "OTHER"
+          ],
+          required: true
+        },
+        {
+          name: "water_heater_year",
+          label: "Water Heater Year",
+          widget: "number",
+          required: false
+        },
+        {
+          name: "leaks_present",
+          label: "Leaks Observed",
+          widget: "radio",
+          options: ["Yes", "No"],
+          required: true
+        }
+      ]
+    },
+    {
+      name: "hvac",
+      fields: [
+        {
+          name: "primary_system_type",
+          label: "Primary System Type",
+          widget: "select",
+          options: ["Central AC", "Heat Pump", "Mini-Split", "Other"],
+          required: true
+        },
+        {
+          name: "cooling_year",
+          label: "Cooling Equipment Year",
+          widget: "number",
+          required: false
+        },
+        {
+          name: "heating_present",
+          label: "Heating Present",
+          widget: "radio",
+          options: ["Yes", "No"],
+          required: true
+        }
+      ]
+    },
+    {
+      name: "photos_signatures",
+      fields: [
+        {
+          name: "photos",
+          label: "Photo Uploads",
+          widget: "upload",
+          required: false
+        },
+        {
+          name: "inspector_signature",
+          label: "Signature",
+          widget: "signature",
+          required: true
+        }
+      ]
+    }
+  ]
+};

--- a/src/pages/FlFourPointNew.tsx
+++ b/src/pages/FlFourPointNew.tsx
@@ -1,0 +1,194 @@
+import React, { useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { useQuery } from "@tanstack/react-query";
+import Seo from "@/components/Seo";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { toast } from "@/components/ui/use-toast";
+import { useAuth } from "@/contexts/AuthContext";
+import { dbCreateReport } from "@/integrations/supabase/reportsApi";
+import { contactsApi } from "@/integrations/supabase/crmApi";
+import { getMyOrganization } from "@/integrations/supabase/organizationsApi";
+
+const schema = z.object({
+  title: z.string().min(1, "Required"),
+  clientName: z.string().min(1, "Required"),
+  address: z.string().min(1, "Address is required"),
+  inspectionDate: z.string().min(1, "Required"),
+  contactId: z.string().optional(),
+});
+
+type Values = z.infer<typeof schema>;
+
+const FlFourPointNew: React.FC = () => {
+  const nav = useNavigate();
+  const { user } = useAuth();
+  const [searchParams] = useSearchParams();
+  const contactId = searchParams.get("contactId");
+
+  const { data: contacts = [] } = useQuery({
+    queryKey: ["contacts", user?.id],
+    queryFn: () => contactsApi.list(user!.id),
+    enabled: !!user,
+  });
+
+  const { data: contact } = useQuery({
+    queryKey: ["contact", contactId],
+    queryFn: () => contactsApi.get(contactId!),
+    enabled: !!contactId && !!user,
+  });
+
+  const form = useForm<Values>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      title: "",
+      clientName: "",
+      address: "",
+      inspectionDate: new Date().toISOString().slice(0, 10),
+      contactId: contactId || "",
+    },
+  });
+
+  useEffect(() => {
+    if (contact) {
+      form.setValue("clientName", `${contact.first_name} ${contact.last_name}`);
+      const contactAddress = contact.formatted_address || contact.address || "";
+      if (contactAddress) {
+        form.setValue("address", contactAddress);
+      }
+    }
+  }, [contact, form]);
+
+  const onSubmit = async (values: Values) => {
+    try {
+      if (user) {
+        const organization = await getMyOrganization();
+        const report = await dbCreateReport(
+          {
+            title: values.title,
+            clientName: values.clientName,
+            address: values.address,
+            inspectionDate: values.inspectionDate,
+            contact_id: values.contactId,
+            reportType: "fl_four_point_citizens",
+          },
+          user.id,
+          organization?.id
+        );
+        toast({ title: "FL 4-Point report created" });
+        nav(`/reports/${report.id}`);
+      } else {
+        toast({ title: "Authentication required", description: "Please log in to create reports." });
+      }
+    } catch (e: any) {
+      console.error(e);
+      toast({ title: "Failed to create report", description: e?.message || "Please try again." });
+    }
+  };
+
+  return (
+    <>
+      <Seo
+        title="New FL 4-Point Report"
+        description="Create a new Florida 4-Point inspection report."
+        canonical={window.location.origin + "/reports/new/fl-four-point"}
+      />
+      <section className="max-w-2xl mx-auto px-4 py-10">
+        <h1 className="text-2xl font-semibold mb-6">New FL 4-Point Report</h1>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Report Title</FormLabel>
+                  <FormControl>
+                    <Input placeholder="e.g., 123 Main St 4-Point" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="contactId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Client Contact</FormLabel>
+                  <FormControl>
+                    <Select
+                      value={field.value}
+                      onValueChange={(val) => {
+                        field.onChange(val);
+                        const selected = contacts.find((c) => c.id === val);
+                        if (selected) {
+                          form.setValue("clientName", `${selected.first_name} ${selected.last_name}`);
+                          const addr = selected.formatted_address || selected.address || "";
+                          if (addr) form.setValue("address", addr);
+                        }
+                      }}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select a contact..." />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {contacts.map((c) => (
+                          <SelectItem key={c.id} value={c.id}>
+                            {c.first_name} {c.last_name}
+                            {c.email && <span className="text-muted-foreground ml-2">({c.email})</span>}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="address"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Property Address</FormLabel>
+                  <FormControl>
+                    <Textarea placeholder="123 Main St, Springfield" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="inspectionDate"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Inspection Date</FormLabel>
+                  <FormControl>
+                    <Input type="date" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="outline" onClick={() => nav('/reports/select-type')}>
+                Back
+              </Button>
+              <Button type="submit">Create Report</Button>
+            </div>
+          </form>
+        </Form>
+      </section>
+    </>
+  );
+};
+
+export default FlFourPointNew;

--- a/src/pages/ReportEditor.tsx
+++ b/src/pages/ReportEditor.tsx
@@ -37,6 +37,7 @@ import ContactMultiSelect from "@/components/contacts/ContactMultiSelect";
 
 // Lazy load wind mitigation editor at module level
 const WindMitigationEditor = React.lazy(() => import("@/components/reports/WindMitigationEditor"));
+const FlFourPointEditor = React.lazy(() => import("@/components/reports/FlFourPointEditor"));
 
 const SEVERITIES = ["Info", "Maintenance", "Minor", "Moderate", "Major", "Safety"] as const;
 type Severity = typeof SEVERITIES[number];
@@ -661,10 +662,23 @@ const ReportEditor: React.FC = () => {
         <Seo title={`${report.title} | Uniform Mitigation Editor`} />
         <div className="max-w-4xl mx-auto px-4 py-6">
           <React.Suspense fallback={<div>Loading...</div>}>
-            <WindMitigationEditor 
-              report={report} 
-              onUpdate={setReport} 
+            <WindMitigationEditor
+              report={report}
+              onUpdate={setReport}
             />
+          </React.Suspense>
+        </div>
+      </>
+    );
+  }
+
+  if (report && report.reportType === "fl_four_point_citizens") {
+    return (
+      <>
+        <Seo title={`${report.title} | FL 4-Point Editor`} />
+        <div className="max-w-4xl mx-auto px-4 py-6">
+          <React.Suspense fallback={<div>Loading...</div>}>
+            <FlFourPointEditor report={report} onUpdate={setReport} />
           </React.Suspense>
         </div>
       </>

--- a/src/pages/ReportPreview.tsx
+++ b/src/pages/ReportPreview.tsx
@@ -312,6 +312,24 @@ const ReportPreview: React.FC = () => {
     );
   }
 
+  if (report.reportType === "fl_four_point_citizens") {
+    return (
+      <div className="max-w-4xl mx-auto px-4 py-10">
+        <div className="flex justify-center gap-4 mb-6">
+          <Button onClick={onPrintClick} disabled={isGeneratingPDF}>
+            {isGeneratingPDF ? "Generating PDF..." : "Download PDF"}
+          </Button>
+          <Button variant="outline" onClick={() => nav(`/reports/${report.id}`)}>
+            Back to Editor
+          </Button>
+        </div>
+        <div ref={pdfContainerRef}>
+          <PDFDocument report={report} mediaUrlMap={{}} coverUrl={coverUrl} company={organization?.name || ""} />
+        </div>
+      </div>
+    );
+  }
+
   if (report.reportType !== "home_inspection") {
     return (
       <div className="max-w-4xl mx-auto px-4 py-10 text-center">


### PR DESCRIPTION
## Summary
- add FL 4-point form config and creation/editor pages
- wire report type selection, routing, preview, and PDF support

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b751471670833390f1ddd5603681a2