### PR TITLE
refactor: use named InfoFieldWidget import

### DIFF
--- a/src/components/reports/FlFourPointEditor.tsx
+++ b/src/components/reports/FlFourPointEditor.tsx
@@ -3,7 +3,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { FL_FOUR_POINT_QUESTIONS } from "@/constants/flFourPointQuestions";
 import { Form, FormField } from "@/components/ui/form";
-import InfoFieldWidget from "./InfoFieldWidget";
+import { InfoFieldWidget } from "./InfoFieldWidget";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";

--- a/src/components/reports/TxWindstormEditor.tsx
+++ b/src/components/reports/TxWindstormEditor.tsx
@@ -3,7 +3,7 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Form, FormField } from "@/components/ui/form";
-import InfoFieldWidget from "./InfoFieldWidget";
+import { InfoFieldWidget } from "./InfoFieldWidget";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";


### PR DESCRIPTION
## Summary
- use named export for InfoFieldWidget in FL Four Point and TX Windstorm editors
- ensure no remaining default imports of InfoFieldWidget

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 249 errors, 25 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b75d4c8fd483338077b7b5c5e65190