### PR TITLE
feat: add unified report builder

### DIFF
--- a/src/components/reports/NewReportBuilder.tsx
+++ b/src/components/reports/NewReportBuilder.tsx
@@ -1,0 +1,215 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Save, Settings2 } from "lucide-react";
+import { UniversalSectionsList } from "@/components/sections/UniversalSectionsList";
+import { SectionFieldsPanel } from "@/components/sections/SectionFieldsPanel";
+import { FieldEditor } from "@/components/sections/FieldEditor";
+import { CustomSectionDialog } from "@/components/reports/CustomSectionDialog";
+import { useCustomSections } from "@/hooks/useCustomSections";
+import { useCustomFields } from "@/hooks/useCustomFields";
+import { useToast } from "@/hooks/use-toast";
+import { customReportTypesApi } from "@/integrations/supabase/customReportTypesApi";
+import type { CustomField } from "@/integrations/supabase/customFieldsApi";
+import type { Report } from "@/lib/reportSchemas";
+import type { ReportCategory } from "@/constants/reportCategories";
+
+interface NewReportBuilderProps {
+  userId: string;
+  category: ReportCategory;
+}
+
+export function NewReportBuilder({ userId, category }: NewReportBuilderProps) {
+  const navigate = useNavigate();
+  const [reportTitle, setReportTitle] = useState("");
+  const [selectedSection, setSelectedSection] = useState<string | null>(null);
+  const [fieldEditorOpen, setFieldEditorOpen] = useState(false);
+  const [sectionDialogOpen, setSectionDialogOpen] = useState(false);
+  const [editingField, setEditingField] = useState<CustomField | undefined>();
+  const [isSaving, setIsSaving] = useState(false);
+
+  const [reportType] = useState<Report["reportType"]>(() => (`custom_${crypto.randomUUID()}`) as Report["reportType"]);
+
+  const { customSections, deleteSection } = useCustomSections();
+  const { customFields, createField, updateField, deleteField } = useCustomFields();
+  const { toast } = useToast();
+
+  const orderedCustomSections = customSections
+    .filter(section => section.report_types.includes(reportType))
+    .map(section => ({
+      key: section.section_key,
+      name: section.title,
+      type: "custom" as const,
+      id: section.section_key,
+      sortOrder: section.sort_order || 0,
+    }))
+    .sort((a, b) => a.sortOrder - b.sortOrder);
+
+  const handleAddField = () => {
+    setEditingField(undefined);
+    setFieldEditorOpen(true);
+  };
+
+  const handleEditField = (field: CustomField) => {
+    setEditingField(field);
+    setFieldEditorOpen(true);
+  };
+
+  const handleSaveField = async (fieldData: {
+    field_name: string;
+    field_label: string;
+    widget_type: CustomField["widget_type"];
+    options?: string[];
+    required?: boolean;
+  }) => {
+    if (!selectedSection) return;
+
+    if (editingField) {
+      await updateField(editingField.id, {
+        field_label: fieldData.field_label,
+        widget_type: fieldData.widget_type,
+        options: fieldData.options,
+        required: fieldData.required,
+      });
+    } else {
+      await createField({
+        ...fieldData,
+        section_key: selectedSection,
+        report_types: [reportType],
+      });
+    }
+  };
+
+  const handleSectionCreated = async () => {
+    setSectionDialogOpen(false);
+  };
+
+  const handleSaveReport = async () => {
+    if (!reportTitle.trim()) {
+      toast({
+        title: "Error",
+        description: "Please enter a report title",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await customReportTypesApi.create(userId, {
+        id: reportType,
+        name: reportTitle.trim(),
+        category,
+      });
+
+      toast({
+        title: "Success",
+        description: "Report type created successfully",
+      });
+
+      setReportTitle("");
+      setSelectedSection(null);
+      navigate("/settings/account/report-manager");
+    } catch (error) {
+      console.error("Error saving report type:", error);
+      toast({
+        title: "Error",
+        description: "Failed to save report type",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Report Configuration</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4">
+            <div>
+              <Label htmlFor="report-title">Report Title</Label>
+              <Input
+                id="report-title"
+                value={reportTitle}
+                onChange={(e) => setReportTitle(e.target.value)}
+                placeholder="Enter report title"
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Settings2 className="w-5 h-5" />
+            Section & Field Configuration
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="h-[600px] flex gap-4 rounded-lg overflow-hidden border">
+            <UniversalSectionsList
+              reportType={reportType}
+              selectedSection={selectedSection}
+              onSectionSelect={setSelectedSection}
+              customSections={customSections}
+              customFields={customFields}
+              onAddSection={() => setSectionDialogOpen(true)}
+              orderedSections={orderedCustomSections}
+            />
+
+            <SectionFieldsPanel
+              selectedSection={selectedSection}
+              reportType={reportType}
+              customFields={customFields.filter(field =>
+                selectedSection ?
+                  field.section_key === selectedSection &&
+                  field.report_types.includes(reportType)
+                  : false
+              )}
+              customSections={customSections}
+              onAddField={handleAddField}
+              onEditField={handleEditField}
+              onDeleteField={deleteField}
+              onDeleteSection={deleteSection}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex justify-end">
+        <Button onClick={handleSaveReport} disabled={!reportTitle.trim() || isSaving} size="lg">
+          <Save className="w-4 h-4 mr-2" />
+          {isSaving ? "Saving..." : "Save Report"}
+        </Button>
+      </div>
+
+      <FieldEditor
+        open={fieldEditorOpen}
+        onOpenChange={setFieldEditorOpen}
+        field={editingField}
+        sectionKey={selectedSection || ""}
+        onSave={handleSaveField}
+        isEditing={!!editingField}
+      />
+
+      <CustomSectionDialog
+        open={sectionDialogOpen}
+        onOpenChange={setSectionDialogOpen}
+        userId={userId}
+        reportTypes={[reportType]}
+        onSectionCreated={handleSectionCreated}
+      />
+    </div>
+  );
+}
+
+export default NewReportBuilder;
+

--- a/src/integrations/supabase/customReportTypesApi.ts
+++ b/src/integrations/supabase/customReportTypesApi.ts
@@ -1,0 +1,42 @@
+import { supabase } from "./client";
+
+export interface CustomReportType {
+  id: string;
+  user_id: string;
+  organization_id?: string | null;
+  name: string;
+  description?: string | null;
+  icon_name?: string | null;
+  category?: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+async function create(userId: string, data: { id: string; name: string; description?: string; icon_name?: string; category?: string; organization_id?: string; }): Promise<CustomReportType> {
+  const { data: result, error } = await supabase
+    .from("custom_report_types")
+    .insert({
+      id: data.id,
+      user_id: userId,
+      organization_id: data.organization_id,
+      name: data.name,
+      description: data.description,
+      icon_name: data.icon_name,
+      category: data.category,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    console.error("Error creating custom report type:", error);
+    throw error;
+  }
+
+  return result as CustomReportType;
+}
+
+export const customReportTypesApi = {
+  create,
+};
+

--- a/src/pages/ReportBuilder.tsx
+++ b/src/pages/ReportBuilder.tsx
@@ -4,20 +4,16 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { ArrowLeft, FileText, FormInput, Sparkles, Plus } from "lucide-react";
-import { DefectBasedBuilder } from "@/components/reports/DefectBasedBuilder";
-import { FormBasedBuilder } from "@/components/reports/FormBasedBuilder";
 import { useAuth } from "@/contexts/AuthContext";
-import { useReportTemplates } from "@/hooks/useReportTemplates";
+import { NewReportBuilder } from "@/components/reports/NewReportBuilder";
 import { REPORT_CATEGORY_LABELS, REPORT_CATEGORY_DESCRIPTIONS, type ReportCategory } from "@/constants/reportCategories";
 import Seo from "@/components/Seo";
-import type { Report } from "@/lib/reportSchemas";
 
 export default function ReportBuilder() {
   const navigate = useNavigate();
   const { user } = useAuth();
   const [selectedCategory, setSelectedCategory] = useState<ReportCategory | null>(null);
   const [step, setStep] = useState<"category" | "builder">("category");
-  const { createTemplate } = useReportTemplates();
 
   const handleCategorySelect = (category: ReportCategory) => {
     setSelectedCategory(category);
@@ -27,31 +23,6 @@ export default function ReportBuilder() {
   const handleBackToCategory = () => {
     setSelectedCategory(null);
     setStep("category");
-  };
-
-  const handleSaveTemplate = async (templateData: {
-    name: string;
-    description?: string;
-    report_type: Report["reportType"];
-    sections_config: Array<{
-      sectionKey: string;
-      title: string;
-      isCustom: boolean;
-      isRequired: boolean;
-      sortOrder: number;
-    }>;
-    fields_config: Record<string, Array<{
-      fieldId: string;
-      fieldName: string;
-      fieldLabel: string;
-      widgetType: string;
-      options?: string[];
-      required: boolean;
-      sortOrder: number;
-    }>>;
-  }) => {
-    await createTemplate(templateData);
-    navigate("/settings/account/report-manager");
   };
 
   if (!user) {
@@ -203,15 +174,10 @@ export default function ReportBuilder() {
         </div>
 
         {/* Builder Interface */}
-        {selectedCategory === "defect_based" ? (
-          <DefectBasedBuilder 
-            userId={user.id} 
-            onSaveTemplate={handleSaveTemplate}
-          />
-        ) : (
-          <FormBasedBuilder 
-            userId={user.id} 
-            onSaveTemplate={handleSaveTemplate}
+        {selectedCategory && (
+          <NewReportBuilder
+            userId={user.id}
+            category={selectedCategory}
           />
         )}
       </div>

--- a/src/pages/Settings/ReportManager.tsx
+++ b/src/pages/Settings/ReportManager.tsx
@@ -12,6 +12,7 @@ import { useCustomSections } from "@/hooks/useCustomSections";
 import { useCustomFields } from "@/hooks/useCustomFields";
 import { useSectionOrder } from "@/hooks/useSectionOrder";
 import { useAuth } from "@/contexts/AuthContext";
+import { useNavigate } from "react-router-dom";
 import { REPORT_TYPE_LABELS } from "@/constants/reportTypes";
 import { getReportCategory, REPORT_CATEGORY_LABELS, REPORT_CATEGORY_DESCRIPTIONS, isDefectBasedReport } from "@/constants/reportCategories";
 import type { Report } from "@/lib/reportSchemas";
@@ -19,6 +20,7 @@ import type { CustomField } from "@/integrations/supabase/customFieldsApi";
 
 export default function ReportManager() {
   const { user } = useAuth();
+  const navigate = useNavigate();
   const [selectedReportType, setSelectedReportType] = useState<Report["reportType"]>("home_inspection");
   const [selectedSection, setSelectedSection] = useState<string | null>(null);
   const [fieldEditorOpen, setFieldEditorOpen] = useState(false);
@@ -33,7 +35,7 @@ export default function ReportManager() {
   const isDefectBased = isDefectBasedReport(selectedReportType);
 
   const handleOpenReportBuilder = () => {
-    window.open("/report-builder", "_blank");
+    navigate("/report-builder");
   };
 
   const handleAddField = () => {


### PR DESCRIPTION
## Summary
- replace separate defect/form builders with a unified `NewReportBuilder`
- allow creating and saving custom report types using Supabase `custom_report_types`
- update settings navigation to open the new builder

## Testing
- ⚠️ `npm test` (missing script)
- ❌ `npm run lint` (400 problems)
- ✅ `npx eslint src/pages/ReportBuilder.tsx src/components/reports/NewReportBuilder.tsx src/pages/Settings/ReportManager.tsx src/integrations/supabase/customReportTypesApi.ts`

------
https://chatgpt.com/codex/tasks/task_e_68bf7270e13083338996e5a4bddf6592