### PR TITLE
feat: add reusable signature pad

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "react-quill": "^2.0.0",
         "react-resizable-panels": "^2.1.9",
         "react-router-dom": "^6.30.1",
+        "react-signature-canvas": "^1.1.0-alpha.2",
         "react-to-print": "^3.1.1",
         "recharts": "^2.15.4",
         "resend": "^6.0.2",
@@ -5849,6 +5850,12 @@
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/signature_pad": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@types/signature_pad/-/signature_pad-2.3.6.tgz",
+      "integrity": "sha512-v3j92gCQJoxomHhd+yaG4Vsf8tRS/XbzWKqDv85UsqjMGy4zhokuwKe4b6vhbgncKkh+thF+gpz6+fypTtnFqQ==",
       "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
@@ -13923,6 +13930,36 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-signature-canvas": {
+      "version": "1.1.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/react-signature-canvas/-/react-signature-canvas-1.1.0-alpha.2.tgz",
+      "integrity": "sha512-tKUNk3Gmh04Ug4K8p5g8Is08BFUKvbXxi0PyetQ/f8OgCBzcx4vqNf9+OArY/TdNdfHtswXQNRwZD6tyELjkjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.17.9",
+        "@types/signature_pad": "^2.3.0",
+        "signature_pad": "^2.3.2",
+        "trim-canvas": "^0.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/agilgur5"
+      },
+      "peerDependencies": {
+        "@types/prop-types": "^15.7.3",
+        "@types/react": "0.14 - 19",
+        "prop-types": "^15.5.8",
+        "react": "0.14 - 19",
+        "react-dom": "0.14 - 19"
+      },
+      "peerDependenciesMeta": {
+        "@types/prop-types": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-smooth": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
@@ -14758,6 +14795,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/signature_pad": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/signature_pad/-/signature_pad-2.3.2.tgz",
+      "integrity": "sha512-peYXLxOsIY6MES2TrRLDiNg2T++8gGbpP2yaC+6Ohtxr+a2dzoaqWosWDY9sWqTAAk6E/TyQO+LJw9zQwyu5kA==",
+      "license": "MIT"
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -15665,6 +15708,12 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/trim-canvas": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/trim-canvas/-/trim-canvas-0.1.2.tgz",
+      "integrity": "sha512-nd4Ga3iLFV94mdhW9JFMLpQbHUyCQuhFOD71PEAt1NjtMD5wbZctzhX8c3agHNybMR5zXD1XTGoIEWk995E6pQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "react-quill": "^2.0.0",
     "react-resizable-panels": "^2.1.9",
     "react-router-dom": "^6.30.1",
+    "react-signature-canvas": "^1.1.0-alpha.2",
     "react-to-print": "^3.1.1",
     "recharts": "^2.15.4",
     "resend": "^6.0.2",

--- a/src/components/signature/SignaturePad.tsx
+++ b/src/components/signature/SignaturePad.tsx
@@ -1,0 +1,308 @@
+import React, { useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import SignatureCanvas from "react-signature-canvas";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { useDropzone } from "react-dropzone";
+import { toast } from "@/components/ui/use-toast";
+import { RotateCcw, Save, Upload, Trash2 } from "lucide-react";
+
+const SIGNATURE_FONTS = [
+  { id: "dancing", name: "Dancing Script", className: "font-dancing" },
+  { id: "great", name: "Great Vibes", className: "font-great" },
+  { id: "allura", name: "Allura", className: "font-allura" },
+  { id: "sacramento", name: "Sacramento", className: "font-sacramento" },
+];
+
+export interface SignaturePadHandle {
+  clear: () => void;
+  toDataURL: () => string | undefined;
+}
+
+interface SignaturePadProps {
+  currentSignature?: string;
+  currentSignatureType?: string;
+  fullName?: string;
+  onChange: (dataUrl: string, type: string) => void;
+  onDelete: () => void;
+  isLoading?: boolean;
+}
+
+const SignaturePad = React.forwardRef<SignaturePadHandle, SignaturePadProps>(
+  (
+    {
+      currentSignature,
+      currentSignatureType,
+      fullName = "",
+      onChange,
+      onDelete,
+      isLoading = false,
+    },
+    ref
+  ) => {
+    const [signature, setSignature] = useState<string | undefined>(currentSignature);
+    const [signatureType, setSignatureType] = useState<string | undefined>(currentSignatureType);
+    const [tab, setTab] = useState("draw");
+
+    // Draw
+    const canvasRef = useRef<SignatureCanvas | null>(null);
+
+    const applyDraw = () => {
+      if (!canvasRef.current || canvasRef.current.isEmpty()) {
+        toast({
+          title: "No signature",
+          description: "Please draw your signature before saving.",
+          variant: "destructive",
+        });
+        return;
+      }
+      const dataUrl = canvasRef.current.toDataURL("image/png");
+      setSignature(dataUrl);
+      setSignatureType("drawn");
+      onChange(dataUrl, "drawn");
+    };
+
+    const clearDraw = () => {
+      canvasRef.current?.clear();
+    };
+
+    useImperativeHandle(ref, () => ({
+      clear: () => clearDraw(),
+      toDataURL: () => canvasRef.current?.toDataURL("image/png"),
+    }));
+
+    // Type
+    const [typedName, setTypedName] = useState(fullName);
+    const [selectedFont, setSelectedFont] = useState(SIGNATURE_FONTS[0].id);
+    const typedCanvasRef = useRef<HTMLCanvasElement | null>(null);
+
+    const generateTypedSignature = useCallback(() => {
+      const canvas = typedCanvasRef.current;
+      if (!canvas) return;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+
+      canvas.width = 400;
+      canvas.height = 120;
+      ctx.fillStyle = "#ffffff";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      const font = SIGNATURE_FONTS.find((f) => f.id === selectedFont)?.name || SIGNATURE_FONTS[0].name;
+      ctx.font = `48px "${font}", cursive`;
+      ctx.fillStyle = "#000000";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillText(typedName.trim(), canvas.width / 2, canvas.height / 2);
+    }, [typedName, selectedFont]);
+
+    useEffect(() => {
+      generateTypedSignature();
+    }, [generateTypedSignature]);
+
+    const applyTyped = () => {
+      if (!typedName.trim()) {
+        toast({
+          title: "Name required",
+          description: "Please enter your name to create a signature.",
+          variant: "destructive",
+        });
+        return;
+      }
+      if (!typedCanvasRef.current) return;
+      const dataUrl = typedCanvasRef.current.toDataURL("image/png");
+      setSignature(dataUrl);
+      setSignatureType("typed");
+      onChange(dataUrl, "typed");
+    };
+
+    // Upload
+    const handleFile = (file: File) => {
+      if (!file.type.startsWith("image/")) {
+        toast({
+          title: "Invalid file type",
+          description: "Please upload a valid image file (PNG, JPG, SVG).",
+          variant: "destructive",
+        });
+        return;
+      }
+      if (file.size > 2 * 1024 * 1024) {
+        toast({
+          title: "File too large",
+          description: "Please upload an image smaller than 2MB.",
+          variant: "destructive",
+        });
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        const dataUrl = e.target?.result as string;
+        setSignature(dataUrl);
+        setSignatureType("uploaded");
+        onChange(dataUrl, "uploaded");
+      };
+      reader.readAsDataURL(file);
+    };
+
+    const onDrop = useCallback((accepted: File[]) => {
+      const file = accepted[0];
+      if (file) handleFile(file);
+    }, []);
+
+    const { getRootProps, getInputProps, isDragActive } = useDropzone({
+      onDrop,
+      multiple: false,
+      accept: { "image/*": [] },
+      maxSize: 2 * 1024 * 1024,
+    });
+
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) handleFile(file);
+    };
+
+    const handleRemove = () => {
+      setSignature(undefined);
+      setSignatureType(undefined);
+      onDelete();
+    };
+
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-medium">Digital Signature</h3>
+          {signature && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleRemove}
+              disabled={isLoading}
+            >
+              <Trash2 className="h-4 w-4 mr-2" />
+              Remove
+            </Button>
+          )}
+        </div>
+
+        <div className="flex items-center justify-center p-4 border border-border rounded-lg bg-muted/30">
+          {signature ? (
+            <img
+              src={signature}
+              alt="Current signature"
+              className="max-h-20 max-w-full object-contain"
+            />
+          ) : (
+            <p className="text-sm text-muted-foreground">No signature set</p>
+          )}
+        </div>
+        {signature && (
+          <p className="text-sm text-muted-foreground text-center">
+            Current signature ({signatureType || "unknown"})
+          </p>
+        )}
+
+        <Tabs value={tab} onValueChange={setTab} className="w-full">
+          <TabsList className="grid w-full grid-cols-3">
+            <TabsTrigger value="draw">Draw</TabsTrigger>
+            <TabsTrigger value="type">Type</TabsTrigger>
+            <TabsTrigger value="upload">Upload</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="draw" className="space-y-2">
+            <div className="flex items-center justify-center border border-border rounded-lg bg-background">
+              <SignatureCanvas
+                ref={canvasRef}
+                canvasProps={{
+                  width: 400,
+                  height: 200,
+                  className: "border-none bg-white",
+                }}
+              />
+            </div>
+            <div className="flex gap-2 justify-end">
+              <Button type="button" variant="outline" onClick={clearDraw}>
+                <RotateCcw className="h-4 w-4 mr-2" />
+                Clear
+              </Button>
+              <Button type="button" onClick={applyDraw}>
+                <Save className="h-4 w-4 mr-2" />
+                Use
+              </Button>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="type" className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="typed-name">Full Name</Label>
+              <Input
+                id="typed-name"
+                value={typedName}
+                onChange={(e) => setTypedName(e.target.value)}
+                placeholder="Enter your full name"
+              />
+            </div>
+
+            <div className="space-y-3">
+              <Label>Font Style</Label>
+              <RadioGroup value={selectedFont} onValueChange={setSelectedFont}>
+                {SIGNATURE_FONTS.map((font) => (
+                  <div key={font.id} className="flex items-center space-x-2">
+                    <RadioGroupItem value={font.id} id={font.id} />
+                    <Label
+                      htmlFor={font.id}
+                      className="cursor-pointer flex-1"
+                      style={{ fontFamily: `"${font.name}", cursive`, fontSize: "18px" }}
+                    >
+                      {font.name}
+                    </Label>
+                  </div>
+                ))}
+              </RadioGroup>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Preview</Label>
+              <div className="flex items-center justify-center p-4 border border-border rounded-lg bg-background">
+                <canvas
+                  ref={typedCanvasRef}
+                  className="max-w-full h-auto"
+                  style={{ maxHeight: "120px" }}
+                />
+              </div>
+            </div>
+
+            <div className="flex justify-end">
+              <Button type="button" onClick={applyTyped} disabled={!typedName.trim()}>
+                <Save className="h-4 w-4 mr-2" />
+                Use
+              </Button>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="upload" className="space-y-2">
+            <div
+              {...getRootProps({
+                className:
+                  "flex flex-col items-center justify-center p-6 border-2 border-dashed rounded-lg cursor-pointer text-center bg-background",
+              })}
+            >
+              <input {...getInputProps({ onChange: handleInputChange })} />
+              <Upload className="h-8 w-8 mb-2" />
+              {isDragActive ? (
+                <p>Drop the image here...</p>
+              ) : (
+                <p>Drag and drop an image here, or click to browse</p>
+              )}
+              <p className="text-xs text-muted-foreground mt-2">PNG, JPG up to 2MB</p>
+            </div>
+          </TabsContent>
+        </Tabs>
+      </div>
+    );
+  }
+);
+
+SignaturePad.displayName = "SignaturePad";
+
+export default SignaturePad;

