### PR TITLE
feat(calendar): darken selected day highlight

### DIFF
--- a/src/components/calendar/DraggableCalendarGrid.tsx
+++ b/src/components/calendar/DraggableCalendarGrid.tsx
@@ -171,7 +171,7 @@ export const DraggableCalendarGrid: React.FC<DraggableCalendarGridProps> = ({
                 key={day.toString()}
                 className={cn(
                   "p-2 text-center font-medium bg-muted text-muted-foreground border-r last:border-r-0 cursor-pointer hover:bg-muted/80",
-                  isSameDay(day, selectedDate) && "bg-primary/30 text-primary font-semibold",
+                  isSameDay(day, selectedDate) && "bg-primary/40 text-primary font-semibold",
                   isToday(day) && "bg-accent"
                 )}
                 onClick={() => onDateSelect(day)}
@@ -202,6 +202,7 @@ export const DraggableCalendarGrid: React.FC<DraggableCalendarGridProps> = ({
                           {...provided.droppableProps}
                           className={cn(
                             "p-1 min-h-[40px] border-r last:border-r-0",
+                            isSameDay(day, selectedDate) && "bg-primary/40",
                             snapshot.isDraggingOver && "bg-primary/10"
                           )}
                         >
@@ -268,7 +269,7 @@ export const DraggableCalendarGrid: React.FC<DraggableCalendarGridProps> = ({
                 className={cn(
                   "min-h-[100px] border border-border p-2 cursor-pointer transition-colors hover:bg-muted/50",
                   !isSameMonth(day, monthStart) && "bg-muted/20 text-muted-foreground",
-                  isSameDay(day, selectedDate) && "bg-primary/30 border-primary font-semibold",
+                  isSameDay(day, selectedDate) && "bg-primary/40 border-primary font-semibold",
                   isToday(day) && "bg-accent/50",
                   snapshot.isDraggingOver && "bg-primary/20"
                 )}


### PR DESCRIPTION
## Summary
- darken selected day styling in week header
- apply matching highlight to selected week's time slots
- use darker emphasis for selected days in month view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 322 problems)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b9d30f5a94833392ba77d9f71e1fec