### PR TITLE
feat: add template and color to booking settings

### DIFF
--- a/src/integrations/supabase/bookingApi.ts
+++ b/src/integrations/supabase/bookingApi.ts
@@ -6,6 +6,8 @@ export interface BookingSettings {
   slug: string;
   default_duration?: number | null;
   advance_notice?: number | null;
+  template?: string;
+  theme_color?: string | null;
 }
 
 export interface AppointmentPayload {
@@ -22,7 +24,9 @@ export const bookingApi = {
   async getSettingsBySlug(slug: string): Promise<BookingSettings | null> {
     const { data, error } = await supabase
       .from('booking_settings' as any)
-      .select('*')
+      .select(
+        'id, user_id, slug, default_duration, advance_notice, template, theme_color'
+      )
       .eq('slug', slug)
       .maybeSingle();
 
@@ -33,7 +37,9 @@ export const bookingApi = {
   async getSettingsByUser(userId: string): Promise<BookingSettings | null> {
     const { data, error } = await supabase
       .from('booking_settings' as any)
-      .select('*')
+      .select(
+        'id, user_id, slug, default_duration, advance_notice, template, theme_color'
+      )
       .eq('user_id', userId)
       .maybeSingle();
 
@@ -41,10 +47,15 @@ export const bookingApi = {
     return data as BookingSettings | null;
   },
 
-  async upsertSettings(userId: string, slug: string): Promise<BookingSettings> {
+  async upsertSettings(
+    userId: string,
+    slug: string,
+    template: string = 'templateA',
+    themeColor?: string | null
+  ): Promise<BookingSettings> {
     const { data, error } = await supabase
       .from('booking_settings' as any)
-      .upsert({ user_id: userId, slug })
+      .upsert({ user_id: userId, slug, template, theme_color: themeColor })
       .select()
       .single();
 

--- a/supabase/migrations/20250918000000_add_template_and_color.sql
+++ b/supabase/migrations/20250918000000_add_template_and_color.sql
@@ -1,0 +1,5 @@
+-- Add template and theme_color columns to booking_settings
+ALTER TABLE public.booking_settings
+  ADD COLUMN IF NOT EXISTS template text NOT NULL DEFAULT 'templateA';
+ALTER TABLE public.booking_settings
+  ADD COLUMN IF NOT EXISTS theme_color text;


### PR DESCRIPTION
## Summary
- add BookingSettings template and theme_color fields and update supabase API access
- add migration adding template and theme_color columns to booking_settings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any & require import errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8c0e55fbc8333b49ceb37c80aeedf