### PR TITLE
Add preview and back navigation to report editors

### DIFF
--- a/src/components/reports/CaWildfireEditor.tsx
+++ b/src/components/reports/CaWildfireEditor.tsx
@@ -7,6 +7,7 @@ import { InfoFieldWidget } from "./InfoFieldWidget";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useNavigate } from "react-router-dom";
 import { uploadFindingFiles, getSignedUrlFromSupabaseUrl, isSupabaseUrl } from "@/integrations/supabase/storage";
 import { useAuth } from "@/contexts/AuthContext";
 import { dbUpdateReport } from "@/integrations/supabase/reportsApi";
@@ -27,6 +28,7 @@ const FormSchema = z.object(sectionSchema);
 
 const CaWildfireEditor: React.FC<EditorProps> = ({ report, onUpdate }) => {
   const { user } = useAuth();
+  const navigate = useNavigate();
   const [coverPreviewUrl, setCoverPreviewUrl] = React.useState<string>("");
   const [photoPreviews, setPhotoPreviews] = React.useState<string[]>([]);
 
@@ -165,7 +167,11 @@ const CaWildfireEditor: React.FC<EditorProps> = ({ report, onUpdate }) => {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">{CA_WILDFIRE_QUESTIONS.title}</h1>
-        <Button onClick={handleSave}>Save Report</Button>
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" onClick={() => navigate("/reports")}>Back to Reports</Button>
+          <Button variant="outline" onClick={() => navigate(`/reports/${report.id}/preview`)}>Preview</Button>
+          <Button onClick={handleSave}>Save Report</Button>
+        </div>
       </div>
 
       <div className="space-y-2">

--- a/src/components/reports/FlFourPointEditor.tsx
+++ b/src/components/reports/FlFourPointEditor.tsx
@@ -7,6 +7,7 @@ import { InfoFieldWidget } from "./InfoFieldWidget";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useNavigate } from "react-router-dom";
 import { uploadFindingFiles, getSignedUrlFromSupabaseUrl, isSupabaseUrl } from "@/integrations/supabase/storage";
 import { useAuth } from "@/contexts/AuthContext";
 import { dbUpdateReport } from "@/integrations/supabase/reportsApi";
@@ -28,6 +29,7 @@ const FormSchema = z.object(sectionSchema);
 
 const FlFourPointEditor: React.FC<EditorProps> = ({ report, onUpdate }) => {
   const { user } = useAuth();
+  const navigate = useNavigate();
   const [coverPreviewUrl, setCoverPreviewUrl] = React.useState<string>("");
 
   React.useEffect(() => {
@@ -105,7 +107,11 @@ const FlFourPointEditor: React.FC<EditorProps> = ({ report, onUpdate }) => {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">{FL_FOUR_POINT_QUESTIONS.title}</h1>
-        <Button onClick={handleSave}>Save Report</Button>
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" onClick={() => navigate("/reports")}>Back to Reports</Button>
+          <Button variant="outline" onClick={() => navigate(`/reports/${report.id}/preview`)}>Preview</Button>
+          <Button onClick={handleSave}>Save Report</Button>
+        </div>
       </div>
 
       <div className="space-y-2">

--- a/src/components/reports/ManufacturedHomeEditor.tsx
+++ b/src/components/reports/ManufacturedHomeEditor.tsx
@@ -7,6 +7,7 @@ import { InfoFieldWidget } from "./InfoFieldWidget";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useNavigate } from "react-router-dom";
 import { uploadFindingFiles, getSignedUrlFromSupabaseUrl, isSupabaseUrl } from "@/integrations/supabase/storage";
 import { useAuth } from "@/contexts/AuthContext";
 import { dbUpdateReport } from "@/integrations/supabase/reportsApi";
@@ -27,6 +28,7 @@ const FormSchema = z.object(sectionSchema);
 
 const ManufacturedHomeEditor: React.FC<EditorProps> = ({ report, onUpdate }) => {
   const { user } = useAuth();
+  const navigate = useNavigate();
   const [coverPreviewUrl, setCoverPreviewUrl] = React.useState<string>("");
   const [photoPreviews, setPhotoPreviews] = React.useState<string[]>([]);
 
@@ -165,7 +167,11 @@ const ManufacturedHomeEditor: React.FC<EditorProps> = ({ report, onUpdate }) => 
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">{MANUFACTURED_HOME_QUESTIONS.title}</h1>
-        <Button onClick={handleSave}>Save Report</Button>
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" onClick={() => navigate("/reports")}>Back to Reports</Button>
+          <Button variant="outline" onClick={() => navigate(`/reports/${report.id}/preview`)}>Preview</Button>
+          <Button onClick={handleSave}>Save Report</Button>
+        </div>
       </div>
 
       <div className="space-y-2">

--- a/src/components/reports/RoofCertificationEditor.tsx
+++ b/src/components/reports/RoofCertificationEditor.tsx
@@ -7,6 +7,7 @@ import { InfoFieldWidget } from "./InfoFieldWidget";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useNavigate } from "react-router-dom";
 import { uploadFindingFiles, getSignedUrlFromSupabaseUrl, isSupabaseUrl } from "@/integrations/supabase/storage";
 import { useAuth } from "@/contexts/AuthContext";
 import { dbUpdateReport } from "@/integrations/supabase/reportsApi";
@@ -27,6 +28,7 @@ const FormSchema = z.object(sectionSchema);
 
 const RoofCertificationEditor: React.FC<EditorProps> = ({ report, onUpdate }) => {
   const { user } = useAuth();
+  const navigate = useNavigate();
   const [coverPreviewUrl, setCoverPreviewUrl] = React.useState<string>("");
   const [photoPreviews, setPhotoPreviews] = React.useState<string[]>([]);
 
@@ -165,7 +167,11 @@ const RoofCertificationEditor: React.FC<EditorProps> = ({ report, onUpdate }) =>
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">{ROOF_CERTIFICATION_QUESTIONS.title}</h1>
-        <Button onClick={handleSave}>Save Report</Button>
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" onClick={() => navigate("/reports")}>Back to Reports</Button>
+          <Button variant="outline" onClick={() => navigate(`/reports/${report.id}/preview`)}>Preview</Button>
+          <Button onClick={handleSave}>Save Report</Button>
+        </div>
       </div>
 
       <div className="space-y-2">

--- a/src/components/reports/TxWindstormEditor.tsx
+++ b/src/components/reports/TxWindstormEditor.tsx
@@ -7,6 +7,7 @@ import { InfoFieldWidget } from "./InfoFieldWidget";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { useNavigate } from "react-router-dom";
 import { uploadFindingFiles, getSignedUrlFromSupabaseUrl, isSupabaseUrl } from "@/integrations/supabase/storage";
 import { useAuth } from "@/contexts/AuthContext";
 import { dbUpdateReport } from "@/integrations/supabase/reportsApi";
@@ -27,6 +28,7 @@ const FormSchema = z.object(sectionSchema);
 
 const TxWindstormEditor: React.FC<EditorProps> = ({ report, onUpdate }) => {
   const { user } = useAuth();
+  const navigate = useNavigate();
   const [coverPreviewUrl, setCoverPreviewUrl] = React.useState<string>("");
   const [photoPreviews, setPhotoPreviews] = React.useState<string[]>([]);
 
@@ -165,7 +167,11 @@ const TxWindstormEditor: React.FC<EditorProps> = ({ report, onUpdate }) => {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">{TX_WINDSTORM_QUESTIONS.title}</h1>
-        <Button onClick={handleSave}>Save Report</Button>
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" onClick={() => navigate("/reports")}>Back to Reports</Button>
+          <Button variant="outline" onClick={() => navigate(`/reports/${report.id}/preview`)}>Preview</Button>
+          <Button onClick={handleSave}>Save Report</Button>
+        </div>
       </div>
 
       <div className="space-y-2">

--- a/src/components/reports/WindMitigationEditor.tsx
+++ b/src/components/reports/WindMitigationEditor.tsx
@@ -7,6 +7,7 @@ import {Button} from "@/components/ui/button";
 import {toast} from "@/hooks/use-toast";
 import {Input} from "@/components/ui/input";
 import {Label} from "@/components/ui/label";
+import { useNavigate } from "react-router-dom";
 import {uploadFindingFiles, getSignedUrlFromSupabaseUrl, isSupabaseUrl} from "@/integrations/supabase/storage";
 import {useAuth} from "@/contexts/AuthContext";
 import {WIND_MITIGATION_QUESTIONS} from "@/constants/windMitigationQuestions";
@@ -26,6 +27,7 @@ const WindMitigationEditor: React.FC<WindMitigationEditorProps> = ({report, onUp
     console.log("WindMitigationEditor render", {reportId: report.id, reportData: report.reportData});
 
     const {user} = useAuth();
+    const navigate = useNavigate();
     const [coverPreviewUrl, setCoverPreviewUrl] = React.useState<string>("");
 
     React.useEffect(() => {
@@ -137,7 +139,8 @@ const WindMitigationEditor: React.FC<WindMitigationEditorProps> = ({report, onUp
                     <p className="text-sm text-muted-foreground">Form {WIND_MITIGATION_QUESTIONS.version}</p>
                 </div>
                 <div className="flex items-center gap-2">
-                    {/* Cover page selection removed */}
+                    <Button variant="secondary" onClick={() => navigate("/reports")}>Back to Reports</Button>
+                    <Button variant="outline" onClick={() => navigate(`/reports/${report.id}/preview`)}>Preview</Button>
                     <Button onClick={handleSave} className="shrink-0">
                         Save Report
                     </Button>

--- a/src/components/reports/WindMitigationMainEditor.tsx
+++ b/src/components/reports/WindMitigationMainEditor.tsx
@@ -3,6 +3,8 @@ import { WindMitigationReport } from "@/lib/reportSchemas";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { useNavigate } from "react-router-dom";
+import { dbUpdateReport } from "@/integrations/supabase/reportsApi";
+import { toast } from "@/components/ui/use-toast";
 
 interface WindMitigationMainEditorProps {
   report: WindMitigationReport;
@@ -11,12 +13,27 @@ interface WindMitigationMainEditorProps {
 
 const WindMitigationMainEditor: React.FC<WindMitigationMainEditorProps> = ({ report, onUpdate }) => {
   const nav = useNavigate();
-  
+
+  const handleSave = async () => {
+    try {
+      await dbUpdateReport(report);
+      onUpdate(report);
+      toast({ title: "Report saved" });
+    } catch (e) {
+      console.error(e);
+      toast({ title: "Save failed", variant: "destructive" });
+    }
+  };
+
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <h1 className="text-2xl font-bold">Uniform Mitigation Verification Inspection</h1>
-        <Button onClick={() => nav(`/reports/${report.id}/preview`)}>Preview Report</Button>
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" onClick={() => nav("/reports")}>Back to Reports</Button>
+          <Button variant="outline" onClick={() => nav(`/reports/${report.id}/preview`)}>Preview</Button>
+          <Button onClick={handleSave}>Save Report</Button>
+        </div>
       </div>
       
       <Card>

--- a/src/pages/ReportEditor.tsx
+++ b/src/pages/ReportEditor.tsx
@@ -628,6 +628,20 @@ const ReportEditor: React.FC = () => {
     toast({ title: "Report finalized. Use Preview to print/PDF." });
   };
 
+  const handleSave = async () => {
+    if (!report) return;
+    try {
+      saveLocalReport(report);
+      if (user) {
+        await dbUpdateReport(report);
+      }
+      toast({ title: "Report saved" });
+    } catch (e) {
+      console.error(e);
+      toast({ title: "Save failed", variant: "destructive" });
+    }
+  };
+
   const handleCoverImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file || !report) return;
@@ -759,8 +773,17 @@ const ReportEditor: React.FC = () => {
   return (
     <>
       <Seo title={`${report.title} | Report Editor`} />
-      <div className="max-w-7xl mx-auto px-4 py-6 md:flex md:flex-nowrap items-start gap-6">
-        <aside className="w-full md:w-64 shrink-0">
+      <div className="max-w-7xl mx-auto px-4 py-6 space-y-6">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl font-bold">{report.title}</h1>
+          <div className="flex items-center gap-2">
+            <Button variant="secondary" onClick={() => nav("/reports")}>Back to Reports</Button>
+            <Button variant="outline" onClick={() => nav(`/reports/${report.id}/preview`)}>Preview</Button>
+            <Button onClick={handleSave}>Save Report</Button>
+          </div>
+        </div>
+        <div className="md:flex md:flex-nowrap items-start gap-6">
+          <aside className="w-full md:w-64 shrink-0">
           <div className="rounded-lg border p-3">
             <h2 className="font-medium mb-3">Sections</h2>
             <nav className="space-y-1">
@@ -860,11 +883,11 @@ const ReportEditor: React.FC = () => {
               )}
             </nav>
           </div>
-        </aside>
-        <main className="flex-1 min-w-0">
+          </aside>
+          <main className="flex-1 min-w-0">
           {!showDetails && !excludedKeys.includes(activeSection.key) && (
             <>
-              <div className="flex justify-between border-b mb-4">
+              <div className="border-b mb-4">
                 <div className="mb-4 flex gap-6">
                   <button
                     onClick={() => setActiveTab("info")}
@@ -879,14 +902,6 @@ const ReportEditor: React.FC = () => {
                     Observations
                   </button>
                 </div>
-                <Button
-                  variant="secondary"
-                  onClick={() => nav(`/reports/${report.id}/preview`)}
-                >
-                  Preview Report
-                </Button>
-          
-                
               </div>
 
               {activeTab === "info" && (
@@ -1413,7 +1428,8 @@ const ReportEditor: React.FC = () => {
               setCustomSectionDialogOpen(false);
             }}
           />
-        </main>
+          </main>
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- add preview and back-to-reports controls beside Save buttons for all report editors
- include manual save/preview/back header on the home inspection editor

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint reported numerous errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b7898b5c248333894ddbae4e491443