### PR TITLE
feat: add terms and conditions management

### DIFF
--- a/src/integrations/supabase/termsApi.ts
+++ b/src/integrations/supabase/termsApi.ts
@@ -1,0 +1,92 @@
+import { supabase } from './client';
+import type { Report } from '@/lib/reportSchemas';
+
+export interface Term {
+  id?: string;
+  user_id: string;
+  report_type: Report['reportType'] | 'all';
+  text: string;
+  file_url?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+const TERMS_BUCKET = 'terms-and-conditions';
+
+async function uploadDocx(userId: string, file: File): Promise<string> {
+  const cleanName = file.name.replace(/\s+/g, '_');
+  const path = `${userId}/${Date.now()}_${cleanName}`;
+  const { error } = await supabase.storage
+    .from(TERMS_BUCKET)
+    .upload(path, file, {
+      cacheControl: '3600',
+      upsert: true,
+      contentType:
+        file.type ||
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    });
+  if (error) throw error;
+  return path;
+}
+
+async function list(userId: string): Promise<Term[]> {
+  const { data, error } = await supabase
+    .from('terms_and_conditions' as any)
+    .select('*')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: true });
+
+  if (error) throw error;
+  return (data as unknown as Term[]) || [];
+}
+
+async function save(term: Term & { file?: File | null }): Promise<Term> {
+  let file_url = term.file_url;
+  if (term.file) {
+    file_url = await uploadDocx(term.user_id, term.file);
+  }
+
+  const payload = {
+    user_id: term.user_id,
+    report_type: term.report_type,
+    text: term.text,
+    file_url,
+  };
+
+  if (term.id) {
+    const { data, error } = await supabase
+      .from('terms_and_conditions' as any)
+      .update(payload)
+      .eq('id', term.id)
+      .select()
+      .single();
+
+    if (error) throw error;
+    return data as unknown as Term;
+  } else {
+    const { data, error } = await supabase
+      .from('terms_and_conditions' as any)
+      .insert(payload)
+      .select()
+      .single();
+
+    if (error) throw error;
+    return data as unknown as Term;
+  }
+}
+
+async function remove(id: string): Promise<void> {
+  const { error } = await supabase
+    .from('terms_and_conditions' as any)
+    .delete()
+    .eq('id', id);
+  if (error) throw error;
+}
+
+export const termsApi = {
+  list,
+  save,
+  remove,
+};
+
+export default termsApi;

--- a/src/pages/Settings/TermsAndConditions.tsx
+++ b/src/pages/Settings/TermsAndConditions.tsx
@@ -1,15 +1,169 @@
-import React from "react";
+import React from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { termsApi, Term } from '@/integrations/supabase/termsApi';
+import { REPORT_TYPE_LABELS } from '@/constants/reportTypes';
+import { useToast } from '@/hooks/use-toast';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { Plus, Save, Trash2 } from 'lucide-react';
+
+interface TermRow extends Term {
+  file?: File | null;
+}
 
 const TermsAndConditions: React.FC = () => {
+  const { user } = useAuth();
+  const { toast } = useToast();
+
+  const { data: terms = [], refetch } = useQuery({
+    queryKey: ['terms-and-conditions', user?.id],
+    queryFn: () => termsApi.list(user!.id),
+    enabled: !!user,
+  });
+
+  const [rows, setRows] = React.useState<TermRow[]>([]);
+
+  React.useEffect(() => {
+    setRows(terms);
+  }, [terms]);
+
+  const updateRow = (index: number, updates: Partial<TermRow>) => {
+    setRows((prev) => prev.map((row, i) => (i === index ? { ...row, ...updates } : row)));
+  };
+
+  const addRow = () => {
+    setRows((prev) => [...prev, { user_id: user!.id, report_type: 'all', text: '', file: null }]);
+  };
+
+  const saveMutation = useMutation({
+    mutationFn: (row: TermRow) => termsApi.save({ ...row, user_id: user!.id }),
+    onSuccess: () => {
+      toast({ title: 'Saved', description: 'Terms saved successfully.' });
+      refetch();
+    },
+    onError: () => {
+      toast({ title: 'Error', description: 'Failed to save terms.', variant: 'destructive' });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => termsApi.remove(id),
+    onSuccess: () => {
+      toast({ title: 'Deleted', description: 'Terms deleted successfully.' });
+      refetch();
+    },
+    onError: () => {
+      toast({ title: 'Error', description: 'Failed to delete terms.', variant: 'destructive' });
+    },
+  });
+
+  const handleSave = (index: number) => {
+    const row = rows[index];
+    saveMutation.mutate(row);
+  };
+
+  const handleDelete = (index: number) => {
+    const row = rows[index];
+    if (row.id) {
+      deleteMutation.mutate(row.id);
+    }
+    setRows((prev) => prev.filter((_, i) => i !== index));
+  };
+
   return (
     <div className="space-y-4">
       <h2 className="text-lg font-medium">Terms and Conditions</h2>
       <p className="text-sm text-muted-foreground">
         Manage your organization's terms and conditions.
       </p>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[200px]">Template</TableHead>
+            <TableHead className="w-[200px]">Upload .docx</TableHead>
+            <TableHead>Manual Entry</TableHead>
+            <TableHead className="w-[150px]">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row, index) => (
+            <TableRow key={row.id || index}>
+              <TableCell>
+                <Select
+                  value={row.report_type}
+                  onValueChange={(val) => updateRow(index, { report_type: val as TermRow['report_type'] })}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select template" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All templates</SelectItem>
+                    {Object.entries(REPORT_TYPE_LABELS).map(([value, label]) => (
+                      <SelectItem key={value} value={value}>
+                        {label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </TableCell>
+              <TableCell>
+                <Input
+                  type="file"
+                  accept=".docx"
+                  onChange={(e) =>
+                    updateRow(index, { file: e.target.files ? e.target.files[0] : null })
+                  }
+                />
+              </TableCell>
+              <TableCell>
+                <Textarea
+                  value={row.text || ''}
+                  onChange={(e) => updateRow(index, { text: e.target.value })}
+                  className="min-h-24"
+                />
+              </TableCell>
+              <TableCell className="flex gap-2">
+                <Button
+                  size="sm"
+                  onClick={() => handleSave(index)}
+                  disabled={saveMutation.isPending}
+                  className="flex items-center gap-2"
+                >
+                  <Save className="h-4 w-4" />
+                  Save
+                </Button>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={() => handleDelete(index)}
+                  disabled={deleteMutation.isPending}
+                  className="flex items-center gap-2"
+                >
+                  <Trash2 className="h-4 w-4" />
+                  Delete
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      <Button
+        onClick={addRow}
+        variant="outline"
+        size="sm"
+        className="flex items-center gap-2"
+      >
+        <Plus className="h-4 w-4" />
+        Add Row
+      </Button>
     </div>
   );
 };
 
 export default TermsAndConditions;
-


### PR DESCRIPTION
## Summary
- allow editing terms and conditions by report template
- support uploading docx files or manual text for each entry
- add Supabase API helpers for terms

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 321 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e92a90dc8333a9e3c94432562bed