### PR TITLE
feat: use table layout for reports list

### DIFF
--- a/src/components/reports/ReportsListView.tsx
+++ b/src/components/reports/ReportsListView.tsx
@@ -3,10 +3,28 @@ import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { FileText, Eye, Trash2, Archive, ArchiveRestore, Wind, Flame, ShieldCheck, Home, Pencil } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  FileText,
+  Eye,
+  Trash2,
+  Archive,
+  ArchiveRestore,
+  Wind,
+  Flame,
+  ShieldCheck,
+  Home,
+  Pencil,
+} from "lucide-react";
 import { downloadWindMitigationReport } from "@/utils/fillWindMitigationPDF";
 import { REPORT_TYPE_LABELS } from "@/constants/reportTypes";
-import type { Report } from "@/lib/reportSchemas";
 
 interface ReportsListViewProps {
   reports: any[];
@@ -15,136 +33,161 @@ interface ReportsListViewProps {
   showArchived?: boolean;
 }
 
-export const ReportsListView: React.FC<ReportsListViewProps> = ({ 
-  reports, 
-  onDelete, 
-  onArchive, 
-  showArchived = false 
+export const ReportsListView: React.FC<ReportsListViewProps> = ({
+  reports,
+  onDelete,
+  onArchive,
+  showArchived: _showArchived = false
 }) => {
-  return (
-    <div className="space-y-2">
-      {reports.map((report) => (
-        <div key={report.id} className="flex items-center justify-between p-4 border rounded-lg hover:bg-muted/50 transition-colors">
-          <div className="flex items-center gap-4 flex-1 min-w-0">
-            <div className="flex-shrink-0">
-              {(report.reportType as string).includes("wind") ? (
-                <Wind className="h-5 w-5 text-muted-foreground" />
-              ) : (report.reportType as string).includes("wildfire") ? (
-                <Flame className="h-5 w-5 text-muted-foreground" />
-              ) : (report.reportType as string).includes("roof") ? (
-                <ShieldCheck className="h-5 w-5 text-muted-foreground" />
-              ) : (report.reportType as string).includes("home") ? (
-                <Home className="h-5 w-5 text-muted-foreground" />
-              ) : (
-                <FileText className="h-5 w-5 text-muted-foreground" />
-              )}
-            </div>
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2 mb-1">
-                  <h3 className="font-medium truncate">
-                    {report.title || "Untitled Report"}
-                  </h3>
-                  <Badge variant="secondary">
-                    {REPORT_TYPE_LABELS[report.reportType] || report.reportType}
-                  </Badge>
-                  {report.archived && (
-                    <Badge variant="outline">Archived</Badge>
-                  )}
-                </div>
-                {report.address && (
-                  <p className="text-sm text-muted-foreground truncate">
-                    {report.address}
-                  </p>
-                )}
-                <div className="text-sm text-muted-foreground mt-1">
-                  {report.inspectionDate && (
-                    <span>Inspection: {new Date(report.inspectionDate).toLocaleDateString()}</span>
-                  )}
-                  {report.clientName && (
-                    <span className="ml-4">Client: {report.clientName}</span>
-                  )}
-                </div>
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button size="sm" variant="ghost" className="border" asChild>
-                    <Link to={`/reports/${report.id}`}>
-                      <Pencil className="h-4 w-4" />
-                      <span className="sr-only">Edit</span>
-                    </Link>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Edit report</TooltipContent>
-              </Tooltip>
-              
-              {report.reportType === "windMitigation" && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      className="border"
-                      onClick={() => downloadWindMitigationReport(report)}
-                    >
-                      Download
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>Download PDF</TooltipContent>
-                </Tooltip>
-              )}
-              
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button size="sm" variant="ghost" className="border" asChild>
-                    <Link to={`/reports/${report.id}/preview`}>
-                      <Eye className="h-4 w-4" />
-                      <span className="sr-only">Preview</span>
-                    </Link>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Preview report</TooltipContent>
-              </Tooltip>
-              
-              {onArchive && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      className="border"
-                      onClick={() => onArchive(report.id, !report.archived)}
-                    >
-                      {report.archived ? (
-                        <ArchiveRestore className="h-4 w-4" />
-                      ) : (
-                        <Archive className="h-4 w-4" />
-                      )}
-                      <span className="sr-only">{report.archived ? "Restore" : "Archive"}</span>
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>{report.archived ? "Restore report" : "Archive report"}</TooltipContent>
-                </Tooltip>
-              )}
-              
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    size="sm"
-                    variant="destructive"
-                    className="border"
-                    onClick={() => onDelete(report.id)}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                    <span className="sr-only">Delete</span>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Delete report</TooltipContent>
-              </Tooltip>
-            </div>
-          </div>
-        ))}
-      </div>
-    );
+  const getReportIcon = (type: string) => {
+    if (type.includes("wind")) return <Wind className="h-4 w-4 text-muted-foreground" />;
+    if (type.includes("wildfire")) return <Flame className="h-4 w-4 text-muted-foreground" />;
+    if (type.includes("roof")) return <ShieldCheck className="h-4 w-4 text-muted-foreground" />;
+    if (type.includes("home")) return <Home className="h-4 w-4 text-muted-foreground" />;
+    return <FileText className="h-4 w-4 text-muted-foreground" />;
   };
+
+  return (
+    <div className="border rounded-lg">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Title</TableHead>
+            <TableHead>Type</TableHead>
+            <TableHead>Client</TableHead>
+            <TableHead>Inspection</TableHead>
+            <TableHead>Address</TableHead>
+            <TableHead className="text-right">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {reports.map((report) => (
+            <TableRow key={report.id} className="group">
+              <TableCell>
+                <div className="flex items-center gap-2">
+                  {getReportIcon(report.reportType as string)}
+                  <Link
+                    to={`/reports/${report.id}`}
+                    className="font-medium hover:text-primary transition-colors truncate"
+                  >
+                    {report.title || "Untitled Report"}
+                  </Link>
+                  {report.archived && (
+                    <Badge variant="outline" className="ml-2">Archived</Badge>
+                  )}
+                </div>
+              </TableCell>
+              <TableCell>
+                <Badge variant="secondary">
+                  {REPORT_TYPE_LABELS[report.reportType] || report.reportType}
+                </Badge>
+              </TableCell>
+              <TableCell>{report.clientName || "-"}</TableCell>
+              <TableCell>
+                {report.inspectionDate
+                  ? new Date(report.inspectionDate).toLocaleDateString()
+                  : "-"}
+              </TableCell>
+              <TableCell className="max-w-[200px] truncate">
+                {report.address || "-"}
+              </TableCell>
+              <TableCell className="text-right">
+                <div className="flex items-center justify-end gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-8 w-8 p-0"
+                        asChild
+                      >
+                        <Link to={`/reports/${report.id}`}>
+                          <Pencil className="h-4 w-4" />
+                          <span className="sr-only">Edit</span>
+                        </Link>
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Edit report</TooltipContent>
+                  </Tooltip>
+
+                  {report.reportType === "windMitigation" && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-8 px-2"
+                          onClick={() => downloadWindMitigationReport(report)}
+                        >
+                          Download
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Download PDF</TooltipContent>
+                    </Tooltip>
+                  )}
+
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        className="h-8 w-8 p-0"
+                        asChild
+                      >
+                        <Link to={`/reports/${report.id}/preview`}>
+                          <Eye className="h-4 w-4" />
+                          <span className="sr-only">Preview</span>
+                        </Link>
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Preview report</TooltipContent>
+                  </Tooltip>
+
+                  {onArchive && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="h-8 w-8 p-0"
+                          onClick={() => onArchive(report.id, !report.archived)}
+                        >
+                          {report.archived ? (
+                            <ArchiveRestore className="h-4 w-4" />
+                          ) : (
+                            <Archive className="h-4 w-4" />
+                          )}
+                          <span className="sr-only">
+                            {report.archived ? "Restore" : "Archive"}
+                          </span>
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {report.archived ? "Restore report" : "Archive report"}
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        className="h-8 w-8 p-0"
+                        onClick={() => onDelete(report.id)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                        <span className="sr-only">Delete</span>
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Delete report</TooltipContent>
+                  </Tooltip>
+                </div>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- switch report list view to table layout
- keep edit, preview, archive, download and delete actions within each row

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 293 errors, 28 warnings)


------
https://chatgpt.com/codex/tasks/task_e_68b9cbabf28483338f849f799fa206c5