### PR TITLE
Use local fontsource fonts for signatures

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,11 +12,6 @@
     <meta name="mobile-web-app-capable" content="yes">
     <link rel="apple-touch-icon" href="/pwa-192x192.png">
 
-    <!-- Google Fonts for signature functionality -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@400;700&family=Great+Vibes&family=Allura&family=Sacramento&display=swap" rel="stylesheet">
-
     <meta property="og:title" content="Home Report Pro | Complete Home Inspection Business Management" />
     <meta property="og:description" content="All-in-one platform for home inspectors: CRM, scheduling, reporting, task management, and client portal. InterNACHI compliant with offline sync." />
     <meta property="og:type" content="website" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,10 @@
       "version": "0.0.0",
       "dependencies": {
         "@demark-pro/react-booking-calendar": "^4.0.4",
+        "@fontsource/allura": "^5.2.6",
+        "@fontsource/dancing-script": "^5.2.6",
+        "@fontsource/great-vibes": "^5.2.6",
+        "@fontsource/sacramento": "^5.2.6",
         "@googlemaps/js-api-loader": "^1.16.10",
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",
@@ -2328,6 +2332,42 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource/allura": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource/allura/-/allura-5.2.6.tgz",
+      "integrity": "sha512-jMXFki2/8FYHA70UZgSVHHxmXP+l/5kG0WesE1mQ0FVRgIqg8QM9g17VnCBwOX3j6oXNKJr0ig4LBzbipfwv/A==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/dancing-script": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource/dancing-script/-/dancing-script-5.2.6.tgz",
+      "integrity": "sha512-W6hAg34v1AyX10ijrBKMf0jg6V641RpylfBi1oXG1pzKgi+z2cpl0N9UDKDHoedpWnajjMuT6MgoaJvFxVAW5w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/great-vibes": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource/great-vibes/-/great-vibes-5.2.6.tgz",
+      "integrity": "sha512-DdyS+X+4hLt+YYj3r+2baxSeV4Fah/hn1+588GqSp6Y1QdVFjpYLrChhBuMneP868Z/VHfwYQ4J2ney3zog97w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/sacramento": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource/sacramento/-/sacramento-5.2.6.tgz",
+      "integrity": "sha512-1AdcAwF5WV2/fQE9IGfCjsQy8PI/I7DhaeRv+Ug1XYfSmUjPo1zYaSQAO1O4NtBdp0x+aM+qEzRb4wI7EnWpAA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@googlemaps/js-api-loader": {
       "version": "1.16.10",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
   },
   "dependencies": {
     "@demark-pro/react-booking-calendar": "^4.0.4",
+    "@fontsource/allura": "^5.2.6",
+    "@fontsource/dancing-script": "^5.2.6",
+    "@fontsource/great-vibes": "^5.2.6",
+    "@fontsource/sacramento": "^5.2.6",
     "@googlemaps/js-api-loader": "^1.16.10",
     "@hookform/resolvers": "^3.10.0",
     "@radix-ui/react-accordion": "^1.2.11",

--- a/src/components/signature/SignaturePad.tsx
+++ b/src/components/signature/SignaturePad.tsx
@@ -89,12 +89,16 @@ const SignaturePad = React.forwardRef<SignaturePadHandle, SignaturePadProps>(
       ctx.fillStyle = "#ffffff";
       ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-      const font = SIGNATURE_FONTS.find((f) => f.id === selectedFont)?.name || SIGNATURE_FONTS[0].name;
-      ctx.font = `48px "${font}", cursive`;
-      ctx.fillStyle = "#000000";
-      ctx.textAlign = "center";
-      ctx.textBaseline = "middle";
-      ctx.fillText(typedName.trim(), canvas.width / 2, canvas.height / 2);
+      const font =
+        SIGNATURE_FONTS.find((f) => f.id === selectedFont)?.name || SIGNATURE_FONTS[0].name;
+
+      void document.fonts.load(`48px "${font}"`).then(() => {
+        ctx.font = `48px "${font}", cursive`;
+        ctx.fillStyle = "#000000";
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.fillText(typedName.trim(), canvas.width / 2, canvas.height / 2);
+      });
     }, [typedName, selectedFont]);
 
     useEffect(() => {

--- a/src/components/signature/SignatureTypeDialog.tsx
+++ b/src/components/signature/SignatureTypeDialog.tsx
@@ -54,14 +54,16 @@ const SignatureTypeDialog: React.FC<SignatureTypeDialogProps> = ({
     // Set font properties
     const selectedFontData = SIGNATURE_FONTS.find(f => f.id === selectedFont);
     const fontFamily = selectedFontData?.name || 'Dancing Script';
-    
-    ctx.font = `48px "${fontFamily}", cursive`;
-    ctx.fillStyle = '#000000';
-    ctx.textAlign = 'center';
-    ctx.textBaseline = 'middle';
 
-    // Draw signature text
-    ctx.fillText(signatureName.trim(), canvas.width / 2, canvas.height / 2);
+    void document.fonts.load(`48px "${fontFamily}"`).then(() => {
+      ctx.font = `48px "${fontFamily}", cursive`;
+      ctx.fillStyle = '#000000';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+
+      // Draw signature text
+      ctx.fillText(signatureName.trim(), canvas.width / 2, canvas.height / 2);
+    });
   }, [signatureName, selectedFont]);
 
   React.useEffect(() => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,13 @@ import App from './App.tsx'
 import './index.css'
 import './print.css'
 
+// Local font imports for signature functionality
+import '@fontsource/dancing-script/400.css'
+import '@fontsource/dancing-script/700.css'
+import '@fontsource/great-vibes'
+import '@fontsource/allura'
+import '@fontsource/sacramento'
+
 // Register service worker for PWA
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- replace Google-hosted fonts with @fontsource packages
- import fonts in app entry and ensure signature canvas waits for them to load
- remove Google Fonts links from `index.html`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, no-case-declarations, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b9df3e6d348333ae0284ca3df3263d