### PR TITLE
Refactor booking templates with CSS variable styling

### DIFF
--- a/src/components/booking/templates/TemplateA.tsx
+++ b/src/components/booking/templates/TemplateA.tsx
@@ -1,27 +1,26 @@
 import React from 'react';
-import Widget from '../Widget';
-import { TemplateProps } from './types';
+import type { TemplateProps } from './types';
 
-const TemplateA: React.FC<TemplateProps> = ({ org, settings }) => (
-  <div className="min-h-screen p-4" style={{ backgroundColor: org?.primary_color || undefined }}>
+const TemplateA: React.FC<TemplateProps> = ({ org, children }) => (
+  <div
+    className="min-h-screen p-4 bg-[var(--primary-color)]"
+    style={{
+      '--primary-color': org?.primary_color || 'transparent',
+      '--secondary-color': org?.secondary_color || '#000',
+    } as React.CSSProperties}
+  >
     <div className="max-w-2xl mx-auto space-y-4">
       {org?.logo_url && (
         <img src={org.logo_url} alt={org.name || ''} className="h-16 mx-auto" />
       )}
       {org?.name && (
-        <h1
-          className="text-2xl font-bold text-center"
-          style={{ color: org.secondary_color || undefined }}
-        >
+        <h1 className="text-2xl font-bold text-center text-[var(--secondary-color)]">
           {org.name}
         </h1>
       )}
-      <Widget settings={settings} />
+      {children}
       {(org?.address || org?.phone || org?.email || org?.website) && (
-        <div
-          className="text-center space-y-1 text-sm"
-          style={{ color: org?.secondary_color || undefined }}
-        >
+        <div className="text-center space-y-1 text-sm text-[var(--secondary-color)]">
           {org.address && <p>{org.address}</p>}
           {org.phone && <p>{org.phone}</p>}
           {org.email && <p>{org.email}</p>}

--- a/src/components/booking/templates/TemplateB.tsx
+++ b/src/components/booking/templates/TemplateB.tsx
@@ -1,20 +1,26 @@
 import React from 'react';
-import Widget from '../Widget';
-import { TemplateProps } from './types';
+import type { TemplateProps } from './types';
 
-const TemplateB: React.FC<TemplateProps> = ({ org, settings }) => (
+const TemplateB: React.FC<TemplateProps> = ({ org, children }) => (
   <div
-    className="min-h-screen flex items-center justify-center"
-    style={{ backgroundColor: org?.secondary_color || undefined }}
+    className="min-h-screen flex items-center justify-center bg-[var(--secondary-color)]"
+    style={{
+      '--primary-color': org?.primary_color || '#000',
+      '--secondary-color': org?.secondary_color || 'transparent',
+    } as React.CSSProperties}
   >
     <div className="p-8 space-y-4 bg-white rounded shadow max-w-md w-full">
       {org?.logo_url && (
         <img src={org.logo_url} alt={org.name || ''} className="h-12 mx-auto" />
       )}
-      {org?.name && <h1 className="text-xl font-semibold text-center">{org.name}</h1>}
-      <Widget settings={settings} />
+      {org?.name && (
+        <h1 className="text-xl font-semibold text-center text-[var(--primary-color)]">
+          {org.name}
+        </h1>
+      )}
+      {children}
       {(org?.address || org?.phone || org?.email || org?.website) && (
-        <div className="text-center space-y-1 text-sm text-gray-700">
+        <div className="text-center space-y-1 text-sm text-[var(--primary-color)]">
           {org.address && <p>{org.address}</p>}
           {org.phone && <p>{org.phone}</p>}
           {org.email && <p>{org.email}</p>}

--- a/src/components/booking/templates/TemplateC.tsx
+++ b/src/components/booking/templates/TemplateC.tsx
@@ -1,18 +1,23 @@
 import React from 'react';
-import Widget from '../Widget';
-import { TemplateProps } from './types';
+import type { TemplateProps } from './types';
 
-const TemplateC: React.FC<TemplateProps> = ({ org, settings }) => (
-  <div className="min-h-screen flex flex-col" style={{ backgroundColor: org?.primary_color || undefined }}>
+const TemplateC: React.FC<TemplateProps> = ({ org, children }) => (
+  <div
+    className="min-h-screen flex flex-col bg-[var(--primary-color)]"
+    style={{
+      '--primary-color': org?.primary_color || 'transparent',
+      '--secondary-color': org?.secondary_color || '#000',
+    } as React.CSSProperties}
+  >
     <header className="p-4 bg-white flex items-center justify-center gap-2 shadow">
       {org?.logo_url && <img src={org.logo_url} alt={org.name || ''} className="h-10" />}
-      {org?.name && <span className="text-lg font-bold">{org.name}</span>}
+      {org?.name && (
+        <span className="text-lg font-bold text-[var(--secondary-color)]">{org.name}</span>
+      )}
     </header>
-    <main className="flex-1 flex items-center justify-center p-4">
-      <Widget settings={settings} />
-    </main>
+    <main className="flex-1 flex items-center justify-center p-4">{children}</main>
     {(org?.address || org?.phone || org?.email || org?.website) && (
-      <footer className="p-4 bg-white text-center space-y-1 text-sm">
+      <footer className="p-4 bg-white text-center space-y-1 text-sm text-[var(--secondary-color)]">
         {org.address && <p>{org.address}</p>}
         {org.phone && <p>{org.phone}</p>}
         {org.email && <p>{org.email}</p>}

--- a/src/components/booking/templates/types.ts
+++ b/src/components/booking/templates/types.ts
@@ -1,4 +1,4 @@
-import { BookingSettings } from '@/integrations/supabase/bookingApi';
+import type { ReactNode } from 'react';
 
 export interface TemplateProps {
   org: {
@@ -11,5 +11,5 @@ export interface TemplateProps {
     primary_color: string | null;
     secondary_color: string | null;
   } | null;
-  settings: BookingSettings;
+  children?: ReactNode;
 }

--- a/src/pages/BookingPage.tsx
+++ b/src/pages/BookingPage.tsx
@@ -70,7 +70,11 @@ const BookingPage: React.FC = () => {
   const templateKey = (settings.template || 'templateA') as TemplateId;
   const Template = templates[templateKey] ?? templates.templateA;
 
-  return <Template org={organization || null} settings={settings} />;
+  return (
+    <Template org={organization || null}>
+      <Widget settings={settings} />
+    </Template>
+  );
 };
 
 export default BookingPage;


### PR DESCRIPTION
## Summary
- refactor booking templates to accept children and use CSS variable-based colors
- expose templates map for dynamic booking page layouts
- render booking widget inside selected template on booking page

## Testing
- `npm run lint` *(fails: Unexpected any in many files)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b8e0518a4883338d97f35c219e0786