### PR TITLE
feat: add roof certification report

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ const App = () => (
                 <Route path="/reports/new/fl-four-point" element={lazyLoad(() => import("./pages/FlFourPointNew"))} />
                 <Route path="/reports/new/tx-windstorm" element={lazyLoad(() => import("./pages/TxWindstormNew"))} />
                 <Route path="/reports/new/ca-wildfire" element={lazyLoad(() => import("./pages/CaWildfireNew"))} />
+                <Route path="/reports/new/roof-certification" element={lazyLoad(() => import("./pages/RoofCertificationNew"))} />
                 <Route path="/reports/new/:reportType" element={lazyLoad(() => import("./pages/GenericReportNew"))} />
               <Route path="/reports/:id" element={lazyLoad(() => import("./pages/ReportEditor"))} />
               <Route path="/reports/:id/preview" element={lazyLoad(() => import("./pages/ReportPreview"))} />

--- a/src/components/reports/PDFDocument.tsx
+++ b/src/components/reports/PDFDocument.tsx
@@ -10,6 +10,7 @@ import { COVER_TEMPLATES } from "@/constants/coverTemplates";
 import { FL_FOUR_POINT_QUESTIONS } from "@/constants/flFourPointQuestions";
 import { TX_WINDSTORM_QUESTIONS } from "@/constants/txWindstormQuestions";
 import { CA_WILDFIRE_QUESTIONS } from "@/constants/caWildfireQuestions";
+import { ROOF_CERTIFICATION_QUESTIONS } from "@/constants/roofCertificationQuestions";
 
 
 interface PDFDocumentProps {
@@ -99,6 +100,48 @@ const PDFDocument = React.forwardRef<HTMLDivElement, PDFDocumentProps>(
 
         if (report.reportType === "ca_wildfire_defensible_space") {
             const sections = CA_WILDFIRE_QUESTIONS.sections;
+            return (
+                <div ref={ref} className="pdf-document">
+                    <section className="pdf-page-break">
+                        <div className="text-center p-8">
+                            {coverUrl && <img src={coverUrl} alt="Cover" className="mx-auto mb-6 h-40 w-auto" />}
+                            <h1 className="text-2xl font-bold mb-2">{report.title}</h1>
+                            <p className="mb-1">{report.clientName}</p>
+                            <p className="mb-1">{report.address}</p>
+                            <p className="mb-1">Inspection Date: {report.inspectionDate}</p>
+                        </div>
+                    </section>
+                    {sections.map((section) => (
+                        <section key={section.name} className="pdf-page-break p-8">
+                            <h2 className="text-xl font-semibold mb-4 capitalize">{section.name.replace(/_/g, " ")}</h2>
+                            {section.name === "photos" ? (
+                                <div className="flex flex-wrap gap-2">
+                                    {((report.reportData?.[section.name] || {}).photos || []).map((url: string, idx: number) => (
+                                        <img key={idx} src={mediaUrlMap[url] || url} alt="" className="h-24 w-auto rounded border" />
+                                    ))}
+                                </div>
+                            ) : (
+                                <table className="w-full text-sm border-collapse">
+                                    <tbody>
+                                    {section.fields.map((field) => (
+                                        <tr key={field.name}>
+                                            <td className="border p-2 font-medium w-1/2">{field.label}</td>
+                                            <td className="border p-2">
+                                                {String((report.reportData?.[section.name] || {})[field.name] || "")}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                    </tbody>
+                                </table>
+                            )}
+                        </section>
+                    ))}
+                </div>
+            );
+        }
+
+        if (report.reportType === "roof_certification_nationwide") {
+            const sections = ROOF_CERTIFICATION_QUESTIONS.sections;
             return (
                 <div ref={ref} className="pdf-document">
                     <section className="pdf-page-break">

--- a/src/components/reports/ReportTypeSelector.tsx
+++ b/src/components/reports/ReportTypeSelector.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import Seo from "@/components/Seo";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Home, Wind, ClipboardList, Shield, Flame } from "lucide-react";
+import { Home, Wind, ClipboardList, Shield, Flame, ShieldCheck } from "lucide-react";
 
 const ReportTypeSelector: React.FC = () => {
   const navigate = useNavigate();
@@ -146,6 +146,31 @@ const ReportTypeSelector: React.FC = () => {
                 onClick={() => navigate("/reports/new/ca-wildfire")}
               >
                 Create CA Wildfire Report
+              </Button>
+            </CardContent>
+          </Card>
+
+          <Card className="cursor-pointer hover:shadow-lg transition-shadow border-2 hover:border-primary/20">
+            <CardHeader className="text-center">
+              <div className="mx-auto w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mb-4">
+                <ShieldCheck className="w-8 h-8 text-primary" />
+              </div>
+              <CardTitle>Roof Certification</CardTitle>
+              <CardDescription>
+                General roof condition certification for underwriting
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-2 text-sm text-muted-foreground mb-6">
+                <li>• Roof type and material details</li>
+                <li>• Remaining life estimates</li>
+                <li>• Photo documentation</li>
+              </ul>
+              <Button
+                className="w-full"
+                onClick={() => navigate("/reports/new/roof-certification")}
+              >
+                Create Roof Certification Report
               </Button>
             </CardContent>
           </Card>

--- a/src/components/reports/ReportsFilterToggle.tsx
+++ b/src/components/reports/ReportsFilterToggle.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Archive, FileText, Wind, Flame } from "lucide-react";
+import { Archive, FileText, Wind, Flame, ShieldCheck } from "lucide-react";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import type { Report } from "@/lib/reportSchemas";
 import { REPORT_TYPE_LABELS } from "@/constants/reportTypes";
@@ -36,6 +36,8 @@ export const ReportsFilterToggle: React.FC<ReportsFilterToggleProps> = ({
                 ? Wind
                 : value.includes("wildfire")
                 ? Flame
+                : value.includes("roof")
+                ? ShieldCheck
                 : FileText;
               return (
                 <SelectItem key={value} value={value}>

--- a/src/components/reports/RoofCertificationEditor.tsx
+++ b/src/components/reports/RoofCertificationEditor.tsx
@@ -1,0 +1,220 @@
+import React from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Form, FormField } from "@/components/ui/form";
+import { InfoFieldWidget } from "./InfoFieldWidget";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { uploadFindingFiles, getSignedUrlFromSupabaseUrl, isSupabaseUrl } from "@/integrations/supabase/storage";
+import { useAuth } from "@/contexts/AuthContext";
+import { dbUpdateReport } from "@/integrations/supabase/reportsApi";
+import { toast } from "@/components/ui/use-toast";
+import type { RoofCertificationNationwideReport } from "@/lib/reportSchemas";
+import { ROOF_CERTIFICATION_QUESTIONS } from "@/constants/roofCertificationQuestions";
+
+interface EditorProps {
+  report: RoofCertificationNationwideReport;
+  onUpdate: (r: RoofCertificationNationwideReport) => void;
+}
+
+const sectionSchema = ROOF_CERTIFICATION_QUESTIONS.sections.reduce((acc, section) => {
+  acc[section.name] = z.record(z.any()).optional();
+  return acc;
+}, {} as Record<string, any>);
+const FormSchema = z.object(sectionSchema);
+
+const RoofCertificationEditor: React.FC<EditorProps> = ({ report, onUpdate }) => {
+  const { user } = useAuth();
+  const [coverPreviewUrl, setCoverPreviewUrl] = React.useState<string>("");
+  const [photoPreviews, setPhotoPreviews] = React.useState<string[]>([]);
+
+  React.useEffect(() => {
+    if (!report.coverImage) return;
+    if (!user || !isSupabaseUrl(report.coverImage)) {
+      setCoverPreviewUrl(report.coverImage);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const signed = await getSignedUrlFromSupabaseUrl(report.coverImage);
+        if (!cancelled) setCoverPreviewUrl(signed);
+      } catch (e) {
+        console.error("Failed to sign cover image", e);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, report.coverImage]);
+
+  const form = useForm<any>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: report.reportData || {},
+  });
+
+  React.useEffect(() => {
+    const photos: string[] = form.getValues("photos.photos") || [];
+    if (photos.length === 0) return;
+    if (!user) {
+      setPhotoPreviews(photos);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      const signed = await Promise.all(
+        photos.map(async (p) => (isSupabaseUrl(p) ? await getSignedUrlFromSupabaseUrl(p) : p))
+      );
+      if (!cancelled) setPhotoPreviews(signed);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, form]);
+
+  const handleCoverImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (user) {
+      try {
+        const uploaded = await uploadFindingFiles({
+          userId: user.id,
+          reportId: report.id,
+          findingId: "cover",
+          files: [file],
+        });
+        if (uploaded[0]) {
+          const updated = { ...report, coverImage: uploaded[0].url };
+          onUpdate(updated);
+          const signed = await getSignedUrlFromSupabaseUrl(uploaded[0].url);
+          setCoverPreviewUrl(signed);
+          await dbUpdateReport(updated);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    } else {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const url = reader.result as string;
+        const updated = { ...report, coverImage: url };
+        onUpdate(updated);
+        setCoverPreviewUrl(url);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const handlePhotoUpload = async (files: FileList) => {
+    if (!files.length) return;
+    if (user) {
+      try {
+        const uploaded = await uploadFindingFiles({
+          userId: user.id,
+          reportId: report.id,
+          findingId: "photos",
+          files: Array.from(files),
+        });
+        const urls = uploaded.map((u) => u.url);
+        const current = form.getValues("photos.photos") || [];
+        const newVals = [...current, ...urls];
+        form.setValue("photos.photos", newVals);
+        const updated = { ...report, reportData: form.getValues() };
+        onUpdate(updated);
+        await dbUpdateReport(updated);
+        const signed = await Promise.all(urls.map((u) => getSignedUrlFromSupabaseUrl(u)));
+        setPhotoPreviews((prev) => [...prev, ...signed]);
+      } catch (e) {
+        console.error(e);
+      }
+    } else {
+      const readers = Array.from(files).map(
+        (file) =>
+          new Promise<string>((resolve) => {
+            const reader = new FileReader();
+            reader.onload = () => resolve(reader.result as string);
+            reader.readAsDataURL(file);
+          })
+      );
+      const urls = await Promise.all(readers);
+      const current = form.getValues("photos.photos") || [];
+      const newVals = [...current, ...urls];
+      form.setValue("photos.photos", newVals);
+      const updated = { ...report, reportData: form.getValues() };
+      onUpdate(updated);
+      setPhotoPreviews((prev) => [...prev, ...urls]);
+    }
+  };
+
+  const handleSave = async () => {
+    try {
+      const current = form.getValues();
+      const updated = { ...report, reportData: current } as RoofCertificationNationwideReport;
+      await dbUpdateReport(updated);
+      onUpdate(updated);
+      toast({ title: "Report saved" });
+    } catch (e) {
+      console.error(e);
+      toast({ title: "Save failed", variant: "destructive" });
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{ROOF_CERTIFICATION_QUESTIONS.title}</h1>
+        <Button onClick={handleSave}>Save Report</Button>
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-sm font-medium">Cover Image</Label>
+        {coverPreviewUrl && (
+          <img src={coverPreviewUrl} alt="Cover" className="h-40 w-auto rounded border" />
+        )}
+        <Input type="file" accept="image/*" onChange={handleCoverImageUpload} />
+      </div>
+
+      {ROOF_CERTIFICATION_QUESTIONS.sections.find((s) => s.name === "photos") && (
+        <div className="space-y-2">
+          <Label className="text-sm font-medium">Upload Photos</Label>
+          <Input type="file" accept="image/*" multiple onChange={(e) => e.target.files && handlePhotoUpload(e.target.files)} />
+          {photoPreviews.length > 0 && (
+            <div className="flex flex-wrap gap-2 mt-2">
+              {photoPreviews.map((url, idx) => (
+                <img key={idx} src={url} alt="" className="h-24 w-auto rounded border" />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      <Form {...form}>
+        <div className="space-y-8">
+          {ROOF_CERTIFICATION_QUESTIONS.sections.filter((s) => s.name !== "photos").map((section) => (
+            <div key={section.name} className="space-y-4">
+              <h2 className="text-xl font-semibold capitalize">{section.name.replace(/_/g, " ")}</h2>
+              {section.fields.map((field) => (
+                <FormField
+                  key={field.name}
+                  control={form.control}
+                  name={`${section.name}.${field.name}`}
+                  render={({ field: f }) => (
+                    <InfoFieldWidget
+                      field={{ ...field, widget: field.widget === "radio" ? "select" : field.widget }}
+                      value={f.value || ""}
+                      onChange={(val) => f.onChange(val)}
+                    />
+                  )}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </Form>
+    </div>
+  );
+};
+
+export default RoofCertificationEditor;

--- a/src/constants/roofCertificationQuestions.ts
+++ b/src/constants/roofCertificationQuestions.ts
@@ -1,0 +1,57 @@
+export const ROOF_CERTIFICATION_QUESTIONS = {
+  id: "roof_certification_nationwide",
+  title: "Roof Certification",
+  jurisdiction: "US",
+  use_case: "Insurance roof condition certification",
+  sections: [
+    {
+      name: "general",
+      fields: [
+        {
+          name: "roof_type",
+          label: "Roof Type",
+          widget: "select",
+          options: ["Gable", "Hip", "Flat", "Other"],
+          required: true,
+        },
+        {
+          name: "covering_material",
+          label: "Covering Material",
+          widget: "select",
+          options: ["Asphalt Shingle", "Metal", "Tile", "Modified Bitumen", "Other"],
+          required: true,
+        },
+        {
+          name: "year_installed",
+          label: "Year Installed",
+          widget: "number",
+          required: false,
+        },
+        {
+          name: "remaining_life_years",
+          label: "Estimated Remaining Life (yrs)",
+          widget: "number",
+          required: false,
+        },
+        {
+          name: "leaks_observed",
+          label: "Any Leaks Observed?",
+          widget: "radio",
+          options: ["Yes", "No"],
+          required: true,
+        },
+      ],
+    },
+    {
+      name: "photos",
+      fields: [
+        {
+          name: "photos",
+          label: "Roof Photos",
+          widget: "upload",
+          required: false,
+        },
+      ],
+    },
+  ],
+};

--- a/src/pages/ReportEditor.tsx
+++ b/src/pages/ReportEditor.tsx
@@ -40,6 +40,7 @@ const WindMitigationEditor = React.lazy(() => import("@/components/reports/WindM
 const FlFourPointEditor = React.lazy(() => import("@/components/reports/FlFourPointEditor"));
 const TxWindstormEditor = React.lazy(() => import("@/components/reports/TxWindstormEditor"));
 const CaWildfireEditor = React.lazy(() => import("@/components/reports/CaWildfireEditor"));
+const RoofCertificationEditor = React.lazy(() => import("@/components/reports/RoofCertificationEditor"));
 
 const SEVERITIES = ["Info", "Maintenance", "Minor", "Moderate", "Major", "Safety"] as const;
 type Severity = typeof SEVERITIES[number];
@@ -707,6 +708,19 @@ const ReportEditor: React.FC = () => {
         <div className="max-w-4xl mx-auto px-4 py-6">
           <React.Suspense fallback={<div>Loading...</div>}>
             <CaWildfireEditor report={report as any} onUpdate={setReport as any} />
+          </React.Suspense>
+        </div>
+      </>
+    );
+  }
+
+  if (report && report.reportType === "roof_certification_nationwide") {
+    return (
+      <>
+        <Seo title={`${report.title} | Roof Certification Editor`} />
+        <div className="max-w-4xl mx-auto px-4 py-6">
+          <React.Suspense fallback={<div>Loading...</div>}>
+            <RoofCertificationEditor report={report as any} onUpdate={setReport as any} />
           </React.Suspense>
         </div>
       </>

--- a/src/pages/ReportPreview.tsx
+++ b/src/pages/ReportPreview.tsx
@@ -292,6 +292,25 @@ const ReportPreview: React.FC = () => {
           }
         }
 
+        if (report.reportType === "roof_certification_nationwide") {
+          const photos = (report.reportData?.photos?.photos || []).filter((p: string) => isSupabaseUrl(p));
+          if (photos.length > 0) {
+            const entries = await Promise.all(
+              photos.map(async (url: string) => {
+                const signed = await getSignedUrlFromSupabaseUrl(url);
+                return [url, signed] as const;
+              })
+            );
+            if (!cancelled) {
+              setMediaUrlMap((prev) => {
+                const next = { ...prev };
+                for (const [url, signed] of entries) next[url] = signed;
+                return next;
+              });
+            }
+          }
+        }
+
         if (report.coverImage) {
           if (isSupabaseUrl(report.coverImage)) {
             const signed = await getSignedUrlFromSupabaseUrl(report.coverImage);
@@ -387,6 +406,24 @@ const ReportPreview: React.FC = () => {
   }
 
   if (report.reportType === "ca_wildfire_defensible_space") {
+    return (
+      <div className="max-w-4xl mx-auto px-4 py-10">
+        <div className="flex justify-center gap-4 mb-6">
+          <Button onClick={onPrintClick} disabled={isGeneratingPDF}>
+            {isGeneratingPDF ? "Generating PDF..." : "Download PDF"}
+          </Button>
+          <Button variant="outline" onClick={() => nav(`/reports/${report.id}`)}>
+            Back to Editor
+          </Button>
+        </div>
+        <div ref={pdfContainerRef}>
+          <PDFDocument report={report} mediaUrlMap={mediaUrlMap} coverUrl={coverUrl} company={organization?.name || ""} />
+        </div>
+      </div>
+    );
+  }
+
+  if (report.reportType === "roof_certification_nationwide") {
     return (
       <div className="max-w-4xl mx-auto px-4 py-10">
         <div className="flex justify-center gap-4 mb-6">

--- a/src/pages/RoofCertificationNew.tsx
+++ b/src/pages/RoofCertificationNew.tsx
@@ -1,0 +1,194 @@
+import React, { useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { useQuery } from "@tanstack/react-query";
+import Seo from "@/components/Seo";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { toast } from "@/components/ui/use-toast";
+import { useAuth } from "@/contexts/AuthContext";
+import { dbCreateReport } from "@/integrations/supabase/reportsApi";
+import { contactsApi } from "@/integrations/supabase/crmApi";
+import { getMyOrganization } from "@/integrations/supabase/organizationsApi";
+
+const schema = z.object({
+  title: z.string().min(1, "Required"),
+  clientName: z.string().min(1, "Required"),
+  address: z.string().min(1, "Address is required"),
+  inspectionDate: z.string().min(1, "Required"),
+  contactId: z.string().optional(),
+});
+
+type Values = z.infer<typeof schema>;
+
+const RoofCertificationNew: React.FC = () => {
+  const nav = useNavigate();
+  const { user } = useAuth();
+  const [searchParams] = useSearchParams();
+  const contactId = searchParams.get("contactId");
+
+  const { data: contacts = [] } = useQuery({
+    queryKey: ["contacts", user?.id],
+    queryFn: () => contactsApi.list(user!.id),
+    enabled: !!user,
+  });
+
+  const { data: contact } = useQuery({
+    queryKey: ["contact", contactId],
+    queryFn: () => contactsApi.get(contactId!),
+    enabled: !!contactId && !!user,
+  });
+
+  const form = useForm<Values>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      title: "",
+      clientName: "",
+      address: "",
+      inspectionDate: new Date().toISOString().slice(0, 10),
+      contactId: contactId || "",
+    },
+  });
+
+  useEffect(() => {
+    if (contact) {
+      form.setValue("clientName", `${contact.first_name} ${contact.last_name}`);
+      const contactAddress = contact.formatted_address || contact.address || "";
+      if (contactAddress) {
+        form.setValue("address", contactAddress);
+      }
+    }
+  }, [contact, form]);
+
+  const onSubmit = async (values: Values) => {
+    try {
+      if (user) {
+        const organization = await getMyOrganization();
+        const report = await dbCreateReport(
+          {
+            title: values.title,
+            clientName: values.clientName,
+            address: values.address,
+            inspectionDate: values.inspectionDate,
+            contact_id: values.contactId,
+            reportType: "roof_certification_nationwide",
+          },
+          user.id,
+          organization?.id
+        );
+        toast({ title: "Roof certification report created" });
+        nav(`/reports/${report.id}`);
+      } else {
+        toast({ title: "Authentication required", description: "Please log in to create reports." });
+      }
+    } catch (e: any) {
+      console.error(e);
+      toast({ title: "Failed to create report", description: e?.message || "Please try again." });
+    }
+  };
+
+  return (
+    <>
+      <Seo
+        title="New Roof Certification Report"
+        description="Create a new roof certification report."
+        canonical={window.location.origin + "/reports/new/roof-certification"}
+      />
+      <section className="max-w-2xl mx-auto px-4 py-10">
+        <h1 className="text-2xl font-semibold mb-6">New Roof Certification Report</h1>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            <FormField
+              control={form.control}
+              name="title"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Report Title</FormLabel>
+                  <FormControl>
+                    <Input placeholder="e.g., 123 Main St Roof" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="contactId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Client Contact</FormLabel>
+                  <FormControl>
+                    <Select
+                      value={field.value}
+                      onValueChange={(val) => {
+                        field.onChange(val);
+                        const selected = contacts.find((c) => c.id === val);
+                        if (selected) {
+                          form.setValue("clientName", `${selected.first_name} ${selected.last_name}`);
+                          const addr = selected.formatted_address || selected.address || "";
+                          if (addr) form.setValue("address", addr);
+                        }
+                      }}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select a contact..." />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {contacts.map((c) => (
+                          <SelectItem key={c.id} value={c.id}>
+                            {c.first_name} {c.last_name}
+                            {c.email && <span className="text-muted-foreground ml-2">({c.email})</span>}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="address"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Property Address</FormLabel>
+                  <FormControl>
+                    <Textarea placeholder="123 Main St, Springfield" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="inspectionDate"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Inspection Date</FormLabel>
+                  <FormControl>
+                    <Input type="date" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="outline" onClick={() => nav('/reports/select-type')}>
+                Back
+              </Button>
+              <Button type="submit">Create Report</Button>
+            </div>
+          </form>
+        </Form>
+      </section>
+    </>
+  );
+};
+
+export default RoofCertificationNew;


### PR DESCRIPTION
## Summary
- define roof certification form schema and editor
- add creation route and navigation entry
- support preview and PDF output for roof certification reports

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68b7607b18f48333bc6c4b2700965800