### PR TITLE
Compute appointment end date client-side

### DIFF
--- a/src/pages/BookingPage.tsx
+++ b/src/pages/BookingPage.tsx
@@ -16,7 +16,7 @@ const BookingPage: React.FC = () => {
     enabled: !!slug,
   });
 
-  const { data: reserved = [], isLoading: appointmentsLoading } = useQuery<{ start_date: string; end_date: string | null }[]>({
+  const { data: reserved = [], isLoading: appointmentsLoading } = useQuery<{ start_date: string; end_date: string }[]>({
     queryKey: ['booking-reserved', settings?.user_id],
     queryFn: () => bookingApi.getTakenAppointments(settings!.user_id),
     enabled: !!settings?.user_id,
@@ -49,7 +49,7 @@ const BookingPage: React.FC = () => {
 
   const reservedRanges = reserved.map(r => ({
     startDate: new Date(r.start_date),
-    endDate: new Date(r.end_date || r.start_date),
+    endDate: new Date(r.end_date),
   }));
 
   return (


### PR DESCRIPTION
## Summary
- Retrieve duration in booking API and compute end date from appointment date and duration.
- Simplify booking page reservation mapping to consume computed end date.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and require import issues)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b8b58086988333b6c0604072bc7883