### PR TITLE
Map booking calendar ranges client-side

### DIFF
--- a/src/components/booking/Widget.tsx
+++ b/src/components/booking/Widget.tsx
@@ -10,14 +10,10 @@ import { Checkbox } from '@/components/ui/checkbox';
 
 interface WidgetProps {
   settings: BookingSettings;
+  reserved: { startDate: Date; endDate: Date }[];
 }
 
-const Widget: React.FC<WidgetProps> = ({ settings }) => {
-  const { data: reserved = [] } = useQuery<{ start_date: string; end_date: string }[]>({
-    queryKey: ['booking-reserved', settings.user_id],
-    queryFn: () => bookingApi.getTakenAppointments(settings.user_id),
-    enabled: !!settings.user_id,
-  });
+const Widget: React.FC<WidgetProps> = ({ settings, reserved }) => {
 
   const { data: services = [] } = useQuery<Service[]>({
     queryKey: ['booking-services', settings.user_id],
@@ -63,14 +59,9 @@ const Widget: React.FC<WidgetProps> = ({ settings }) => {
     }
   };
 
-  const reservedRanges = reserved.map(r => ({
-    startDate: new Date(r.start_date),
-    endDate: new Date(r.end_date),
-  }));
-
   return (
     <div className="space-y-4">
-      <Calendar selected={selected} reserved={reservedRanges} onChange={setSelected} />
+      <Calendar selected={selected} reserved={reserved} onChange={setSelected} />
       <form onSubmit={onSubmit} className="space-y-2">
         <input
           className="border p-2 w-full"

--- a/src/integrations/supabase/bookingApi.ts
+++ b/src/integrations/supabase/bookingApi.ts
@@ -63,7 +63,9 @@ export const bookingApi = {
     return data as BookingSettings;
   },
 
-  async getTakenAppointments(userId: string): Promise<{ start_date: string; end_date: string }[]> {
+  async getTakenAppointments(
+    userId: string
+  ): Promise<{ appointment_date: string; duration_minutes: number | null }[]> {
     const { data, error } = await supabase
       .from('appointments')
       .select('appointment_date, duration_minutes')
@@ -71,13 +73,9 @@ export const bookingApi = {
       .in('status', ['scheduled', 'confirmed', 'in_progress']);
 
     if (error) throw error;
-    const rows = (data as { appointment_date: string; duration_minutes: number | null }[]) || [];
-    return rows.map((a) => {
-      const end = new Date(
-        new Date(a.appointment_date).getTime() + (a.duration_minutes ?? 0) * 60000
-      );
-      return { start_date: a.appointment_date, end_date: end.toISOString() };
-    });
+    return (
+      (data as { appointment_date: string; duration_minutes: number | null }[]) || []
+    );
   },
 
   async createAppointment(appointment: AppointmentPayload) {

--- a/src/pages/BookingPage.tsx
+++ b/src/pages/BookingPage.tsx
@@ -58,11 +58,27 @@ const BookingPage: React.FC = () => {
     enabled: !!settings?.user_id,
   });
 
+  const { data: taken = [] } = useQuery({
+    queryKey: ['booking-taken', settings?.user_id],
+    queryFn: () => bookingApi.getTakenAppointments(settings!.user_id),
+    enabled: !!settings?.user_id,
+  });
+
+  const reservedRanges = React.useMemo(
+    () =>
+      taken.map((a: { appointment_date: string; duration_minutes: number | null }) => {
+        const start = new Date(a.appointment_date);
+        const end = new Date(start.getTime() + (a.duration_minutes ?? 0) * 60000);
+        return { startDate: start, endDate: end };
+      }),
+    [taken]
+  );
+
   if (settingsLoading) return <div className="p-4">Loading...</div>;
   if (!settings) return <div className="p-4">Booking page not found.</div>;
 
   if (embed) {
-    return <Widget settings={settings} />;
+    return <Widget settings={settings} reserved={reservedRanges} />;
   }
 
   if (orgLoading) return <div className="p-4">Loading...</div>;
@@ -72,7 +88,7 @@ const BookingPage: React.FC = () => {
 
   return (
     <Template org={organization || null}>
-      <Widget settings={settings} />
+      <Widget settings={settings} reserved={reservedRanges} />
     </Template>
   );
 };


### PR DESCRIPTION
## Summary
- Select `appointment_date` and `duration_minutes` in `getTakenAppointments` to return raw scheduling data.
- Map appointment rows into `{startDate, endDate}` ranges on the booking page and pass them down to the calendar widget.
- Update booking widgets to accept precomputed reserved ranges.

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8e6b486a88333baf84bc7993f8cda