### PR TITLE
Store report terms HTML content

### DIFF
--- a/src/integrations/supabase/reportsApi.ts
+++ b/src/integrations/supabase/reportsApi.ts
@@ -23,6 +23,7 @@ function toDbPayload(report: Report) {
     inspection_date: report.inspectionDate.slice(0, 10), // 'YYYY-MM-DD'
     status: report.status,
     final_comments: report.finalComments || null,
+    terms_html: (report as any).termsHtml || null,
     cover_image: report.coverImage || null,
     cover_template: report.coverTemplate || 'templateOne',
     preview_template: report.previewTemplate || 'classic',
@@ -67,6 +68,7 @@ function fromDbRow(row: any): Report {
     inspectionDate: new Date(`${row.inspection_date}T00:00:00Z`).toISOString(),
     status: row.status,
     finalComments: row.final_comments || "",
+    termsHtml: row.terms_html ?? undefined,
     coverImage: row.cover_image || "",
     coverTemplate: transformCoverTemplate(row.cover_template || "templateOne"),
     previewTemplate: row.preview_template || "classic",

--- a/src/lib/reportSchemas.ts
+++ b/src/lib/reportSchemas.ts
@@ -54,6 +54,7 @@ export const BaseReportSchema = z.object({
     weatherConditions: z.string().optional(),
     status: z.enum(["Draft", "Final"]).default("Draft"),
     finalComments: z.string().optional().default(""),
+    termsHtml: z.string().optional(),
     coverImage: z.string().optional().default(""),
     coverTemplate: z
         .enum(["templateOne", "templateTwo", "templateThree", "templateFour", "templateFive", "templateSix",

--- a/supabase/migrations/20250904201917_c7775f95-16ae-4054-b17f-9ca15f64eb95.sql
+++ b/supabase/migrations/20250904201917_c7775f95-16ae-4054-b17f-9ca15f64eb95.sql
@@ -1,0 +1,2 @@
+ALTER TABLE reports ADD COLUMN terms_html text;
+


### PR DESCRIPTION
## Summary
- extend report schema with optional `termsHtml` field
- persist `terms_html` column in Supabase report mappings
- add migration to store `terms_html` in reports table

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, require imports, etc.)*
- `npm run build` *(fails: Rollup failed to resolve import "mammoth/mammoth.browser")*

------
https://chatgpt.com/codex/tasks/task_e_68b9f3f60bf88333881807766c2c2975