### PR TITLE
feat: add service selection to booking

### DIFF
--- a/src/pages/BookingPage.tsx
+++ b/src/pages/BookingPage.tsx
@@ -4,6 +4,8 @@ import { Calendar } from '@demark-pro/react-booking-calendar';
 import '@demark-pro/react-booking-calendar/dist/react-booking-calendar.css';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { bookingApi, AppointmentPayload } from '@/integrations/supabase/bookingApi';
+import { servicesApi, type Service } from '@/integrations/supabase/servicesApi';
+import { Checkbox } from '@/components/ui/checkbox';
 
 const BookingPage: React.FC = () => {
   const { slug } = useParams();
@@ -22,9 +24,16 @@ const BookingPage: React.FC = () => {
     enabled: !!settings?.user_id,
   });
 
+  const { data: services = [] } = useQuery<Service[]>({
+    queryKey: ['booking-services', settings?.user_id],
+    queryFn: () => servicesApi.list(settings!.user_id),
+    enabled: !!settings?.user_id,
+  });
+
   const [selected, setSelected] = React.useState<Date[]>([]);
   const [name, setName] = React.useState('');
   const [email, setEmail] = React.useState('');
+  const [serviceIds, setServiceIds] = React.useState<string[]>([]);
 
   const mutation = useMutation({
     mutationFn: (payload: AppointmentPayload) => bookingApi.createAppointment(payload),
@@ -41,6 +50,7 @@ const BookingPage: React.FC = () => {
       appointment_date: selected[0].toISOString(),
       contact_name: name,
       contact_email: email,
+      service_ids: serviceIds,
     });
   };
 
@@ -71,6 +81,31 @@ const BookingPage: React.FC = () => {
           onChange={e => setEmail(e.target.value)}
           required
         />
+        {services.length > 0 && (
+          <div className="space-y-1">
+            <p className="font-medium">Select Services</p>
+            {services.map((s) => {
+              const isChecked = serviceIds.includes(s.id!);
+              return (
+                <label key={s.id} className="flex items-center gap-2">
+                  <Checkbox
+                    checked={isChecked}
+                    onCheckedChange={(checked) => {
+                      if (checked) {
+                        setServiceIds([...serviceIds, s.id!]);
+                      } else {
+                        setServiceIds(serviceIds.filter((id) => id !== s.id));
+                      }
+                    }}
+                  />
+                  <span>
+                    {s.name} (${s.price})
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+        )}
         <button type="submit" className="px-4 py-2 bg-primary text-primary-foreground rounded" disabled={mutation.isPending}>
           Book
         </button>


### PR DESCRIPTION
## Summary
- load services when booking page opens
- allow selecting one or more services during booking
- save selected services when creating an appointment

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 283 errors, 25 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b8bc2338708333a97301317590c71d