### PR TITLE
feat: add services management

### DIFF
--- a/src/integrations/supabase/servicesApi.ts
+++ b/src/integrations/supabase/servicesApi.ts
@@ -1,0 +1,57 @@
+import { supabase } from './client';
+
+export interface Service {
+  id?: string;
+  user_id: string;
+  name: string;
+  price: number;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export const servicesApi = {
+  async list(userId: string): Promise<Service[]> {
+    const { data, error } = await supabase
+      .from('services')
+      .select('*')
+      .eq('user_id', userId)
+      .order('name', { ascending: true });
+
+    if (error) throw error;
+    return (data as Service[]) || [];
+  },
+
+  async create(service: Omit<Service, 'id' | 'created_at' | 'updated_at'>): Promise<Service> {
+    const { data, error } = await supabase
+      .from('services')
+      .insert(service)
+      .select()
+      .single();
+
+    if (error) throw error;
+    return data as Service;
+  },
+
+  async update(id: string, updates: Partial<Omit<Service, 'id' | 'user_id'>>): Promise<Service> {
+    const { data, error } = await supabase
+      .from('services')
+      .update(updates)
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (error) throw error;
+    return data as Service;
+  },
+
+  async remove(id: string): Promise<void> {
+    const { error } = await supabase
+      .from('services')
+      .delete()
+      .eq('id', id);
+
+    if (error) throw error;
+  }
+};
+
+export default servicesApi;

--- a/src/pages/Settings/Services.tsx
+++ b/src/pages/Settings/Services.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useForm } from 'react-hook-form';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { servicesApi, Service } from '@/integrations/supabase/servicesApi';
+
+interface ServiceForm {
+  name: string;
+  price: number;
+}
+
+const Services: React.FC = () => {
+  const { user } = useAuth();
+  const { data: services = [], refetch } = useQuery({
+    queryKey: ['services', user?.id],
+    queryFn: () => servicesApi.list(user!.id),
+    enabled: !!user,
+  });
+
+  const createForm = useForm<ServiceForm>();
+  const createMutation = useMutation({
+    mutationFn: (values: ServiceForm) =>
+      servicesApi.create({ ...values, user_id: user!.id }),
+    onSuccess: () => {
+      refetch();
+      createForm.reset();
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, values }: { id: string; values: ServiceForm }) =>
+      servicesApi.update(id, values),
+    onSuccess: () => refetch(),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => servicesApi.remove(id),
+    onSuccess: () => refetch(),
+  });
+
+  const onCreate = createForm.handleSubmit((values) => createMutation.mutate(values));
+
+  const ServiceItem: React.FC<{ service: Service }> = ({ service }) => {
+    const { register, handleSubmit } = useForm<ServiceForm>({
+      defaultValues: { name: service.name, price: service.price },
+    });
+    const onSubmit = handleSubmit((values) =>
+      updateMutation.mutate({ id: service.id!, values })
+    );
+
+    return (
+      <form onSubmit={onSubmit} className="flex gap-2 items-center">
+        <input
+          className="border p-1 flex-1"
+          {...register('name')}
+          required
+        />
+        <input
+          type="number"
+          step="0.01"
+          className="border p-1 w-24"
+          {...register('price', { valueAsNumber: true })}
+          required
+        />
+        <button
+          type="submit"
+          className="px-2 py-1 bg-primary text-primary-foreground rounded"
+        >
+          Save
+        </button>
+        <button
+          type="button"
+          onClick={() => deleteMutation.mutate(service.id!)}
+          className="px-2 py-1 bg-destructive text-destructive-foreground rounded"
+        >
+          Delete
+        </button>
+      </form>
+    );
+  };
+
+  return (
+    <div className="space-y-4 max-w-md">
+      <form onSubmit={onCreate} className="flex gap-2 items-center">
+        <input
+          className="border p-1 flex-1"
+          placeholder="Service name"
+          {...createForm.register('name')}
+          required
+        />
+        <input
+          type="number"
+          step="0.01"
+          className="border p-1 w-24"
+          placeholder="Price"
+          {...createForm.register('price', { valueAsNumber: true })}
+          required
+        />
+        <button
+          type="submit"
+          className="px-2 py-1 bg-primary text-primary-foreground rounded"
+          disabled={createMutation.isPending}
+        >
+          Add
+        </button>
+      </form>
+      <div className="space-y-2">
+        {services.map((s) => (
+          <ServiceItem key={s.id} service={s} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Services;

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -15,6 +15,7 @@ import Data from "./Data";
 import Integrations from "./Integrations";
 import Advanced from "./Advanced";
 import Booking from "./Booking";
+import Services from "./Services";
 
 const Settings: React.FC = () => {
   const location = useLocation();
@@ -55,6 +56,7 @@ const Settings: React.FC = () => {
           <TabsTrigger value="email-template">Email Template</TabsTrigger>
           <TabsTrigger value="data">Data</TabsTrigger>
           <TabsTrigger value="integrations">Integrations</TabsTrigger>
+          <TabsTrigger value="services">Services</TabsTrigger>
           <TabsTrigger value="booking">Booking</TabsTrigger>
           {isAdminOrOwner && <TabsTrigger value="advanced">Advanced</TabsTrigger>}
         </TabsList>
@@ -77,6 +79,9 @@ const Settings: React.FC = () => {
         </TabsContent>
         <TabsContent value="integrations">
           <Integrations />
+        </TabsContent>
+        <TabsContent value="services">
+          <Services />
         </TabsContent>
         <TabsContent value="booking">
           <Booking />

--- a/supabase/migrations/20250917000000_create_services.sql
+++ b/supabase/migrations/20250917000000_create_services.sql
@@ -1,0 +1,95 @@
+-- Create services table
+create table if not exists public.services (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id),
+  name text not null,
+  price numeric not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- Indexes
+create index if not exists services_user_id_idx on public.services (user_id);
+
+-- Enable RLS
+alter table public.services enable row level security;
+
+-- Policies
+create policy "Users can select own services"
+  on public.services
+  for select
+  to authenticated
+  using (auth.uid() = user_id);
+
+create policy "Users can insert own services"
+  on public.services
+  for insert
+  to authenticated
+  with check (auth.uid() = user_id);
+
+create policy "Users can update own services"
+  on public.services
+  for update
+  to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "Users can delete own services"
+  on public.services
+  for delete
+  to authenticated
+  using (auth.uid() = user_id);
+
+-- Trigger for updated_at
+create trigger update_services_updated_at
+  before update on public.services
+  for each row execute function public.set_updated_at();
+
+-- Create appointment_services join table
+create table if not exists public.appointment_services (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id),
+  appointment_id uuid not null references public.appointments(id) on delete cascade,
+  service_id uuid not null references public.services(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- Indexes
+create index if not exists appointment_services_user_id_idx on public.appointment_services (user_id);
+create index if not exists appointment_services_appointment_id_idx on public.appointment_services (appointment_id);
+create index if not exists appointment_services_service_id_idx on public.appointment_services (service_id);
+
+-- Enable RLS
+alter table public.appointment_services enable row level security;
+
+-- Policies
+create policy "Users can select own appointment services"
+  on public.appointment_services
+  for select
+  to authenticated
+  using (auth.uid() = user_id);
+
+create policy "Users can insert own appointment services"
+  on public.appointment_services
+  for insert
+  to authenticated
+  with check (auth.uid() = user_id);
+
+create policy "Users can update own appointment services"
+  on public.appointment_services
+  for update
+  to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "Users can delete own appointment services"
+  on public.appointment_services
+  for delete
+  to authenticated
+  using (auth.uid() = user_id);
+
+-- Trigger for updated_at
+create trigger update_appointment_services_updated_at
+  before update on public.appointment_services
+  for each row execute function public.set_updated_at();


### PR DESCRIPTION
## Summary
- add services and appointment_services tables with RLS policies
- expose services CRUD via Supabase API layer
- add Services settings page and tab for managing user services

## Testing
- `bun run lint` *(fails: script "lint" exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bb0648108333bcc6190f1855b859