### PR TITLE
Add tags support to accounts

### DIFF
--- a/src/components/accounts/AccountsListView.tsx
+++ b/src/components/accounts/AccountsListView.tsx
@@ -20,6 +20,7 @@ export const AccountsListView: React.FC<AccountsListViewProps> = ({ accounts, fo
             <TableHead>Account Name</TableHead>
             <TableHead>Type</TableHead>
             <TableHead>Industry</TableHead>
+            <TableHead>Tags</TableHead>
             <TableHead>Location</TableHead>
             <TableHead>Employees</TableHead>
             <TableHead>Revenue</TableHead>
@@ -44,6 +45,13 @@ export const AccountsListView: React.FC<AccountsListViewProps> = ({ accounts, fo
                 {account.industry && (
                   <Badge variant="outline">{account.industry}</Badge>
                 )}
+              </TableCell>
+              <TableCell>
+                {account.tags?.map((tag) => (
+                  <Badge key={tag} variant="outline" className="mr-1">
+                    {tag}
+                  </Badge>
+                ))}
               </TableCell>
               <TableCell>
                 {(account.city || account.state) && (

--- a/src/integrations/supabase/accountsApi.ts
+++ b/src/integrations/supabase/accountsApi.ts
@@ -5,7 +5,7 @@ export const accountsApi = {
   async list(userId: string): Promise<Account[]> {
     const { data, error } = await supabase
       .from('accounts')
-      .select('*')
+      .select('*, tags')
       .eq('user_id', userId)
       .eq('is_active', true)
       .order('name');
@@ -17,7 +17,7 @@ export const accountsApi = {
   async get(id: string): Promise<Account | null> {
     const { data, error } = await supabase
       .from('accounts')
-      .select('*')
+      .select('*, tags')
       .eq('id', id)
       .single();
     
@@ -43,6 +43,7 @@ export const accountsApi = {
       notes: account.notes,
       annual_revenue: account.annual_revenue,
       employee_count: account.employee_count,
+      tags: account.tags,
       user_id: user.user.id,
     };
 
@@ -57,9 +58,14 @@ export const accountsApi = {
   },
 
   async update(id: string, updates: UpdateAccount): Promise<Account> {
+    const updateData = {
+      ...updates,
+      tags: updates.tags,
+    };
+
     const { data, error } = await supabase
       .from('accounts')
-      .update(updates)
+      .update(updateData)
       .eq('id', id)
       .select()
       .single();
@@ -80,7 +86,7 @@ export const accountsApi = {
   async search(userId: string, query: string): Promise<Account[]> {
     const { data, error } = await supabase
       .from('accounts')
-      .select('*')
+      .select('*, tags')
       .eq('user_id', userId)
       .eq('is_active', true)
       .or(`name.ilike.%${query}%,email.ilike.%${query}%,website.ilike.%${query}%`)
@@ -97,7 +103,7 @@ export const accountsApi = {
       .eq('account_id', accountId)
       .eq('is_active', true)
       .order('first_name');
-    
+
     if (error) throw error;
     return data;
   },

--- a/src/lib/accountSchemas.ts
+++ b/src/lib/accountSchemas.ts
@@ -15,6 +15,7 @@ export const AccountSchema = z.object({
   notes: z.string().optional(),
   annual_revenue: z.number().optional(),
   employee_count: z.number().optional(),
+  tags: z.array(z.string()).default([]),
   user_id: z.string().uuid(),
   organization_id: z.string().uuid().optional(),
   is_active: z.boolean().default(true),

--- a/src/pages/AccountDetail.tsx
+++ b/src/pages/AccountDetail.tsx
@@ -12,6 +12,7 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { TagInput } from "@/components/ui";
 import { accountsApi } from "@/integrations/supabase/accountsApi";
 import { CreateAccountSchema } from "@/lib/accountSchemas";
 import { useAuth } from "@/contexts/AuthContext";
@@ -42,6 +43,7 @@ export default function AccountDetail() {
       notes: "",
       annual_revenue: undefined,
       employee_count: undefined,
+      tags: [],
     },
   });
 
@@ -92,6 +94,7 @@ export default function AccountDetail() {
         notes: account.notes || "",
         annual_revenue: account.annual_revenue,
         employee_count: account.employee_count,
+        tags: account.tags || [],
       });
       setIsEditing(true);
     }
@@ -170,11 +173,14 @@ export default function AccountDetail() {
                 </Avatar>
                 <div>
                   <CardTitle className="text-2xl">{account.name}</CardTitle>
-                  <div className="flex items-center gap-2 mt-2">
+                  <div className="flex items-center gap-2 mt-2 flex-wrap">
                     <Badge variant="secondary">{account.type}</Badge>
                     {account.industry && (
                       <Badge variant="outline">{account.industry}</Badge>
                     )}
+                    {account.tags?.map((tag) => (
+                      <Badge key={tag}>{tag}</Badge>
+                    ))}
                   </div>
                 </div>
               </div>
@@ -444,6 +450,19 @@ export default function AccountDetail() {
                       )}
                     />
                   </div>
+
+                  <FormField
+                    control={form.control}
+                    name="tags"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Tags</FormLabel>
+                        <FormControl>
+                          <TagInput value={field.value || []} onChange={field.onChange} placeholder="Add tags" />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
 
                   <FormField
                     control={form.control}

--- a/src/pages/AccountNew.tsx
+++ b/src/pages/AccountNew.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { TagInput } from "@/components/ui";
 import { useToast } from "@/hooks/use-toast";
 import { accountsApi } from "@/integrations/supabase/accountsApi";
 import { ArrowLeft } from "lucide-react";
@@ -47,6 +48,7 @@ export default function AccountNew() {
     notes: "",
     annual_revenue: undefined,
     employee_count: undefined,
+    tags: [],
   });
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -213,7 +215,16 @@ export default function AccountNew() {
               </div>
             </div>
 
-
+            
+            <div className="space-y-2">
+              <Label htmlFor="tags">Tags</Label>
+              <TagInput
+                id="tags"
+                value={formData.tags}
+                onChange={(tags) => handleInputChange("tags", tags)}
+                placeholder="Add tags"
+              />
+            </div>
 
             <div className="space-y-2">
               <Label htmlFor="notes">Notes</Label>

--- a/src/pages/Accounts.tsx
+++ b/src/pages/Accounts.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { TagInput } from "@/components/ui";
 import { useToast } from "@/hooks/use-toast";
 import { accountsApi } from "@/integrations/supabase/accountsApi";
 import { useAuth } from "@/contexts/AuthContext";
@@ -23,6 +24,7 @@ export default function Accounts() {
   const effectiveView = isMobile ? "card" : view;
   const [selectedType, setSelectedType] = useState<string | null>(null);
   const [selectedIndustry, setSelectedIndustry] = useState<string | null>(null);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
   const { toast } = useToast();
   const { user } = useAuth();
@@ -35,7 +37,7 @@ export default function Accounts() {
 
   useEffect(() => {
     filterAccounts();
-  }, [accounts, searchTerm, selectedType, selectedIndustry]);
+  }, [accounts, searchTerm, selectedType, selectedIndustry, selectedTags]);
 
   const loadAccounts = async () => {
     try {
@@ -73,6 +75,13 @@ export default function Accounts() {
     // Industry filter
     if (selectedIndustry) {
       filtered = filtered.filter(account => account.industry === selectedIndustry);
+    }
+
+    // Tags filter
+    if (selectedTags.length > 0) {
+      filtered = filtered.filter(account =>
+        selectedTags.every(tag => account.tags?.includes(tag))
+      );
     }
 
     setFilteredAccounts(filtered);
@@ -132,6 +141,11 @@ export default function Accounts() {
               onIndustryChange={setSelectedIndustry}
               availableIndustries={availableIndustries}
             />
+            <TagInput
+              value={selectedTags}
+              onChange={setSelectedTags}
+              placeholder="Filter tags"
+            />
           </div>
         </div>
       ) : (
@@ -168,6 +182,13 @@ export default function Accounts() {
                 onIndustryChange={setSelectedIndustry}
                 availableIndustries={availableIndustries}
               />
+              <div className="max-w-sm">
+                <TagInput
+                  value={selectedTags}
+                  onChange={setSelectedTags}
+                  placeholder="Filter tags"
+                />
+              </div>
             </div>
             {!isMobile && <AccountsViewToggle view={view} onViewChange={setView} />}
           </div>
@@ -210,6 +231,15 @@ export default function Accounts() {
                 </div>
                 {account.industry && (
                   <p className="text-sm text-muted-foreground">{account.industry}</p>
+                )}
+                {account.tags?.length > 0 && (
+                  <div className="flex flex-wrap gap-1 mt-2">
+                    {account.tags.map((tag) => (
+                      <Badge key={tag} variant="outline">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
                 )}
               </CardHeader>
               <CardContent className="space-y-3">


### PR DESCRIPTION
## Summary
- extend account schemas and Supabase API to include tags
- add TagInput fields to account create and edit forms
- show and filter account tags in account lists

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, require import)*

------
https://chatgpt.com/codex/tasks/task_e_68c030f71ca4833393a8ae90a4309d75