### PR TITLE
Add tag support for reports

### DIFF
--- a/src/components/reports/ReportDetailsForm.tsx
+++ b/src/components/reports/ReportDetailsForm.tsx
@@ -5,6 +5,7 @@ import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ContactMultiSelect } from "@/components/contacts/ContactMultiSelect";
 import type { Report } from "@/lib/reportSchemas";
+import { TagInput } from "@/components/ui/TagInput";
 
 interface Props {
   report: Report;
@@ -95,6 +96,14 @@ const ReportDetailsForm: React.FC<Props> = ({ report, onUpdate }) => {
         <ContactMultiSelect
           value={report.contactIds || []}
           onChange={(contactIds) => onUpdate({ ...report, contactIds } as Report)}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="tags">Tags</Label>
+        <TagInput
+          value={report.tags || []}
+          onChange={(tags) => onUpdate({ ...report, tags } as Report)}
+          placeholder="Add tags"
         />
       </div>
     </section>

--- a/src/components/reports/ReportsListView.tsx
+++ b/src/components/reports/ReportsListView.tsx
@@ -76,6 +76,15 @@ export const ReportsListView: React.FC<ReportsListViewProps> = ({
                     <Badge variant="outline" className="ml-2">Archived</Badge>
                   )}
                 </div>
+                {report.tags?.length > 0 && (
+                  <div className="flex flex-wrap gap-1 mt-1">
+                    {report.tags.map((tag: string) => (
+                      <Badge key={tag} variant="secondary">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
               </TableCell>
               <TableCell>
                 <Badge variant="secondary">

--- a/src/hooks/useLocalDraft.ts
+++ b/src/hooks/useLocalDraft.ts
@@ -16,7 +16,7 @@ function setIndex(ids: string[]) {
   localStorage.setItem(INDEX_KEY, JSON.stringify(ids));
 }
 
-export function listReports(): Pick<Report, "id" | "title" | "clientName" | "inspectionDate" | "status" | "address">[] {
+export function listReports(): Pick<Report, "id" | "title" | "clientName" | "inspectionDate" | "status" | "address" | "tags">[] {
   const ids = getIndex();
   return ids
     .map((id) => loadReport(id))
@@ -28,6 +28,7 @@ export function listReports(): Pick<Report, "id" | "title" | "clientName" | "ins
       inspectionDate: r!.inspectionDate,
       status: r!.status,
       address: r!.address,
+      tags: r!.tags || [],
     }));
 }
 
@@ -64,6 +65,7 @@ export function createReport(meta: {
   reportType?: Report["reportType"];
   includeStandardsOfPractice?: boolean;
   contactIds?: string[];
+  tags?: string[];
 }): Report {
   const id = crypto.randomUUID();
   const reportType = meta.reportType || "home_inspection";
@@ -92,6 +94,7 @@ export function createReport(meta: {
       sections,
       includeStandardsOfPractice: meta.includeStandardsOfPractice ?? true,
       contactIds: meta.contactIds || [],
+      tags: meta.tags || [],
     };
   } else if (reportType === "wind_mitigation") {
     report = {
@@ -106,6 +109,7 @@ export function createReport(meta: {
       previewTemplate: "classic",
       reportType: "wind_mitigation",
       contactIds: meta.contactIds || [],
+      tags: meta.tags || [],
       reportData: {
         "1_building_code": {},
         "2_roof_covering": {},
@@ -129,6 +133,7 @@ export function createReport(meta: {
       previewTemplate: "classic",
       reportType,
       contactIds: meta.contactIds || [],
+      tags: meta.tags || [],
       reportData: {},
     };
   }

--- a/src/integrations/supabase/reportsApi.ts
+++ b/src/integrations/supabase/reportsApi.ts
@@ -14,6 +14,7 @@ type ReportListItem = {
   reportType: Report["reportType"];
   archived?: boolean;
   address?: string;
+  tags?: string[];
 };
 
 function toDbPayload(report: Report) {
@@ -34,6 +35,7 @@ function toDbPayload(report: Report) {
     report_data: report.reportType === "home_inspection" ? null : (report as any).reportData || null,
     contact_id: (report as any).contactId || null,
     contact_ids: (report as any).contactIds || [],
+    tags: (report as any).tags || [],
     county: (report as any).county || null,
     ofStories: (report as any).ofStories || null,
     phone_home: (report as any).phoneHome || null,
@@ -79,6 +81,7 @@ function fromDbRow(row: any): Report {
     customColors: row.custom_colors || undefined,
     contactId: row.contact_id || undefined,
     contactIds: row.contact_ids || [],
+    tags: row.tags || [],
     reportData: row.report_data ?? {},
     reportType,
     phoneHome: row.phone_home || "",
@@ -203,6 +206,7 @@ export async function dbCreateReport(meta: {
   policyNumber?: string;
   email?: string;
   includeStandardsOfPractice?: boolean;
+  tags?: string[];
 }, userId: string, organizationId?: string): Promise<Report> {
   const id = crypto.randomUUID();
 
@@ -230,6 +234,7 @@ export async function dbCreateReport(meta: {
       coverTemplate: "templateOne",
       previewTemplate: "classic",
       reportType: "home_inspection",
+      tags: meta.tags || [],
       sections,
       // includeStandardsOfPractice: removed as not in DB schema
     };
@@ -255,6 +260,7 @@ export async function dbCreateReport(meta: {
       insuranceCompany: meta.insuranceCompany || "",
       policyNumber: meta.policyNumber || "",
       email: meta.email || "",
+      tags: meta.tags || [],
       reportData: {
         "1_building_code": {},
         "2_roof_covering": {},
@@ -283,6 +289,7 @@ export async function dbCreateReport(meta: {
       reportType: meta.reportType,
       clientPhone: meta.phoneHome || "",
       clientEmail: meta.email || "",
+      tags: meta.tags || [],
       reportData: {},
     };
   }
@@ -328,7 +335,7 @@ export async function dbCreateReport(meta: {
 }
 
 export async function dbListReports(userId: string, includeArchived: boolean = false): Promise<ReportListItem[]> {
-  const selectQuery = "id,title,client_name,address,inspection_date,status,archived,report_type";
+  const selectQuery = "id,title,client_name,address,inspection_date,status,archived,report_type,tags";
   
   const query = supabase
     .from("reports")
@@ -356,6 +363,7 @@ export async function dbListReports(userId: string, includeArchived: boolean = f
     archived: r.archived || false,
     reportType: r.report_type || "home_inspection",
     address: r.address || "",
+    tags: r.tags || [],
   }));
 }
 

--- a/src/lib/reportSchemas.ts
+++ b/src/lib/reportSchemas.ts
@@ -55,6 +55,7 @@ export const BaseReportSchema = z.object({
     status: z.enum(["Draft", "Final"]).default("Draft"),
     contactId: z.string().optional(), // Deprecated, use contactIds
     contactIds: z.array(z.string()).optional().default([]),
+    tags: z.array(z.string()).default([]),
     finalComments: z.string().optional().default(""),
     termsHtml: z.string().optional(),
     includeStandardsOfPractice: z.boolean().default(true),

--- a/src/pages/GenericReportNew.tsx
+++ b/src/pages/GenericReportNew.tsx
@@ -19,6 +19,7 @@ import { getMyOrganization } from "@/integrations/supabase/organizationsApi";
 import type { Report } from "@/lib/reportSchemas";
 import { REPORT_TYPE_LABELS } from "@/constants/reportTypes";
 import { ContactMultiSelect } from "@/components/contacts/ContactMultiSelect";
+import { TagInput } from "@/components/ui/TagInput";
 
 const schema = z.object({
   title: z.string().min(1, "Required"),
@@ -26,6 +27,7 @@ const schema = z.object({
   address: z.string().min(1, "Address is required"),
   inspectionDate: z.string().min(1, "Required"),
   contactIds: z.array(z.string()).optional().default([]),
+  tags: z.array(z.string()).optional().default([]),
 });
 
 type Values = z.infer<typeof schema>;
@@ -59,6 +61,7 @@ const GenericReportNew: React.FC = () => {
       address: "",
       inspectionDate: new Date().toISOString().slice(0, 10),
       contactIds: contactId ? [contactId] : [],
+      tags: [],
     },
   });
 
@@ -84,6 +87,7 @@ const GenericReportNew: React.FC = () => {
             inspectionDate: values.inspectionDate,
             contactIds: values.contactIds || [],
             reportType: type,
+            tags: values.tags || [],
           },
           user.id,
           organization?.id
@@ -98,6 +102,7 @@ const GenericReportNew: React.FC = () => {
           inspectionDate: new Date(values.inspectionDate).toISOString(),
           reportType: type,
           contactIds: values.contactIds || [],
+          tags: values.tags || [],
         });
         toast({ title: `${label} report created (local draft)` });
         nav(`/reports/${report.id}`);
@@ -184,6 +189,19 @@ const GenericReportNew: React.FC = () => {
                   <FormLabel>Inspection Date</FormLabel>
                   <FormControl>
                     <Input type="date" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="tags"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Tags</FormLabel>
+                  <FormControl>
+                    <TagInput value={field.value || []} onChange={field.onChange} placeholder="Add tags" />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/src/pages/HomeInspectionNew.tsx
+++ b/src/pages/HomeInspectionNew.tsx
@@ -18,6 +18,7 @@ import { contactsApi } from "@/integrations/supabase/crmApi";
 import { getMyOrganization } from "@/integrations/supabase/organizationsApi";
 import { ContactMultiSelect } from "@/components/contacts/ContactMultiSelect";
 import type { Contact } from "@/lib/crmSchemas";
+import { TagInput } from "@/components/ui/TagInput";
 
 const schema = z.object({
   title: z.string().min(1, "Required"),
@@ -26,6 +27,7 @@ const schema = z.object({
   inspectionDate: z.string().min(1, "Required"),
   contactIds: z.array(z.string()).optional().default([]),
   includeStandardsOfPractice: z.boolean().default(true),
+  tags: z.array(z.string()).optional().default([]),
 });
 
 type Values = z.infer<typeof schema>;
@@ -60,6 +62,7 @@ const HomeInspectionNew: React.FC = () => {
       inspectionDate: new Date().toISOString().slice(0, 10),
       contactIds: contactId ? [contactId] : [],
       includeStandardsOfPractice: true,
+      tags: [],
     },
   });
 
@@ -101,6 +104,7 @@ const HomeInspectionNew: React.FC = () => {
             contactIds: values.contactIds || [],
             reportType: "home_inspection",
             includeStandardsOfPractice: values.includeStandardsOfPractice,
+            tags: values.tags || [],
           },
           user.id,
           organization?.id
@@ -116,6 +120,7 @@ const HomeInspectionNew: React.FC = () => {
           reportType: "home_inspection",
           includeStandardsOfPractice: values.includeStandardsOfPractice,
           contactIds: values.contactIds || [],
+          tags: values.tags || [],
         });
         toast({ title: "Home inspection report created (local draft)" });
         nav(`/reports/${report.id}`);
@@ -210,6 +215,19 @@ const HomeInspectionNew: React.FC = () => {
                   <FormLabel>Inspection Date</FormLabel>
                   <FormControl>
                     <Input type="date" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="tags"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Tags</FormLabel>
+                  <FormControl>
+                    <TagInput value={field.value || []} onChange={field.onChange} placeholder="Add tags" />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/src/pages/ReportsList.tsx
+++ b/src/pages/ReportsList.tsx
@@ -25,6 +25,7 @@ import type {Report} from "@/lib/reportSchemas";
 import {REPORT_TYPE_LABELS} from "@/constants/reportTypes";
 import {Search, Plus} from "lucide-react";
 import {useIsMobile} from "@/hooks/use-mobile";
+import { TagInput } from "@/components/ui/TagInput";
 
 const ReportsList: React.FC = () => {
     const {user} = useAuth();
@@ -37,6 +38,7 @@ const ReportsList: React.FC = () => {
     const [itemsPerPage, setItemsPerPage] = React.useState(10);
     const [currentPage, setCurrentPage] = React.useState(1);
     const [searchQuery, setSearchQuery] = React.useState("");
+    const [tagFilter, setTagFilter] = React.useState<string[]>([]);
 
     const {data: remoteItems, refetch, isLoading} = useQuery({
         queryKey: ["reports", user?.id, showArchived],
@@ -71,6 +73,11 @@ const ReportsList: React.FC = () => {
             return false;
         }
 
+        // Filter by tags
+        if (tagFilter.length > 0 && !tagFilter.every((tag) => item.tags?.includes(tag))) {
+            return false;
+        }
+
         // Finally filter by search query
         const query = searchQuery.toLowerCase();
         if (query) {
@@ -95,7 +102,7 @@ const ReportsList: React.FC = () => {
 
     React.useEffect(() => {
         setCurrentPage(1);
-    }, [itemsPerPage, showArchived, reportTypeFilter, items, searchQuery]);
+    }, [itemsPerPage, showArchived, reportTypeFilter, items, searchQuery, tagFilter]);
 
     const onDelete = async (id: string) => {
         try {
@@ -174,6 +181,11 @@ const ReportsList: React.FC = () => {
                                     onReportTypeChange={setReportTypeFilter}
                                 />
                             )}
+                            <TagInput
+                                value={tagFilter}
+                                onChange={setTagFilter}
+                                placeholder="Filter tags"
+                            />
                         </div>
                     </div>
                 ) : (
@@ -185,7 +197,7 @@ const ReportsList: React.FC = () => {
                             </h1>
                         </header>
                         <div className="flex items-center justify-between mb-6">
-                            <div className="flex items-center ">
+                            <div className="flex items-center gap-2">
                                 <div className="relative flex-1 min-w-lg max-w-lg">
                                     <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground w-4 h-4"/>
                                     <Input
@@ -193,6 +205,13 @@ const ReportsList: React.FC = () => {
                                         value={searchQuery}
                                         onChange={(e) => setSearchQuery(e.target.value)}
                                         className="pl-10 min-w-[300px] max-w-lg w-full"
+                                    />
+                                </div>
+                                <div className="max-w-sm">
+                                    <TagInput
+                                        value={tagFilter}
+                                        onChange={setTagFilter}
+                                        placeholder="Filter tags"
                                     />
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- add tags array to report schema
- persist and expose report tags in Supabase API
- allow tag editing and filtering across report forms and lists

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any / forbidden require imports in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c035e7a9e08333996340f26dac912c