### PR TITLE
feat: gate category-aware report editor behind readiness checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,20 @@ When adding external images, the app routes the request through `/api/image-prox
 This server-side proxy fetches the image and returns it with permissive CORS headers
 to prevent cross-origin errors when loading user-provided URLs.
 
+## Category-Aware Report Editor
+
+An experimental `CategoryAwareReportEditor` is available but disabled by default.
+To enable it safely, ensure the following features are complete and at parity with
+the legacy editor:
+
+- Tabbed navigation
+- Template support
+- Image annotation workflow
+- AI assistance
+
+Once these are implemented, set `ENABLE_CATEGORY_REPORT_EDITOR` to `true` in
+`src/constants/featureFlags.ts` to turn on the new editor.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/069944d1-052a-41dd-b482-c41df0da3591) and click on Share -> Publish.

--- a/src/constants/featureFlags.ts
+++ b/src/constants/featureFlags.ts
@@ -4,7 +4,10 @@
 export const FEATURE_FLAGS = {
   // AI functionality - defect detection, report writing
   SHOW_AI_FEATURES: false,
-  
+
+  // Use the new category-aware report editor when all required features are ready
+  ENABLE_CATEGORY_REPORT_EDITOR: false,
+
   // Future flags can be added here
   // SHOW_BETA_FEATURES: false,
 } as const;

--- a/src/pages/ReportEditor.tsx
+++ b/src/pages/ReportEditor.tsx
@@ -37,6 +37,7 @@ import { CustomSectionDialog } from "@/components/reports/CustomSectionDialog";
 import { Plus } from "lucide-react";
 import { Label } from "@/components/ui/label";
 import ContactMultiSelect from "@/components/contacts/ContactMultiSelect";
+import FEATURE_FLAGS from "@/constants/featureFlags";
 
 // Lazy load wind mitigation editor at module level
 const WindMitigationEditor = React.lazy(() => import("@/components/reports/WindMitigationEditor"));
@@ -98,10 +99,26 @@ const ReportEditor: React.FC = () => {
   // Get templates for the report type
   const { templates } = useReportTemplates(report?.reportType);
   const reportTemplate = templates.find(t => t.is_default) || templates[0] || null;
-  
+
   // Check if this is a category-aware report
   const reportCategory = report ? getReportCategory(report.reportType) : null;
-  const shouldUseCategoryEditor = reportCategory && reportTemplate;
+
+  // Readiness checks for enabling the new category-aware editor
+  // Toggle these once the corresponding features reach parity with the legacy editor
+  const hasTabs = false; // TODO: implement tabbed navigation in CategoryAwareReportEditor
+  const hasTemplates = !!reportTemplate; // templates must exist for the report type
+  const hasAnnotation = false; // TODO: support image annotation workflow
+  const hasAI = false; // TODO: integrate AI assistance
+
+  const categoryEditorReady =
+    FEATURE_FLAGS.ENABLE_CATEGORY_REPORT_EDITOR &&
+    hasTabs &&
+    hasTemplates &&
+    hasAnnotation &&
+    hasAI;
+
+  // Only use the new editor when all readiness checks pass
+  const shouldUseCategoryEditor = reportCategory && categoryEditorReady;
 
   const { data: recipientOptions = [] } = useQuery({
     queryKey: ["contacts", user?.id],


### PR DESCRIPTION
## Summary
- add `ENABLE_CATEGORY_REPORT_EDITOR` flag
- use readiness checks for tabs, templates, annotation, and AI before rendering CategoryAwareReportEditor
- document conditions for enabling new editor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c06df92534833387cc89c1901fe1ac