### PR TITLE
feat(booking): add templates and dynamic selection

### DIFF
--- a/src/components/booking/templates/TemplateA.tsx
+++ b/src/components/booking/templates/TemplateA.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import Widget from '../Widget';
+import { TemplateProps } from './types';
+
+const TemplateA: React.FC<TemplateProps> = ({ org, settings }) => (
+  <div className="min-h-screen p-4" style={{ backgroundColor: org?.primary_color || undefined }}>
+    <div className="max-w-2xl mx-auto space-y-4">
+      {org?.logo_url && (
+        <img src={org.logo_url} alt={org.name || ''} className="h-16 mx-auto" />
+      )}
+      {org?.name && (
+        <h1
+          className="text-2xl font-bold text-center"
+          style={{ color: org.secondary_color || undefined }}
+        >
+          {org.name}
+        </h1>
+      )}
+      <Widget settings={settings} />
+    </div>
+  </div>
+);
+
+export default TemplateA;

--- a/src/components/booking/templates/TemplateB.tsx
+++ b/src/components/booking/templates/TemplateB.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Widget from '../Widget';
+import { TemplateProps } from './types';
+
+const TemplateB: React.FC<TemplateProps> = ({ org, settings }) => (
+  <div
+    className="min-h-screen flex items-center justify-center"
+    style={{ backgroundColor: org?.secondary_color || undefined }}
+  >
+    <div className="p-8 space-y-4 bg-white rounded shadow max-w-md w-full">
+      {org?.logo_url && (
+        <img src={org.logo_url} alt={org.name || ''} className="h-12 mx-auto" />
+      )}
+      {org?.name && <h1 className="text-xl font-semibold text-center">{org.name}</h1>}
+      <Widget settings={settings} />
+    </div>
+  </div>
+);
+
+export default TemplateB;

--- a/src/components/booking/templates/TemplateC.tsx
+++ b/src/components/booking/templates/TemplateC.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Widget from '../Widget';
+import { TemplateProps } from './types';
+
+const TemplateC: React.FC<TemplateProps> = ({ org, settings }) => (
+  <div className="min-h-screen flex flex-col" style={{ backgroundColor: org?.primary_color || undefined }}>
+    <header className="p-4 bg-white flex items-center justify-center gap-2 shadow">
+      {org?.logo_url && <img src={org.logo_url} alt={org.name || ''} className="h-10" />}
+      {org?.name && <span className="text-lg font-bold">{org.name}</span>}
+    </header>
+    <main className="flex-1 flex items-center justify-center p-4">
+      <Widget settings={settings} />
+    </main>
+  </div>
+);
+
+export default TemplateC;

--- a/src/components/booking/templates/index.ts
+++ b/src/components/booking/templates/index.ts
@@ -1,0 +1,13 @@
+import TemplateA from './TemplateA';
+import TemplateB from './TemplateB';
+import TemplateC from './TemplateC';
+
+export { type TemplateProps } from './types';
+
+export const templates = {
+  templateA: TemplateA,
+  templateB: TemplateB,
+  templateC: TemplateC,
+} as const;
+
+export type TemplateId = keyof typeof templates;

--- a/src/components/booking/templates/types.ts
+++ b/src/components/booking/templates/types.ts
@@ -1,0 +1,11 @@
+import { BookingSettings } from '@/integrations/supabase/bookingApi';
+
+export interface TemplateProps {
+  org: {
+    logo_url: string | null;
+    name: string | null;
+    primary_color: string | null;
+    secondary_color: string | null;
+  } | null;
+  settings: BookingSettings;
+}

--- a/src/pages/BookingPage.tsx
+++ b/src/pages/BookingPage.tsx
@@ -4,48 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { bookingApi, type BookingSettings } from '@/integrations/supabase/bookingApi';
 import { supabase } from '@/integrations/supabase/client';
 import Widget from '@/components/booking/Widget';
-
-interface TemplateProps {
-  organization: {
-    logo_url: string | null;
-    name: string | null;
-    primary_color: string | null;
-    secondary_color: string | null;
-  } | null;
-  children: React.ReactNode;
-}
-
-const TemplateA: React.FC<TemplateProps> = ({ organization, children }) => (
-  <div
-    className="min-h-screen p-4"
-    style={{ backgroundColor: organization?.primary_color || undefined }}
-  >
-    <div className="max-w-2xl mx-auto space-y-4">
-      {organization?.logo_url && (
-        <img
-          src={organization.logo_url}
-          alt={organization.name || ''}
-          className="h-16 mx-auto"
-        />
-      )}
-      {organization?.name && (
-        <h1
-          className="text-2xl font-bold text-center"
-          style={{ color: organization.secondary_color || undefined }}
-        >
-          {organization.name}
-        </h1>
-      )}
-      {children}
-    </div>
-  </div>
-);
-
-const BOOKING_TEMPLATES = {
-  templateA: TemplateA,
-} as const;
-
-type TemplateId = keyof typeof BOOKING_TEMPLATES;
+import { templates, type TemplateId, type TemplateProps } from '@/components/booking/templates';
 
 const BookingPage: React.FC = () => {
   const { slug } = useParams();
@@ -65,7 +24,7 @@ const BookingPage: React.FC = () => {
         .from('organization_members')
         .select('organizations(logo_url,name,primary_color,secondary_color)')
         .eq('user_id', settings!.user_id)
-        .single<{ organizations: TemplateProps['organization'] }>();
+        .single<{ organizations: TemplateProps['org'] }>();
       if (error) throw error;
       return data?.organizations ?? null;
     },
@@ -82,13 +41,9 @@ const BookingPage: React.FC = () => {
   if (orgLoading) return <div className="p-4">Loading...</div>;
 
   const templateKey = (settings.template || 'templateA') as TemplateId;
-  const Template = BOOKING_TEMPLATES[templateKey] || TemplateA;
+  const Template = templates[templateKey] ?? templates.templateA;
 
-  return (
-    <Template organization={organization || null}>
-      <Widget settings={settings} />
-    </Template>
-  );
+  return <Template org={organization || null} settings={settings} />;
 };
 
 export default BookingPage;


### PR DESCRIPTION
## Summary
- add booking templates folder with TemplateA/B/C and map
- dynamically render booking page using selected template

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8c32dbbc48333ae3c1dff71157a6a