### PR TITLE
feat: expand roof certification sections

### DIFF
--- a/src/constants/roofCertificationQuestions.ts
+++ b/src/constants/roofCertificationQuestions.ts
@@ -5,40 +5,118 @@ export const ROOF_CERTIFICATION_QUESTIONS = {
   use_case: "Insurance roof condition certification",
   sections: [
     {
-      name: "general",
+      name: "structure_materials",
       fields: [
         {
-          name: "roof_type",
-          label: "Roof Type",
+          name: "roof_material",
+          label: "Roof Material",
           widget: "select",
-          options: ["Gable", "Hip", "Flat", "Other"],
+          options: [
+            "Class A (e.g., composition/metal)",
+            "Wood Shake/Shingle",
+            "Tile",
+            "Other",
+          ],
           required: true,
         },
         {
-          name: "covering_material",
-          label: "Covering Material",
-          widget: "select",
-          options: ["Asphalt Shingle", "Metal", "Tile", "Modified Bitumen", "Other"],
+          name: "vents_screened",
+          label: "Vents Ember-Screened (≤1/8\")",
+          widget: "radio",
+          options: ["Yes", "No", "Partial"],
           required: true,
         },
         {
-          name: "year_installed",
-          label: "Year Installed",
-          widget: "number",
+          name: "siding_type",
+          label: "Siding Type",
+          widget: "select",
+          options: [
+            "Stucco",
+            "Fiber-Cement",
+            "Wood",
+            "Vinyl",
+            "Masonry",
+            "Other",
+          ],
           required: false,
         },
         {
-          name: "remaining_life_years",
-          label: "Estimated Remaining Life (yrs)",
-          widget: "number",
+          name: "eaves_enclosed",
+          label: "Eaves Enclosed",
+          widget: "radio",
+          options: ["Yes", "No", "Partial"],
+          required: false,
+        },
+      ],
+    },
+    {
+      name: "zone0_ember_resistant",
+      fields: [
+        {
+          name: "zone0_clear",
+          label: "Zone 0 (0-5 ft) Clear of Combustibles",
+          widget: "radio",
+          options: ["Yes", "No", "Partial"],
+          required: true,
+        },
+        {
+          name: "mulch_present",
+          label: "Combustible Mulch Present",
+          widget: "radio",
+          options: ["Yes", "No", "Partial"],
+          required: false,
+        },
+      ],
+    },
+    {
+      name: "zone1_and_2_defensible_space",
+      fields: [
+        {
+          name: "zone1_5to30",
+          label: "Zone 1 (5-30 ft) Maintained",
+          widget: "radio",
+          options: ["Yes", "No", "Partial"],
           required: false,
         },
         {
-          name: "leaks_observed",
-          label: "Any Leaks Observed?",
+          name: "zone2_30to100",
+          label: "Zone 2 (30-100 ft) Maintained",
+          widget: "radio",
+          options: ["Yes", "No", "Partial"],
+          required: false,
+        },
+        {
+          name: "trees_overhanging_roof",
+          label: "Trees Overhanging Roof",
+          widget: "radio",
+          options: ["None", "Some", "Many"],
+          required: false,
+        },
+      ],
+    },
+    {
+      name: "access_and_water",
+      fields: [
+        {
+          name: "road_width",
+          label: "Road Width ≥20 ft",
           widget: "radio",
           options: ["Yes", "No"],
-          required: true,
+          required: false,
+        },
+        {
+          name: "address_visible",
+          label: "Address Visible from Road",
+          widget: "radio",
+          options: ["Yes", "No"],
+          required: false,
+        },
+        {
+          name: "water_supply",
+          label: "On-site Water Supply",
+          widget: "select",
+          options: ["Hydrant", "Tank", "Pool", "None"],
+          required: false,
         },
       ],
     },
@@ -54,4 +132,7 @@ export const ROOF_CERTIFICATION_QUESTIONS = {
       ],
     },
   ],
-};
+} as const;
+
+export type RoofCertificationQuestions = typeof ROOF_CERTIFICATION_QUESTIONS;
+


### PR DESCRIPTION
## Summary
- refactor roof certification questionnaire to include structure materials, ember resistance, defensible space, and access/water sections
- keep photo upload section

## Testing
- `npm run lint` *(fails: Unexpected any in various files)*
- `npm run build` *(fails: JSX tag mismatches in src/pages/Index.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b7680fa8e88333be2b60eafc962a97