### PR TITLE
feat: add CA wildfire assessment report

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,6 +57,7 @@ const App = () => (
                 <Route path="/reports/new/wind-mitigation" element={lazyLoad(() => import("./pages/WindMitigationNew"))} />
                 <Route path="/reports/new/fl-four-point" element={lazyLoad(() => import("./pages/FlFourPointNew"))} />
                 <Route path="/reports/new/tx-windstorm" element={lazyLoad(() => import("./pages/TxWindstormNew"))} />
+                <Route path="/reports/new/ca-wildfire" element={lazyLoad(() => import("./pages/CaWildfireNew"))} />
                 <Route path="/reports/new/:reportType" element={lazyLoad(() => import("./pages/GenericReportNew"))} />
               <Route path="/reports/:id" element={lazyLoad(() => import("./pages/ReportEditor"))} />
               <Route path="/reports/:id/preview" element={lazyLoad(() => import("./pages/ReportPreview"))} />

--- a/src/components/reports/CaWildfireEditor.tsx
+++ b/src/components/reports/CaWildfireEditor.tsx
@@ -1,0 +1,231 @@
+import React from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Form, FormField } from "@/components/ui/form";
+import { InfoFieldWidget } from "./InfoFieldWidget";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { uploadFindingFiles, getSignedUrlFromSupabaseUrl, isSupabaseUrl } from "@/integrations/supabase/storage";
+import { useAuth } from "@/contexts/AuthContext";
+import { dbUpdateReport } from "@/integrations/supabase/reportsApi";
+import { toast } from "@/components/ui/use-toast";
+import type { CaWildfireDefensibleSpaceReport } from "@/lib/reportSchemas";
+import { CA_WILDFIRE_QUESTIONS } from "@/constants/caWildfireQuestions";
+
+interface EditorProps {
+  report: CaWildfireDefensibleSpaceReport;
+  onUpdate: (r: CaWildfireDefensibleSpaceReport) => void;
+}
+
+const sectionSchema = CA_WILDFIRE_QUESTIONS.sections.reduce((acc, section) => {
+  acc[section.name] = z.record(z.any()).optional();
+  return acc;
+}, {} as Record<string, any>);
+const FormSchema = z.object(sectionSchema);
+
+const CaWildfireEditor: React.FC<EditorProps> = ({ report, onUpdate }) => {
+  const { user } = useAuth();
+  const [coverPreviewUrl, setCoverPreviewUrl] = React.useState<string>("");
+  const [photoPreviews, setPhotoPreviews] = React.useState<string[]>([]);
+
+  React.useEffect(() => {
+    if (!report.coverImage) return;
+    if (!user || !isSupabaseUrl(report.coverImage)) {
+      setCoverPreviewUrl(report.coverImage);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const signed = await getSignedUrlFromSupabaseUrl(report.coverImage);
+        if (!cancelled) setCoverPreviewUrl(signed);
+      } catch (e) {
+        console.error("Failed to sign cover image", e);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, report.coverImage]);
+
+  const form = useForm<any>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: report.reportData || {},
+  });
+
+  React.useEffect(() => {
+    const photos: string[] = form.getValues("photos.photos") || [];
+    if (photos.length === 0) return;
+    if (!user) {
+      setPhotoPreviews(photos);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      const signed = await Promise.all(
+        photos.map(async (p) => (isSupabaseUrl(p) ? await getSignedUrlFromSupabaseUrl(p) : p))
+      );
+      if (!cancelled) setPhotoPreviews(signed);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, form]);
+
+  const handleCoverImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (user) {
+      try {
+        const uploaded = await uploadFindingFiles({
+          userId: user.id,
+          reportId: report.id,
+          findingId: "cover",
+          files: [file],
+        });
+        if (uploaded[0]) {
+          const updated = { ...report, coverImage: uploaded[0].url };
+          onUpdate(updated);
+          const signed = await getSignedUrlFromSupabaseUrl(uploaded[0].url);
+          setCoverPreviewUrl(signed);
+          await dbUpdateReport(updated);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    } else {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const url = reader.result as string;
+        const updated = { ...report, coverImage: url };
+        onUpdate(updated);
+        setCoverPreviewUrl(url);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const handlePhotoUpload = async (files: FileList) => {
+    if (!files.length) return;
+    if (user) {
+      try {
+        const uploaded = await uploadFindingFiles({
+          userId: user.id,
+          reportId: report.id,
+          findingId: "photos",
+          files: Array.from(files),
+        });
+        const urls = uploaded.map((u) => u.url);
+        const current = form.getValues("photos.photos") || [];
+        const newVals = [...current, ...urls];
+        form.setValue("photos.photos", newVals);
+        const updated = { ...report, reportData: form.getValues() };
+        onUpdate(updated);
+        await dbUpdateReport(updated);
+        const signed = await Promise.all(urls.map((u) => getSignedUrlFromSupabaseUrl(u)));
+        setPhotoPreviews((prev) => [...prev, ...signed]);
+      } catch (e) {
+        console.error(e);
+      }
+    } else {
+      const readers = Array.from(files).map(
+        (file) =>
+          new Promise<string>((resolve) => {
+            const reader = new FileReader();
+            reader.onload = () => resolve(reader.result as string);
+            reader.readAsDataURL(file);
+          })
+      );
+      const urls = await Promise.all(readers);
+      const current = form.getValues("photos.photos") || [];
+      const newVals = [...current, ...urls];
+      form.setValue("photos.photos", newVals);
+      const updated = { ...report, reportData: form.getValues() };
+      onUpdate(updated);
+      setPhotoPreviews((prev) => [...prev, ...urls]);
+    }
+  };
+
+  const handleSave = async () => {
+    try {
+      const current = form.getValues();
+      const updated = { ...report, reportData: current } as CaWildfireDefensibleSpaceReport;
+      await dbUpdateReport(updated);
+      onUpdate(updated);
+      toast({ title: "Report saved" });
+    } catch (e) {
+      console.error(e);
+      toast({ title: "Save failed", variant: "destructive" });
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{CA_WILDFIRE_QUESTIONS.title}</h1>
+        <Button onClick={handleSave}>Save Report</Button>
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-sm font-medium">Cover Image</Label>
+        {coverPreviewUrl && (
+          <img src={coverPreviewUrl} alt="Cover" className="h-40 w-auto rounded border" />
+        )}
+        <Input type="file" accept="image/*" onChange={handleCoverImageUpload} />
+      </div>
+
+      <Form {...form}>
+        <div className="space-y-8">
+          {CA_WILDFIRE_QUESTIONS.sections.map((section) => (
+            <div key={section.name} className="space-y-4">
+              <h2 className="text-xl font-semibold capitalize">{section.name.replace(/_/g, " ")}</h2>
+              {section.name === "photos" ? (
+                <FormField
+                  control={form.control}
+                  name={`${section.name}.photos`}
+                  render={() => (
+                    <div className="space-y-2">
+                      {photoPreviews.length > 0 && (
+                        <div className="flex flex-wrap gap-2">
+                          {photoPreviews.map((url, idx) => (
+                            <img key={idx} src={url} alt="" className="h-24 w-auto rounded border" />
+                          ))}
+                        </div>
+                      )}
+                      <Input
+                        type="file"
+                        accept="image/*"
+                        multiple
+                        onChange={(e) => e.target.files && handlePhotoUpload(e.target.files)}
+                      />
+                    </div>
+                  )}
+                />
+              ) : (
+                section.fields.map((field) => (
+                  <FormField
+                    key={field.name}
+                    control={form.control}
+                    name={`${section.name}.${field.name}`}
+                    render={({ field: f }) => (
+                      <InfoFieldWidget
+                        field={{ ...field, widget: field.widget === "radio" ? "select" : field.widget }}
+                        value={f.value || ""}
+                        onChange={(val) => f.onChange(val)}
+                      />
+                    )}
+                  />
+                ))
+              )}
+            </div>
+          ))}
+        </div>
+      </Form>
+    </div>
+  );
+};
+
+export default CaWildfireEditor;
+

--- a/src/components/reports/PDFDocument.tsx
+++ b/src/components/reports/PDFDocument.tsx
@@ -9,6 +9,7 @@ import { isSupabaseUrl } from "@/integrations/supabase/storage";
 import { COVER_TEMPLATES } from "@/constants/coverTemplates";
 import { FL_FOUR_POINT_QUESTIONS } from "@/constants/flFourPointQuestions";
 import { TX_WINDSTORM_QUESTIONS } from "@/constants/txWindstormQuestions";
+import { CA_WILDFIRE_QUESTIONS } from "@/constants/caWildfireQuestions";
 
 
 interface PDFDocumentProps {
@@ -56,6 +57,48 @@ const PDFDocument = React.forwardRef<HTMLDivElement, PDFDocumentProps>(
 
         if (report.reportType === "tx_coastal_windstorm_mitigation") {
             const sections = TX_WINDSTORM_QUESTIONS.sections;
+            return (
+                <div ref={ref} className="pdf-document">
+                    <section className="pdf-page-break">
+                        <div className="text-center p-8">
+                            {coverUrl && <img src={coverUrl} alt="Cover" className="mx-auto mb-6 h-40 w-auto" />}
+                            <h1 className="text-2xl font-bold mb-2">{report.title}</h1>
+                            <p className="mb-1">{report.clientName}</p>
+                            <p className="mb-1">{report.address}</p>
+                            <p className="mb-1">Inspection Date: {report.inspectionDate}</p>
+                        </div>
+                    </section>
+                    {sections.map((section) => (
+                        <section key={section.name} className="pdf-page-break p-8">
+                            <h2 className="text-xl font-semibold mb-4 capitalize">{section.name.replace(/_/g, " ")}</h2>
+                            {section.name === "photos" ? (
+                                <div className="flex flex-wrap gap-2">
+                                    {((report.reportData?.[section.name] || {}).photos || []).map((url: string, idx: number) => (
+                                        <img key={idx} src={mediaUrlMap[url] || url} alt="" className="h-24 w-auto rounded border" />
+                                    ))}
+                                </div>
+                            ) : (
+                                <table className="w-full text-sm border-collapse">
+                                    <tbody>
+                                    {section.fields.map((field) => (
+                                        <tr key={field.name}>
+                                            <td className="border p-2 font-medium w-1/2">{field.label}</td>
+                                            <td className="border p-2">
+                                                {String((report.reportData?.[section.name] || {})[field.name] || "")}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                    </tbody>
+                                </table>
+                            )}
+                        </section>
+                    ))}
+                </div>
+            );
+        }
+
+        if (report.reportType === "ca_wildfire_defensible_space") {
+            const sections = CA_WILDFIRE_QUESTIONS.sections;
             return (
                 <div ref={ref} className="pdf-document">
                     <section className="pdf-page-break">

--- a/src/components/reports/ReportTypeSelector.tsx
+++ b/src/components/reports/ReportTypeSelector.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import Seo from "@/components/Seo";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Home, Wind, ClipboardList, Shield } from "lucide-react";
+import { Home, Wind, ClipboardList, Shield, Flame } from "lucide-react";
 
 const ReportTypeSelector: React.FC = () => {
   const navigate = useNavigate();
@@ -23,7 +23,7 @@ const ReportTypeSelector: React.FC = () => {
           </p>
         </div>
         
-        <div className="grid md:grid-cols-4 gap-6">
+        <div className="grid md:grid-cols-5 gap-6">
           <Card className="cursor-pointer hover:shadow-lg transition-shadow border-2 hover:border-primary/20">
             <CardHeader className="text-center">
               <div className="mx-auto w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mb-4">
@@ -121,6 +121,31 @@ const ReportTypeSelector: React.FC = () => {
                 onClick={() => navigate("/reports/new/tx-windstorm")}
               >
                 Create TX Windstorm Report
+              </Button>
+            </CardContent>
+          </Card>
+
+          <Card className="cursor-pointer hover:shadow-lg transition-shadow border-2 hover:border-primary/20">
+            <CardHeader className="text-center">
+              <div className="mx-auto w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mb-4">
+                <Flame className="w-8 h-8 text-primary" />
+              </div>
+              <CardTitle>CA Wildfire Assessment</CardTitle>
+              <CardDescription>
+                California wildfire defensible space assessment for underwriting
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-2 text-sm text-muted-foreground mb-6">
+                <li>• Structure materials and vents</li>
+                <li>• Defensible space zones 0-100 ft</li>
+                <li>• Access and utility hazards</li>
+              </ul>
+              <Button
+                className="w-full"
+                onClick={() => navigate("/reports/new/ca-wildfire")}
+              >
+                Create CA Wildfire Report
               </Button>
             </CardContent>
           </Card>

--- a/src/components/reports/ReportsFilterToggle.tsx
+++ b/src/components/reports/ReportsFilterToggle.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Archive, FileText, Wind } from "lucide-react";
+import { Archive, FileText, Wind, Flame } from "lucide-react";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { Report } from "@/lib/reportSchemas";
 import { REPORT_TYPE_LABELS } from "@/constants/reportTypes";
@@ -32,7 +32,11 @@ export const ReportsFilterToggle: React.FC<ReportsFilterToggleProps> = ({
           <SelectContent>
             <SelectItem value="all">All Report Types</SelectItem>
             {Object.entries(REPORT_TYPE_LABELS).map(([value, label]) => {
-              const Icon = value.includes("wind") ? Wind : FileText;
+              const Icon = value.includes("wind")
+                ? Wind
+                : value.includes("wildfire")
+                ? Flame
+                : FileText;
               return (
                 <SelectItem key={value} value={value}>
                   <div className="flex items-center">

--- a/src/components/reports/ReportsListView.tsx
+++ b/src/components/reports/ReportsListView.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { FileText, Eye, Trash2, Archive, ArchiveRestore } from "lucide-react";
+import { FileText, Eye, Trash2, Archive, ArchiveRestore, Wind, Flame } from "lucide-react";
 import { downloadWindMitigationReport } from "@/utils/fillWindMitigationPDF";
 import { REPORT_TYPE_LABELS } from "@/constants/reportTypes";
 import type { Report } from "@/lib/reportSchemas";
@@ -26,7 +26,13 @@ export const ReportsListView: React.FC<ReportsListViewProps> = ({
         <div key={report.id} className="flex items-center justify-between p-4 border rounded-lg hover:bg-muted/50 transition-colors">
           <div className="flex items-center gap-4 flex-1 min-w-0">
             <div className="flex-shrink-0">
-              <FileText className="h-5 w-5 text-muted-foreground" />
+              {(report.reportType as string).includes("wind") ? (
+                <Wind className="h-5 w-5 text-muted-foreground" />
+              ) : (report.reportType as string).includes("wildfire") ? (
+                <Flame className="h-5 w-5 text-muted-foreground" />
+              ) : (
+                <FileText className="h-5 w-5 text-muted-foreground" />
+              )}
             </div>
             <div className="flex-1 min-w-0">
               <h3 className="font-medium truncate">{report.title}</h3>

--- a/src/constants/caWildfireQuestions.ts
+++ b/src/constants/caWildfireQuestions.ts
@@ -1,0 +1,138 @@
+export const CA_WILDFIRE_QUESTIONS = {
+  id: "ca_wildfire_defensible_space",
+  title: "California Wildfire / Defensible Space Assessment",
+  jurisdiction: "CA",
+  use_case: "Carrier wildfire risk underwriting",
+  sections: [
+    {
+      name: "structure_materials",
+      fields: [
+        {
+          name: "roof_material",
+          label: "Roof Material",
+          widget: "select",
+          options: [
+            "Class A (e.g., composition/metal)",
+            "Wood Shake/Shingle",
+            "Tile",
+            "Other"
+          ],
+          required: true,
+        },
+        {
+          name: "vents_screened",
+          label: "Vents Ember-Screened (≤1/8\")",
+          widget: "radio",
+          options: ["Yes", "No", "Partial"],
+          required: true,
+        },
+        {
+          name: "siding_type",
+          label: "Siding Type",
+          widget: "select",
+          options: ["Stucco", "Fiber-Cement", "Wood", "Vinyl", "Masonry", "Other"],
+          required: false,
+        },
+        {
+          name: "eaves_enclosed",
+          label: "Eaves Enclosed",
+          widget: "radio",
+          options: ["Yes", "No", "Partial"],
+          required: false,
+        },
+      ],
+    },
+    {
+      name: "zone_0_5_ft",
+      fields: [
+        {
+          name: "combustibles_near_structure",
+          label: "Combustibles within 0-5 ft of structure",
+          widget: "radio",
+          options: ["Yes", "No", "Partial"],
+          required: true,
+        },
+        {
+          name: "vegetation_managed",
+          label: "Vegetation managed (cleared/mowed)",
+          widget: "radio",
+          options: ["Yes", "No", "Partial"],
+          required: false,
+        },
+      ],
+    },
+    {
+      name: "zone_5_30_ft",
+      fields: [
+        {
+          name: "trees_overhanging",
+          label: "Trees overhanging roof",
+          widget: "radio",
+          options: ["None", "Some", "Many"],
+          required: false,
+        },
+        {
+          name: "ladder_fuels",
+          label: "Ladder Fuels Present",
+          widget: "radio",
+          options: ["Yes", "No", "Partial"],
+          required: false,
+        },
+      ],
+    },
+    {
+      name: "zone_30_100_ft",
+      fields: [
+        {
+          name: "tree_spacing",
+          label: "Tree Crown Spacing",
+          widget: "select",
+          options: ["<10 ft", "10-30 ft", ">30 ft"],
+          required: false,
+        },
+        {
+          name: "surface_fuel",
+          label: "Surface Fuel Load",
+          widget: "select",
+          options: ["Light", "Moderate", "Heavy"],
+          required: false,
+        },
+      ],
+    },
+    {
+      name: "access_utilities",
+      fields: [
+        {
+          name: "road_width",
+          label: "Road Width ≥20 ft",
+          widget: "radio",
+          options: ["Yes", "No"],
+          required: false,
+        },
+        {
+          name: "address_visible",
+          label: "Address Visible from Road",
+          widget: "radio",
+          options: ["Yes", "No"],
+          required: false,
+        },
+        {
+          name: "power_line_clearance",
+          label: "Power Line Clearance",
+          widget: "radio",
+          options: ["Adequate", "Inadequate", "N/A"],
+          required: false,
+        },
+      ],
+    },
+    {
+      name: "photos",
+      fields: [
+        { name: "photos", label: "Photo Uploads", widget: "upload", required: false },
+      ],
+    },
+  ],
+} as const;
+
+export type CaWildfireQuestions = typeof CA_WILDFIRE_QUESTIONS;
+

--- a/src/pages/ReportEditor.tsx
+++ b/src/pages/ReportEditor.tsx
@@ -39,6 +39,7 @@ import ContactMultiSelect from "@/components/contacts/ContactMultiSelect";
 const WindMitigationEditor = React.lazy(() => import("@/components/reports/WindMitigationEditor"));
 const FlFourPointEditor = React.lazy(() => import("@/components/reports/FlFourPointEditor"));
 const TxWindstormEditor = React.lazy(() => import("@/components/reports/TxWindstormEditor"));
+const CaWildfireEditor = React.lazy(() => import("@/components/reports/CaWildfireEditor"));
 
 const SEVERITIES = ["Info", "Maintenance", "Minor", "Moderate", "Major", "Safety"] as const;
 type Severity = typeof SEVERITIES[number];
@@ -693,6 +694,19 @@ const ReportEditor: React.FC = () => {
         <div className="max-w-4xl mx-auto px-4 py-6">
           <React.Suspense fallback={<div>Loading...</div>}>
             <TxWindstormEditor report={report as any} onUpdate={setReport as any} />
+          </React.Suspense>
+        </div>
+      </>
+    );
+  }
+
+  if (report && report.reportType === "ca_wildfire_defensible_space") {
+    return (
+      <>
+        <Seo title={`${report.title} | CA Wildfire Editor`} />
+        <div className="max-w-4xl mx-auto px-4 py-6">
+          <React.Suspense fallback={<div>Loading...</div>}>
+            <CaWildfireEditor report={report as any} onUpdate={setReport as any} />
           </React.Suspense>
         </div>
       </>

--- a/src/pages/ReportPreview.tsx
+++ b/src/pages/ReportPreview.tsx
@@ -273,6 +273,25 @@ const ReportPreview: React.FC = () => {
           }
         }
 
+        if (report.reportType === "ca_wildfire_defensible_space") {
+          const photos = (report.reportData?.photos?.photos || []).filter((p: string) => isSupabaseUrl(p));
+          if (photos.length > 0) {
+            const entries = await Promise.all(
+              photos.map(async (url: string) => {
+                const signed = await getSignedUrlFromSupabaseUrl(url);
+                return [url, signed] as const;
+              })
+            );
+            if (!cancelled) {
+              setMediaUrlMap((prev) => {
+                const next = { ...prev };
+                for (const [url, signed] of entries) next[url] = signed;
+                return next;
+              });
+            }
+          }
+        }
+
         if (report.coverImage) {
           if (isSupabaseUrl(report.coverImage)) {
             const signed = await getSignedUrlFromSupabaseUrl(report.coverImage);
@@ -350,6 +369,24 @@ const ReportPreview: React.FC = () => {
   }
 
   if (report.reportType === "tx_coastal_windstorm_mitigation") {
+    return (
+      <div className="max-w-4xl mx-auto px-4 py-10">
+        <div className="flex justify-center gap-4 mb-6">
+          <Button onClick={onPrintClick} disabled={isGeneratingPDF}>
+            {isGeneratingPDF ? "Generating PDF..." : "Download PDF"}
+          </Button>
+          <Button variant="outline" onClick={() => nav(`/reports/${report.id}`)}>
+            Back to Editor
+          </Button>
+        </div>
+        <div ref={pdfContainerRef}>
+          <PDFDocument report={report} mediaUrlMap={mediaUrlMap} coverUrl={coverUrl} company={organization?.name || ""} />
+        </div>
+      </div>
+    );
+  }
+
+  if (report.reportType === "ca_wildfire_defensible_space") {
     return (
       <div className="max-w-4xl mx-auto px-4 py-10">
         <div className="flex justify-center gap-4 mb-6">


### PR DESCRIPTION
## Summary
- add California Wildfire / Defensible Space Assessment form spec
- enable creation and editing with cover image, photos, and saving
- support CA wildfire reports across routes, listings, and PDF/preview rendering

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b75e8b5f7c8333b805f106b57b5c9e