### PR TITLE
feat: add tag support to contacts

### DIFF
--- a/src/components/contacts/ContactsCardView.tsx
+++ b/src/components/contacts/ContactsCardView.tsx
@@ -39,7 +39,7 @@ export const ContactsCardView: React.FC<ContactsCardViewProps> = ({
                     <CardDescription className="flex items-center gap-1">
                       <div className="flex items-center gap-1">
                         <Building className="w-3 h-3 text-blue-500" />
-                        <Link 
+                        <Link
                           to={`/accounts/${contact.account.id}`}
                           className="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors font-medium"
                           onClick={(e) => e.stopPropagation()}
@@ -51,6 +51,15 @@ export const ContactsCardView: React.FC<ContactsCardViewProps> = ({
                         </Badge>
                       </div>
                     </CardDescription>
+                  )}
+                  {contact.tags?.length > 0 && (
+                    <div className="mt-1 flex flex-wrap gap-1">
+                      {contact.tags.map((tag: string) => (
+                        <Badge key={tag} variant="secondary">
+                          {tag}
+                        </Badge>
+                      ))}
+                    </div>
                   )}
                 </div>
                 <Badge className={getContactTypeColor(contact.contact_type)}>

--- a/src/components/contacts/ContactsListView.tsx
+++ b/src/components/contacts/ContactsListView.tsx
@@ -58,12 +58,21 @@ export const ContactsListView: React.FC<ContactsListViewProps> = ({
           {contacts.map((contact) => (
             <TableRow key={contact.id} className="group">
               <TableCell>
-                <Link 
-                  to={`/contacts/${contact.id}`} 
+                <Link
+                  to={`/contacts/${contact.id}`}
                   className="font-medium hover:text-primary transition-colors"
                 >
                   {contact.first_name} {contact.last_name}
                 </Link>
+                {contact.tags?.length > 0 && (
+                  <div className="flex flex-wrap gap-1 mt-1">
+                    {contact.tags.map((tag: string) => (
+                      <Badge key={tag} variant="secondary">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
               </TableCell>
               <TableCell>
                 <Badge className={getContactTypeColor(contact.contact_type)}>

--- a/src/integrations/supabase/crmApi.ts
+++ b/src/integrations/supabase/crmApi.ts
@@ -8,6 +8,7 @@ export const contactsApi = {
       .from('contacts')
       .select(`
         *,
+        tags,
         account:accounts(id, name, type, industry)
       `)
       .eq('user_id', userId)
@@ -23,6 +24,7 @@ export const contactsApi = {
       .from('contacts')
       .select(`
         *,
+        tags,
         account:accounts(id, name, type, industry, website, phone, email)
       `)
       .eq('id', id)
@@ -36,7 +38,7 @@ export const contactsApi = {
     const { data, error } = await supabase
       .from('contacts')
       .insert(contact)
-      .select()
+      .select('*')
       .single();
     
     if (error) throw error;
@@ -62,7 +64,7 @@ export const contactsApi = {
       .from('contacts')
       .update(updates)
       .eq('id', id)
-      .select()
+      .select('*')
       .single();
     
     if (error) throw error;
@@ -83,6 +85,7 @@ export const contactsApi = {
       .from('contacts')
       .select(`
         *,
+        tags,
         account:accounts(id, name, type, industry)
       `)
       .eq('user_id', userId)

--- a/src/lib/crmSchemas.ts
+++ b/src/lib/crmSchemas.ts
@@ -21,6 +21,7 @@ export const ContactSchema = z.object({
   state: z.string().optional().nullable(),
   zip_code: z.string().optional().nullable(),
   notes: z.string().optional().nullable(),
+  tags: z.array(z.string()).default([]),
   is_active: z.boolean().default(true),
   created_at: z.string(),
   updated_at: z.string(),
@@ -52,6 +53,7 @@ export const CreateContactSchema = z.object({
   state: z.string().optional().nullable(),
   zip_code: z.string().optional().nullable(),
   notes: z.string().optional().nullable(),
+  tags: z.array(z.string()).default([]),
   is_active: z.boolean().default(true),
 });
 export type Contact = z.infer<typeof ContactSchema>;

--- a/src/pages/ContactDetail.tsx
+++ b/src/pages/ContactDetail.tsx
@@ -21,6 +21,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useToast } from "@/hooks/use-toast";
 import { ArrowLeft, Plus, Mail, Phone, MapPin, Building2, Calendar, FileText, CheckSquare, Activity, Edit2, Save, X } from "lucide-react";
 import { format } from "date-fns";
+import { TagInput } from "@/components/ui/TagInput";
 
 export default function ContactDetail() {
   const { id } = useParams<{ id: string }>();
@@ -47,6 +48,7 @@ export default function ContactDetail() {
       state: "",
       zip_code: "",
       notes: "",
+      tags: [],
       is_active: true,
     },
   });
@@ -116,12 +118,13 @@ export default function ContactDetail() {
         address_components: contact.address_components,
         city: contact.city || "",
         state: contact.state || "",
-        zip_code: contact.zip_code || "",
-        notes: contact.notes || "",
-        is_active: contact.is_active,
-      });
-      setIsEditing(true);
-    }
+      zip_code: contact.zip_code || "",
+      notes: contact.notes || "",
+      tags: contact.tags || [],
+      is_active: contact.is_active,
+    });
+    setIsEditing(true);
+  }
   };
 
   const handleCancel = () => {
@@ -208,6 +211,11 @@ export default function ContactDetail() {
                     <Badge className={getContactTypeColor(contact.contact_type)}>
                       {contact.contact_type}
                     </Badge>
+                    {contact.tags?.map((tag) => (
+                      <Badge key={tag} variant="secondary">
+                        {tag}
+                      </Badge>
+                    ))}
                   </div>
                 </div>
               </div>
@@ -509,6 +517,24 @@ export default function ContactDetail() {
                       )}
                     />
                   </div>
+
+                  <FormField
+                    control={form.control}
+                    name="tags"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Tags</FormLabel>
+                        <FormControl>
+                          <TagInput
+                            value={field.value}
+                            onChange={field.onChange}
+                            placeholder="Add tags"
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
 
                   <FormField
                     control={form.control}

--- a/src/pages/ContactNew.tsx
+++ b/src/pages/ContactNew.tsx
@@ -16,6 +16,7 @@ import { CreateContactSchema } from "@/lib/crmSchemas";
 import { AddressAutocomplete } from "@/components/maps/AddressAutocomplete";
 import { useToast } from "@/hooks/use-toast";
 import Seo from "@/components/Seo";
+import { TagInput } from "@/components/ui/TagInput";
 
 const ContactNew: React.FC = () => {
   const { user } = useAuth();
@@ -41,6 +42,7 @@ const ContactNew: React.FC = () => {
       state: "",
       zip_code: "",
       notes: "",
+      tags: [],
       is_active: true,
     },
   });
@@ -73,6 +75,7 @@ const ContactNew: React.FC = () => {
       state: data.state || null,
       zip_code: data.zip_code || null,
       notes: data.notes || null,
+      tags: data.tags || [],
     };
     createMutation.mutate(contactData);
   };
@@ -278,27 +281,45 @@ const ContactNew: React.FC = () => {
                       </FormItem>
                     )}
                   />
-                  <FormField
-                    control={form.control}
-                    name="zip_code"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>ZIP Code</FormLabel>
-                        <FormControl>
-                          <Input {...field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </div>
-
                 <FormField
                   control={form.control}
-                  name="notes"
+                  name="zip_code"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Notes</FormLabel>
+                      <FormLabel>ZIP Code</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <FormField
+                control={form.control}
+                name="tags"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Tags</FormLabel>
+                    <FormControl>
+                      <TagInput
+                        value={field.value}
+                        onChange={field.onChange}
+                        placeholder="Add tags"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="notes"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Notes</FormLabel>
                       <FormControl>
                         <Textarea 
                           {...field} 

--- a/src/pages/Contacts.tsx
+++ b/src/pages/Contacts.tsx
@@ -24,6 +24,7 @@ import { ContactsViewToggle } from "@/components/contacts/ContactsViewToggle";
 import { ContactsListView } from "@/components/contacts/ContactsListView";
 import { ContactsCardView } from "@/components/contacts/ContactsCardView";
 import { ContactsFilter } from "@/components/contacts/ContactsFilter";
+import { TagInput } from "@/components/ui/TagInput";
 import {
   Pagination,
   PaginationContent,
@@ -45,6 +46,7 @@ const Contacts: React.FC = () => {
   const [view, setView] = useState<"list" | "card">("list");
   const effectiveView = isMobile ? "card" : view;
   const [selectedType, setSelectedType] = useState<string | null>(null);
+  const [tagFilter, setTagFilter] = useState<string[]>([]);
   const [sortField, setSortField] = useState<string | null>(null);
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
   const [itemsPerPage, setItemsPerPage] = useState(10);
@@ -91,8 +93,11 @@ const Contacts: React.FC = () => {
              contact.company?.toLowerCase().includes(query);
       
       const matchesType = !selectedType || contact.contact_type === selectedType;
-      
-      return matchesSearch && matchesType;
+      const matchesTags =
+        tagFilter.length === 0 ||
+        tagFilter.every((tag) => contact.tags?.includes(tag));
+
+      return matchesSearch && matchesType && matchesTags;
     }) || [];
 
     // Sort contacts
@@ -134,7 +139,7 @@ const Contacts: React.FC = () => {
     }
 
     return filtered;
-  }, [contacts, searchQuery, selectedType, sortField, sortDirection]);
+  }, [contacts, searchQuery, selectedType, tagFilter, sortField, sortDirection]);
 
   const totalPages = Math.ceil(filteredAndSortedContacts.length / itemsPerPage) || 1;
   const paginatedContacts = React.useMemo(() => {
@@ -317,6 +322,12 @@ const Contacts: React.FC = () => {
                 onTypeChange={setSelectedType}
                 getContactTypeColor={getContactTypeColor}
               />
+              <TagInput
+                value={tagFilter}
+                onChange={setTagFilter}
+                placeholder="Filter tags"
+                className="max-w-sm"
+              />
             </div>
           </div>
         ) : (
@@ -354,6 +365,12 @@ const Contacts: React.FC = () => {
                   selectedType={selectedType}
                   onTypeChange={setSelectedType}
                   getContactTypeColor={getContactTypeColor}
+                />
+                <TagInput
+                  value={tagFilter}
+                  onChange={setTagFilter}
+                  placeholder="Filter tags"
+                  className="max-w-xs"
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add tags field to contact schemas and API queries
- integrate TagInput on contact pages
- display and filter contacts by tags

## Testing
- `npm run lint` *(fails: Unexpected any, require imports)*
- `npm test` *(fails: canvas.node compiled against different Node.js version)*

------
https://chatgpt.com/codex/tasks/task_e_68c03314440c8333bfb4d7ff7cbf6988