### PR TITLE
remove tag inputs from account, contact, and report pages

### DIFF
--- a/src/components/reports/ReportDetailsForm.tsx
+++ b/src/components/reports/ReportDetailsForm.tsx
@@ -5,7 +5,6 @@ import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { ContactMultiSelect } from "@/components/contacts/ContactMultiSelect";
 import type { Report } from "@/lib/reportSchemas";
-import { TagInput } from "@/components/ui/TagInput";
 
 interface Props {
   report: Report;
@@ -96,14 +95,6 @@ const ReportDetailsForm: React.FC<Props> = ({ report, onUpdate }) => {
         <ContactMultiSelect
           value={report.contactIds || []}
           onChange={(contactIds) => onUpdate({ ...report, contactIds } as Report)}
-        />
-      </div>
-      <div className="space-y-2">
-        <Label htmlFor="tags">Tags</Label>
-        <TagInput
-          value={report.tags || []}
-          onChange={(tags) => onUpdate({ ...report, tags } as Report)}
-          placeholder="Add tags"
         />
       </div>
     </section>

--- a/src/pages/AccountDetail.tsx
+++ b/src/pages/AccountDetail.tsx
@@ -12,7 +12,6 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import { TagInput } from "@/components/ui";
 import { accountsApi } from "@/integrations/supabase/accountsApi";
 import { CreateAccountSchema } from "@/lib/accountSchemas";
 import { useAuth } from "@/contexts/AuthContext";
@@ -450,19 +449,6 @@ export default function AccountDetail() {
                       )}
                     />
                   </div>
-
-                  <FormField
-                    control={form.control}
-                    name="tags"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Tags</FormLabel>
-                        <FormControl>
-                          <TagInput value={field.value || []} onChange={field.onChange} placeholder="Add tags" />
-                        </FormControl>
-                      </FormItem>
-                    )}
-                  />
 
                   <FormField
                     control={form.control}

--- a/src/pages/AccountNew.tsx
+++ b/src/pages/AccountNew.tsx
@@ -6,7 +6,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { TagInput } from "@/components/ui";
 import { useToast } from "@/hooks/use-toast";
 import { accountsApi } from "@/integrations/supabase/accountsApi";
 import { ArrowLeft } from "lucide-react";
@@ -216,16 +215,6 @@ export default function AccountNew() {
             </div>
 
             
-            <div className="space-y-2">
-              <Label htmlFor="tags">Tags</Label>
-              <TagInput
-                id="tags"
-                value={formData.tags}
-                onChange={(tags) => handleInputChange("tags", tags)}
-                placeholder="Add tags"
-              />
-            </div>
-
             <div className="space-y-2">
               <Label htmlFor="notes">Notes</Label>
               <Textarea

--- a/src/pages/ContactDetail.tsx
+++ b/src/pages/ContactDetail.tsx
@@ -21,7 +21,6 @@ import { useAuth } from "@/contexts/AuthContext";
 import { useToast } from "@/hooks/use-toast";
 import { ArrowLeft, Plus, Mail, Phone, MapPin, Building2, Calendar, FileText, CheckSquare, Activity, Edit2, Save, X } from "lucide-react";
 import { format } from "date-fns";
-import { TagInput } from "@/components/ui/TagInput";
 
 export default function ContactDetail() {
   const { id } = useParams<{ id: string }>();
@@ -517,24 +516,6 @@ export default function ContactDetail() {
                       )}
                     />
                   </div>
-
-                  <FormField
-                    control={form.control}
-                    name="tags"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Tags</FormLabel>
-                        <FormControl>
-                          <TagInput
-                            value={field.value}
-                            onChange={field.onChange}
-                            placeholder="Add tags"
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
 
                   <FormField
                     control={form.control}

--- a/src/pages/ContactNew.tsx
+++ b/src/pages/ContactNew.tsx
@@ -16,7 +16,6 @@ import { CreateContactSchema } from "@/lib/crmSchemas";
 import { AddressAutocomplete } from "@/components/maps/AddressAutocomplete";
 import { useToast } from "@/hooks/use-toast";
 import Seo from "@/components/Seo";
-import { TagInput } from "@/components/ui/TagInput";
 
 const ContactNew: React.FC = () => {
   const { user } = useAuth();
@@ -295,24 +294,6 @@ const ContactNew: React.FC = () => {
                   )}
                 />
               </div>
-
-              <FormField
-                control={form.control}
-                name="tags"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Tags</FormLabel>
-                    <FormControl>
-                      <TagInput
-                        value={field.value}
-                        onChange={field.onChange}
-                        placeholder="Add tags"
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
 
               <FormField
                 control={form.control}

--- a/src/pages/GenericReportNew.tsx
+++ b/src/pages/GenericReportNew.tsx
@@ -19,7 +19,6 @@ import { getMyOrganization } from "@/integrations/supabase/organizationsApi";
 import type { Report } from "@/lib/reportSchemas";
 import { REPORT_TYPE_LABELS } from "@/constants/reportTypes";
 import { ContactMultiSelect } from "@/components/contacts/ContactMultiSelect";
-import { TagInput } from "@/components/ui/TagInput";
 
 const schema = z.object({
   title: z.string().min(1, "Required"),
@@ -189,19 +188,6 @@ const GenericReportNew: React.FC = () => {
                   <FormLabel>Inspection Date</FormLabel>
                   <FormControl>
                     <Input type="date" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="tags"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Tags</FormLabel>
-                  <FormControl>
-                    <TagInput value={field.value || []} onChange={field.onChange} placeholder="Add tags" />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/src/pages/HomeInspectionNew.tsx
+++ b/src/pages/HomeInspectionNew.tsx
@@ -18,7 +18,6 @@ import { contactsApi } from "@/integrations/supabase/crmApi";
 import { getMyOrganization } from "@/integrations/supabase/organizationsApi";
 import { ContactMultiSelect } from "@/components/contacts/ContactMultiSelect";
 import type { Contact } from "@/lib/crmSchemas";
-import { TagInput } from "@/components/ui/TagInput";
 
 const schema = z.object({
   title: z.string().min(1, "Required"),
@@ -215,19 +214,6 @@ const HomeInspectionNew: React.FC = () => {
                   <FormLabel>Inspection Date</FormLabel>
                   <FormControl>
                     <Input type="date" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="tags"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Tags</FormLabel>
-                  <FormControl>
-                    <TagInput value={field.value || []} onChange={field.onChange} placeholder="Add tags" />
                   </FormControl>
                   <FormMessage />
                 </FormItem>


### PR DESCRIPTION
## Summary
- drop TagInput imports and components from account creation and detail pages
- remove tag fields from contact creation and detail forms
- strip tag inputs from report details form and new report pages

## Testing
- `npm run lint` (fails: Unexpected any, A `require()` style import is forbidden)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0460454748333b5297bf87f9833e3