### PR TITLE
Use null for global report terms

### DIFF
--- a/src/integrations/supabase/termsApi.ts
+++ b/src/integrations/supabase/termsApi.ts
@@ -5,7 +5,7 @@ import DOMPurify from 'dompurify';
 export interface Term {
   id?: string;
   organization_id: string;
-  report_type: Report['reportType'] | 'all';
+  report_type: Report['reportType'] | null;
   content_html: string;
   file_url?: string | null;
   created_at?: string;
@@ -41,7 +41,12 @@ async function list(organizationId: string): Promise<Term[]> {
     .order('created_at', { ascending: true });
 
   if (error) throw error;
-  return (data as unknown as Term[]) || [];
+  return (
+    ((data as unknown as Term[]) || []).map((t) => ({
+      ...t,
+      report_type: (t.report_type as unknown) === 'all' ? null : t.report_type,
+    }))
+  );
 }
 
 async function save(term: Term & { file?: File | null }): Promise<Term> {
@@ -52,7 +57,8 @@ async function save(term: Term & { file?: File | null }): Promise<Term> {
 
   const payload = {
     organization_id: term.organization_id,
-    report_type: term.report_type,
+    report_type:
+      (term.report_type as unknown) === 'all' ? null : term.report_type,
     content_html: DOMPurify.sanitize(term.content_html),
     file_url,
   };

--- a/src/pages/Settings/TermsAndConditions.tsx
+++ b/src/pages/Settings/TermsAndConditions.tsx
@@ -46,7 +46,7 @@ const TermsAndConditions: React.FC = () => {
   const addRow = () => {
     setRows((prev) => [
       ...prev,
-      { organization_id: organization!.id, report_type: 'all', content_html: '', file: null },
+      { organization_id: organization!.id, report_type: null, content_html: '', file: null },
     ]);
   };
 
@@ -118,8 +118,12 @@ const TermsAndConditions: React.FC = () => {
             <TableRow key={row.id || index}>
               <TableCell>
                 <Select
-                  value={row.report_type}
-                  onValueChange={(val) => updateRow(index, { report_type: val as TermRow['report_type'] })}
+                  value={row.report_type ?? 'all'}
+                  onValueChange={(val) =>
+                    updateRow(index, {
+                      report_type: val === 'all' ? null : (val as TermRow['report_type']),
+                    })
+                  }
                 >
                   <SelectTrigger>
                     <SelectValue placeholder="Select template" />


### PR DESCRIPTION
## Summary
- Allow `report_type` in terms API to be `null` and normalize legacy `'all'` values
- Initialize new terms rows with `null` report type and map "All templates" option to `null`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 318 problems (289 errors, 29 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68ba19d2a6f483339bec5c7ac6d8a70f