### PR TITLE
feat: display organization details on booking page

### DIFF
--- a/src/components/booking/templates/TemplateA.tsx
+++ b/src/components/booking/templates/TemplateA.tsx
@@ -17,6 +17,17 @@ const TemplateA: React.FC<TemplateProps> = ({ org, settings }) => (
         </h1>
       )}
       <Widget settings={settings} />
+      {(org?.address || org?.phone || org?.email || org?.website) && (
+        <div
+          className="text-center space-y-1 text-sm"
+          style={{ color: org?.secondary_color || undefined }}
+        >
+          {org.address && <p>{org.address}</p>}
+          {org.phone && <p>{org.phone}</p>}
+          {org.email && <p>{org.email}</p>}
+          {org.website && <p>{org.website}</p>}
+        </div>
+      )}
     </div>
   </div>
 );

--- a/src/components/booking/templates/TemplateB.tsx
+++ b/src/components/booking/templates/TemplateB.tsx
@@ -13,6 +13,14 @@ const TemplateB: React.FC<TemplateProps> = ({ org, settings }) => (
       )}
       {org?.name && <h1 className="text-xl font-semibold text-center">{org.name}</h1>}
       <Widget settings={settings} />
+      {(org?.address || org?.phone || org?.email || org?.website) && (
+        <div className="text-center space-y-1 text-sm text-gray-700">
+          {org.address && <p>{org.address}</p>}
+          {org.phone && <p>{org.phone}</p>}
+          {org.email && <p>{org.email}</p>}
+          {org.website && <p>{org.website}</p>}
+        </div>
+      )}
     </div>
   </div>
 );

--- a/src/components/booking/templates/TemplateC.tsx
+++ b/src/components/booking/templates/TemplateC.tsx
@@ -11,6 +11,14 @@ const TemplateC: React.FC<TemplateProps> = ({ org, settings }) => (
     <main className="flex-1 flex items-center justify-center p-4">
       <Widget settings={settings} />
     </main>
+    {(org?.address || org?.phone || org?.email || org?.website) && (
+      <footer className="p-4 bg-white text-center space-y-1 text-sm">
+        {org.address && <p>{org.address}</p>}
+        {org.phone && <p>{org.phone}</p>}
+        {org.email && <p>{org.email}</p>}
+        {org.website && <p>{org.website}</p>}
+      </footer>
+    )}
   </div>
 );
 

--- a/src/components/booking/templates/types.ts
+++ b/src/components/booking/templates/types.ts
@@ -4,6 +4,10 @@ export interface TemplateProps {
   org: {
     logo_url: string | null;
     name: string | null;
+    address: string | null;
+    phone: string | null;
+    email: string | null;
+    website: string | null;
     primary_color: string | null;
     secondary_color: string | null;
   } | null;


### PR DESCRIPTION
## Summary
- fetch organization details for booking pages, with fallback to inspector profile
- extend booking templates to show logo, contact info, and colors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b8d03a2b148333aa327580ba0176d6