### PR TITLE
feat: add preview thumbnail navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "embla-carousel-react": "^8.6.0",
         "fabric": "^6.7.1",
         "git-filter-repo": "^0.0.30",
+        "html2canvas": "^1.4.1",
         "input-otp": "^1.4.2",
         "konva": "^9.3.22",
         "lodash.get": "^4.4.2",
@@ -6609,6 +6610,15 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -7254,6 +7264,15 @@
       "license": "MIT",
       "dependencies": {
         "tiny-invariant": "^1.0.6"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -9460,6 +9479,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/htmlparser2": {
@@ -15854,6 +15886,15 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -16445,6 +16486,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/uuid": {
       "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "embla-carousel-react": "^8.6.0",
     "fabric": "^6.7.1",
     "git-filter-repo": "^0.0.30",
+    "html2canvas": "^1.4.1",
     "input-otp": "^1.4.2",
     "konva": "^9.3.22",
     "lodash.get": "^4.4.2",

--- a/src/components/reports/PreviewThumbnailNav.tsx
+++ b/src/components/reports/PreviewThumbnailNav.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import html2canvas from "html2canvas";
+
+interface PreviewThumbnailNavProps {
+  containerRef: React.RefObject<HTMLElement>;
+}
+
+const PreviewThumbnailNav: React.FC<PreviewThumbnailNavProps> = ({ containerRef }) => {
+  const [thumbnails, setThumbnails] = React.useState<string[]>([]);
+  const [pages, setPages] = React.useState<HTMLElement[]>([]);
+  const [activePage, setActivePage] = React.useState(0);
+
+  React.useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const pageNodes = Array.from(container.querySelectorAll<HTMLElement>(".preview-page"));
+    setPages(pageNodes);
+
+    Promise.all(
+      pageNodes.map((page) =>
+        html2canvas(page, { scale: 0.25 }).then((canvas) => canvas.toDataURL("image/png"))
+      )
+    ).then(setThumbnails);
+  }, [containerRef]);
+
+  React.useEffect(() => {
+    if (pages.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            const index = pages.indexOf(entry.target as HTMLElement);
+            if (index !== -1) {
+              setActivePage(index);
+            }
+          }
+        });
+      },
+      { threshold: 0.5 }
+    );
+
+    pages.forEach((p) => observer.observe(p));
+    return () => observer.disconnect();
+  }, [pages]);
+
+  const handleClick = (index: number) => {
+    pages[index]?.scrollIntoView({ behavior: "smooth" });
+  };
+
+  return (
+    <div className="w-24 overflow-y-auto h-screen sticky top-0 print:hidden">
+      <div className="flex flex-col gap-2 p-2 items-center">
+        {thumbnails.map((src, i) => (
+          <button
+            key={i}
+            onClick={() => handleClick(i)}
+            className={`border rounded w-full ${activePage === i ? "border-primary" : "border-transparent"}`}
+          >
+            <img src={src} alt={`Page ${i + 1}`} className="thumbnail-image" />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PreviewThumbnailNav;
+

--- a/src/pages/ReportPreview.tsx
+++ b/src/pages/ReportPreview.tsx
@@ -13,6 +13,7 @@ import {toast} from "@/components/ui/use-toast";
 import {useReactToPrint} from "react-to-print";
 import SpecializedReportPreview from "@/components/reports/SpecializedReportPreview";
 import PDFDocument from "@/components/reports/PDFDocument";
+import PreviewThumbnailNav from "@/components/reports/PreviewThumbnailNav";
 import "../styles/pdf.css";
 import {fillWindMitigationPDF} from "@/utils/fillWindMitigationPDF";
 import {getMyOrganization, getMyProfile, Organization, Profile, getTermsConditions} from "@/integrations/supabase/organizationsApi";
@@ -443,17 +444,22 @@ const ReportPreview: React.FC = () => {
                     }}
                 />
                 {topBar}
-                <div className="max-w-4xl mx-auto px-4 py-10">
-                    <div ref={pdfContainerRef} style={colorVars}>
-                        <SpecializedReportPreview
-                            report={report}
-                            inspector={inspector}
-                            organization={organization}
-                            mediaUrlMap={mediaUrlMap}
-                            coverUrl={coverUrl}
-                            className={tpl.cover}
-                            termsHtml={termsHtml}
-                        />
+                <div className="flex">
+                    <PreviewThumbnailNav containerRef={pdfContainerRef}/>
+                    <div className="flex-1">
+                        <div className="max-w-4xl mx-auto px-4 py-10">
+                            <div ref={pdfContainerRef} style={colorVars}>
+                                <SpecializedReportPreview
+                                    report={report}
+                                    inspector={inspector}
+                                    organization={organization}
+                                    mediaUrlMap={mediaUrlMap}
+                                    coverUrl={coverUrl}
+                                    className={tpl.cover}
+                                    termsHtml={termsHtml}
+                                />
+                            </div>
+                        </div>
                     </div>
                 </div>
             </>
@@ -477,14 +483,19 @@ const ReportPreview: React.FC = () => {
             {/* Top bar */}
             {topBar}
 
-            <PDFDocument
-                ref={pdfContainerRef}
-                report={report}
-                mediaUrlMap={mediaUrlMap}
-                coverUrl={coverUrl}
-                company={organization?.name || ""}
-                termsHtml={termsHtml || undefined}
-            />
+            <div className="flex">
+                <PreviewThumbnailNav containerRef={pdfContainerRef}/>
+                <div className="flex-1">
+                    <PDFDocument
+                        ref={pdfContainerRef}
+                        report={report}
+                        mediaUrlMap={mediaUrlMap}
+                        coverUrl={coverUrl}
+                        company={organization?.name || ""}
+                        termsHtml={termsHtml || undefined}
+                    />
+                </div>
+            </div>
         </>
     );
 };

--- a/src/styles/pdf.css
+++ b/src/styles/pdf.css
@@ -245,3 +245,11 @@
   background: #fff;
   box-shadow: 0 0 4px rgba(0,0,0,.1);
 }
+
+/* Thumbnails used in the preview sidebar */
+.thumbnail-image {
+  width: 400%;
+  height: auto;
+  transform: scale(0.25);
+  transform-origin: top left;
+}


### PR DESCRIPTION
## Summary
- generate sidebar thumbnails for report pages and highlight the active page
- display thumbnail navigation beside report preview and scroll pages on click
- scale preview thumbnails for compact sidebar

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 350 problems)


------
https://chatgpt.com/codex/tasks/task_e_68bb39a647208333b609164bce998f96