### PR TITLE
Refactor report renderer and list view icons

### DIFF
--- a/src/components/reports/ReportsListView.tsx
+++ b/src/components/reports/ReportsListView.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { FileText, Eye, Trash2, Archive, ArchiveRestore, Wind, Flame, ShieldCheck, Home } from "lucide-react";
+import { FileText, Eye, Trash2, Archive, ArchiveRestore, Wind, Flame, ShieldCheck, Home, Pencil } from "lucide-react";
 import { downloadWindMitigationReport } from "@/utils/fillWindMitigationPDF";
 import { REPORT_TYPE_LABELS } from "@/constants/reportTypes";
 import type { Report } from "@/lib/reportSchemas";
@@ -38,20 +38,24 @@ export const ReportsListView: React.FC<ReportsListViewProps> = ({
                 <FileText className="h-5 w-5 text-muted-foreground" />
               )}
             </div>
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 mb-1">
-                <h3 className="font-medium truncate">
-                  {report.propertyAddress || "Untitled Report"}
-                </h3>
-                <Badge variant="secondary">
-                  {REPORT_TYPE_LABELS[report.reportType] || report.reportType}
-                </Badge>
-                {report.archived && (
-                  <Badge variant="outline">Archived</Badge>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                  <h3 className="font-medium truncate">
+                    {report.title || "Untitled Report"}
+                  </h3>
+                  <Badge variant="secondary">
+                    {REPORT_TYPE_LABELS[report.reportType] || report.reportType}
+                  </Badge>
+                  {report.archived && (
+                    <Badge variant="outline">Archived</Badge>
+                  )}
+                </div>
+                {report.address && (
+                  <p className="text-sm text-muted-foreground truncate">
+                    {report.address}
+                  </p>
                 )}
-              </div>
-              <div className="text-sm text-muted-foreground">
-                <div>
+                <div className="text-sm text-muted-foreground mt-1">
                   {report.inspectionDate && (
                     <span>Inspection: {new Date(report.inspectionDate).toLocaleDateString()}</span>
                   )}
@@ -61,59 +65,53 @@ export const ReportsListView: React.FC<ReportsListViewProps> = ({
                 </div>
               </div>
             </div>
-          </div>
-          <div className="flex items-center gap-2">
-            <Button size="sm" variant="outline" asChild>
-              <Link to={`/reports/${report.id}/edit`}>
-                <Eye className="h-4 w-4 mr-1" />
-                Open
-              </Link>
-            </Button>
-            {report.reportType === "windMitigation" && (
+            <div className="flex items-center gap-2">
+              <Button size="sm" variant="ghost" asChild>
+                <Link to={`/reports/${report.id}/edit`}>
+                  <Pencil className="h-4 w-4" />
+                  <span className="sr-only">Edit</span>
+                </Link>
+              </Button>
+              {report.reportType === "windMitigation" && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => downloadWindMitigationReport(report)}
+                >
+                  Download
+                </Button>
+              )}
+              <Button size="sm" variant="ghost" asChild>
+                <Link to={`/reports/${report.id}/preview`}>
+                  <Eye className="h-4 w-4" />
+                  <span className="sr-only">Preview</span>
+                </Link>
+              </Button>
+              {onArchive && (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => onArchive(report.id, !report.archived)}
+                >
+                  {report.archived ? (
+                    <ArchiveRestore className="h-4 w-4" />
+                  ) : (
+                    <Archive className="h-4 w-4" />
+                  )}
+                  <span className="sr-only">{report.archived ? "Restore" : "Archive"}</span>
+                </Button>
+              )}
               <Button
                 size="sm"
-                variant="outline"
-                onClick={() => downloadWindMitigationReport(report)}
+                variant="destructive"
+                onClick={() => onDelete(report.id)}
               >
-                Download
+                <Trash2 className="h-4 w-4" />
+                <span className="sr-only">Delete</span>
               </Button>
-            )}
-            <Button size="sm" variant="outline" asChild>
-              <Link to={`/reports/${report.id}/preview`}>
-                <Eye className="h-4 w-4 mr-1" />
-                Preview
-              </Link>
-            </Button>
-            {onArchive && (
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => onArchive(report.id, !report.archived)}
-              >
-                {report.archived ? (
-                  <>
-                    <ArchiveRestore className="h-4 w-4 mr-1" />
-                    Restore
-                  </>
-                ) : (
-                  <>
-                    <Archive className="h-4 w-4 mr-1" />
-                    Archive
-                  </>
-                )}
-              </Button>
-            )}
-            <Button
-              size="sm"
-              variant="destructive"
-              onClick={() => onDelete(report.id)}
-            >
-              <Trash2 className="h-4 w-4 mr-1" />
-              Delete
-            </Button>
+            </div>
           </div>
-        </div>
-      ))}
-    </div>
-  );
-};
+        ))}
+      </div>
+    );
+  };


### PR DESCRIPTION
## Summary
- consolidate question configs by report type for generic PDF rendering with cover templates
- replace per-report PDF logic with mapping-driven section/field iteration
- clean up reports list view to show title/address and use icon-only action buttons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b7883c39508333bc9e99d611b91e84