--- a/src/pages/Settings/Account.tsx
+++ b/src/pages/Settings/Account.tsx
@@ -18,7 +18,7 @@ import {
   deleteSignature,
   type Organization,
 } from "@/integrations/supabase/organizationsApi";
-import SignatureManager from "@/components/signature/SignatureManager";
+import SignaturePad from "@/components/signature/SignaturePad";
 
 const Account: React.FC = () => {
   const { user } = useAuth();
@@ -235,12 +235,12 @@ const Account: React.FC = () => {
         </CardContent>
       </Card>
 
-      <SignatureManager
+      <SignaturePad
         currentSignature={profile.signature_url || undefined}
         currentSignatureType={profile.signature_type || undefined}
         fullName={profile.full_name || undefined}
-        onSignatureUpdate={handleSignatureUpdate}
-        onSignatureDelete={handleSignatureDelete}
+        onChange={handleSignatureUpdate}
+        onDelete={handleSignatureDelete}
         isLoading={updateSignatureMutation.isPending || deleteSignatureMutation.isPending}
       />
     </>


### PR DESCRIPTION
## Summary
- create SignaturePad component with draw, type, and upload tabs
- switch account settings to use new SignaturePad API

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Unexpected any in existing code)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9ddfb5eb083338dc0a4dd45040a1b