### PR TITLE
feat: add terms conditions table and storage

### DIFF
--- a/supabase/migrations/20250919000000_create_terms_conditions_table.sql
+++ b/supabase/migrations/20250919000000_create_terms_conditions_table.sql
@@ -1,0 +1,42 @@
+-- Create terms_conditions table
+create table if not exists public.terms_conditions (
+  id uuid primary key default gen_random_uuid(),
+  organization_id uuid not null references public.organizations(id) on delete cascade,
+  report_type text,
+  content_html text not null,
+  file_url text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+-- Index for organization lookups
+create index if not exists terms_conditions_organization_id_idx on public.terms_conditions (organization_id);
+
+-- Enable Row Level Security
+alter table public.terms_conditions enable row level security;
+
+-- Policy: organization members can view terms & conditions
+create policy "Organization members can view terms conditions"
+  on public.terms_conditions
+  for select
+  to authenticated
+  using (public.is_organization_member(organization_id));
+
+-- Policy: organization admins can manage terms & conditions
+create policy "Organization admins can manage terms conditions"
+  on public.terms_conditions
+  for all
+  to authenticated
+  using (
+    public.has_organization_role(organization_id, 'owner'::organization_role) or
+    public.has_organization_role(organization_id, 'admin'::organization_role)
+  )
+  with check (
+    public.has_organization_role(organization_id, 'owner'::organization_role) or
+    public.has_organization_role(organization_id, 'admin'::organization_role)
+  );
+
+-- Trigger to keep updated_at current
+create trigger set_updated_at_terms_conditions
+  before update on public.terms_conditions
+  for each row execute function public.set_updated_at();

--- a/supabase/migrations/20250919000001_create_terms_conditions_bucket.sql
+++ b/supabase/migrations/20250919000001_create_terms_conditions_bucket.sql
@@ -1,0 +1,35 @@
+-- Create private bucket for terms-conditions documents
+do $$
+begin
+  if not exists (select 1 from storage.buckets where id = 'terms-conditions') then
+    -- Use positional arguments to avoid named-argument syntax issues
+    perform storage.create_bucket('terms-conditions', 'terms-conditions', false);
+  end if;
+end
+$$;
+
+-- Policy: organization members can view files
+create policy "Organization members can view terms-conditions files"
+  on storage.objects for select to authenticated
+  using (
+    bucket_id = 'terms-conditions'
+    and public.is_organization_member((storage.foldername(name))[1]::uuid)
+  );
+
+-- Policy: organization admins can manage files
+create policy "Organization admins can manage terms-conditions files"
+  on storage.objects for all to authenticated
+  using (
+    bucket_id = 'terms-conditions'
+    and (
+      public.has_organization_role((storage.foldername(name))[1]::uuid, 'owner'::organization_role)
+      or public.has_organization_role((storage.foldername(name))[1]::uuid, 'admin'::organization_role)
+    )
+  )
+  with check (
+    bucket_id = 'terms-conditions'
+    and (
+      public.has_organization_role((storage.foldername(name))[1]::uuid, 'owner'::organization_role)
+      or public.has_organization_role((storage.foldername(name))[1]::uuid, 'admin'::organization_role)
+    )
+  );


### PR DESCRIPTION
## Summary
- add terms_conditions table with RLS policies
- create private `terms-conditions` storage bucket and access rules
- fix create_bucket migration syntax for `terms-conditions` bucket

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 321 problems (292 errors, 29 warnings))*


------
https://chatgpt.com/codex/tasks/task_e_68b9ea532c74833389c254650f6e87ef