### PR TITLE
Reload custom sections after creation

### DIFF
--- a/src/components/reports/NewReportBuilder.tsx
+++ b/src/components/reports/NewReportBuilder.tsx
@@ -33,7 +33,7 @@ export function NewReportBuilder({ userId, category }: NewReportBuilderProps) {
 
   const [reportType] = useState<Report["reportType"]>(() => (`custom_${crypto.randomUUID()}`) as Report["reportType"]);
 
-  const { customSections, deleteSection } = useCustomSections();
+  const { customSections, deleteSection, loadCustomSections } = useCustomSections();
   const { customFields, createField, updateField, deleteField } = useCustomFields();
   const { toast } = useToast();
 
@@ -84,6 +84,7 @@ export function NewReportBuilder({ userId, category }: NewReportBuilderProps) {
   };
 
   const handleSectionCreated = async () => {
+    await loadCustomSections();
     setSectionDialogOpen(false);
   };
 


### PR DESCRIPTION
## Summary
- reload custom sections after creating a new one in `NewReportBuilder`
- wait for section reload before closing the section dialog

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 400 problems (365 errors, 35 warnings))*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf75d7e22883339a2a3eb4cb9d509e