### PR TITLE
Add basic service worker

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,13 @@
+self.addEventListener('install', () => {
+  // Skip waiting to activate the new service worker immediately
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  // Clean up old caches or perform additional setup here
+  console.log('Service worker activated', event);
+});
+
+self.addEventListener('fetch', () => {
+  // Placeholder fetch handler
+});


### PR DESCRIPTION
## Summary
- add minimal `sw.js` to allow service worker registration

## Testing
- `npm run lint` (fails: Unexpected any and other lint errors)
- `npm run build`
- `curl -I http://localhost:8080/sw.js`
- `NODE_PATH=/workspace/node_modules node /tmp/test-sw.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8b6dce2508333ae1d5fa9775b3b6b