### PR TITLE
fix: add fixed top bar offset

### DIFF
--- a/src/pages/ReportPreview.tsx
+++ b/src/pages/ReportPreview.tsx
@@ -395,37 +395,44 @@ const ReportPreview: React.FC = () => {
         );
     }
 
+    const TOPBAR_HEIGHT = 72;
+
     const topBar = (
-        <div className="max-w-4xl mx-auto px-4 py-4 print-hidden flex items-center justify-between gap-2">
-            <div className="flex items-center gap-2">
-                <Button
-                    variant="outline"
-                    onClick={() => nav(`/reports/${report.id}`)}
-                    aria-label="Close preview and return to editor"
-                >
-                    Close Preview
+        <div
+            className="fixed top-0 left-0 right-0 z-50 bg-background shadow print-hidden"
+            style={{height: TOPBAR_HEIGHT}}
+        >
+            <div className="max-w-4xl mx-auto px-4 py-4 flex items-center justify-between gap-2 h-full">
+                <div className="flex items-center gap-2">
+                    <Button
+                        variant="outline"
+                        onClick={() => nav(`/reports/${report.id}`)}
+                        aria-label="Close preview and return to editor"
+                    >
+                        Close Preview
+                    </Button>
+                    <CoverTemplateSelector
+                        value={report.coverTemplate}
+                        onChange={handleCoverTemplateChange}
+                        disabled={savingCoverTpl}
+                        data={coverPreviewData}
+                    />
+                    <StyleSelector
+                        value={report.previewTemplate}
+                        onChange={handleStyleTemplateChange}
+                        disabled={savingStyleTpl}
+                    />
+                    <ColorSchemePicker
+                        value={report.colorScheme || "default"}
+                        customColors={report.customColors}
+                        onChange={handleColorSchemeChange}
+                        disabled={savingColorScheme}
+                    />
+                </div>
+                <Button onClick={onPrintClick} disabled={isGeneratingPDF} aria-label="Download PDF">
+                    {isGeneratingPDF ? "Generating PDF..." : "Download PDF"}
                 </Button>
-                <CoverTemplateSelector
-                    value={report.coverTemplate}
-                    onChange={handleCoverTemplateChange}
-                    disabled={savingCoverTpl}
-                    data={coverPreviewData}
-                />
-                <StyleSelector
-                    value={report.previewTemplate}
-                    onChange={handleStyleTemplateChange}
-                    disabled={savingStyleTpl}
-                />
-                <ColorSchemePicker
-                    value={report.colorScheme || "default"}
-                    customColors={report.customColors}
-                    onChange={handleColorSchemeChange}
-                    disabled={savingColorScheme}
-                />
             </div>
-            <Button onClick={onPrintClick} disabled={isGeneratingPDF} aria-label="Download PDF">
-                {isGeneratingPDF ? "Generating PDF..." : "Download PDF"}
-            </Button>
         </div>
     );
 
@@ -444,7 +451,7 @@ const ReportPreview: React.FC = () => {
                     }}
                 />
                 {topBar}
-                <div className="flex">
+                <div className="flex mt-[72px] print:mt-0">
                     <PreviewThumbnailNav containerRef={pdfContainerRef}/>
                     <div className="flex-1">
                         <div className="max-w-4xl mx-auto px-4 py-10">
@@ -483,7 +490,7 @@ const ReportPreview: React.FC = () => {
             {/* Top bar */}
             {topBar}
 
-            <div className="flex">
+            <div className="flex mt-[72px] print:mt-0">
                 <PreviewThumbnailNav containerRef={pdfContainerRef}/>
                 <div className="flex-1">
                     <PDFDocument


### PR DESCRIPTION
## Summary
- fix report preview top bar to be fixed with centered content
- offset preview content to account for fixed bar
- keep top bar hidden when printing reports

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 350 problems (319 errors, 31 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68bb3abe351c8333b5c279ced9567957