### PR TITLE
Replace deprecated PWA meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,7 @@
     <link rel="icon" href="/favicon.png" type="image/png">
     <link rel="manifest" href="/manifest.json">
     <meta name="theme-color" content="#1e293b">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="default">
-    <meta name="apple-mobile-web-app-title" content="Home Report Pro">
+    <meta name="mobile-web-app-capable" content="yes">
     <link rel="apple-touch-icon" href="/pwa-192x192.png">
 
     <!-- Google Fonts for signature functionality -->


### PR DESCRIPTION
## Summary
- replace deprecated apple mobile web app meta tag with standard `mobile-web-app-capable`
- remove remaining apple-specific PWA meta tags

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 308 problems (283 errors, 25 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68b8b9073adc8333b7bfbeec3d7a0cf9