### PR TITLE
feat: add inspection agreements

### DIFF
--- a/src/integrations/supabase/agreementsApi.ts
+++ b/src/integrations/supabase/agreementsApi.ts
@@ -1,0 +1,54 @@
+import { supabase } from './client';
+
+export interface InspectionAgreement {
+  id?: string;
+  appointment_id: string;
+  service_id?: string | null;
+  client_name: string;
+  signed_at?: string | null;
+  signature_url?: string | null;
+  agreement_html: string;
+}
+
+async function create(
+  agreement: Omit<InspectionAgreement, 'id'>,
+): Promise<InspectionAgreement> {
+  const { data, error } = await supabase
+    .from('inspection_agreements')
+    .insert(agreement)
+    .select()
+    .single();
+  if (error) throw error;
+  return data as unknown as InspectionAgreement;
+}
+
+async function getByAppointment(
+  appointmentId: string,
+): Promise<InspectionAgreement | null> {
+  const { data, error } = await supabase
+    .from('inspection_agreements')
+    .select('*')
+    .eq('appointment_id', appointmentId)
+    .maybeSingle();
+  if (error) throw error;
+  return (data as unknown as InspectionAgreement) || null;
+}
+
+async function attachToReport(
+  reportId: string,
+  agreementId: string,
+): Promise<void> {
+  const { error } = await supabase
+    .from('appointments')
+    .update({ agreement_id: agreementId })
+    .eq('report_id', reportId);
+  if (error) throw error;
+}
+
+export const agreementsApi = {
+  create,
+  getByAppointment,
+  attachToReport,
+};
+
+export default agreementsApi;

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -235,6 +235,7 @@ export type Database = {
       appointments: {
         Row: {
           appointment_date: string
+          agreement_id: string | null
           contact_id: string | null
           created_at: string
           description: string | null
@@ -250,6 +251,7 @@ export type Database = {
         }
         Insert: {
           appointment_date: string
+          agreement_id?: string | null
           contact_id?: string | null
           created_at?: string
           description?: string | null
@@ -265,6 +267,7 @@ export type Database = {
         }
         Update: {
           appointment_date?: string
+          agreement_id?: string | null
           contact_id?: string | null
           created_at?: string
           description?: string | null
@@ -291,6 +294,13 @@ export type Database = {
             columns: ["report_id"]
             isOneToOne: false
             referencedRelation: "reports"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "fk_appointments_agreement"
+            columns: ["agreement_id"]
+            isOneToOne: false
+            referencedRelation: "inspection_agreements"
             referencedColumns: ["id"]
           },
         ]
@@ -738,6 +748,51 @@ export type Database = {
             columns: ["organization_id"]
             isOneToOne: true
             referencedRelation: "organizations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      inspection_agreements: {
+        Row: {
+          id: string
+          appointment_id: string | null
+          service_id: string | null
+          client_name: string | null
+          signed_at: string | null
+          signature_url: string | null
+          agreement_html: string | null
+        }
+        Insert: {
+          id?: string
+          appointment_id?: string | null
+          service_id?: string | null
+          client_name?: string | null
+          signed_at?: string | null
+          signature_url?: string | null
+          agreement_html?: string | null
+        }
+        Update: {
+          id?: string
+          appointment_id?: string | null
+          service_id?: string | null
+          client_name?: string | null
+          signed_at?: string | null
+          signature_url?: string | null
+          agreement_html?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "inspection_agreements_appointment_id_fkey"
+            columns: ["appointment_id"]
+            isOneToOne: false
+            referencedRelation: "appointments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "inspection_agreements_service_id_fkey"
+            columns: ["service_id"]
+            isOneToOne: false
+            referencedRelation: "services"
             referencedColumns: ["id"]
           },
         ]

--- a/supabase/migrations/20250925000000_create_inspection_agreements.sql
+++ b/supabase/migrations/20250925000000_create_inspection_agreements.sql
@@ -1,0 +1,17 @@
+-- Create inspection_agreements table
+create table if not exists public.inspection_agreements (
+  id uuid primary key default gen_random_uuid(),
+  appointment_id uuid references public.appointments(id) on delete cascade,
+  service_id uuid references public.services(id) on delete set null,
+  client_name text,
+  signed_at timestamptz,
+  signature_url text,
+  agreement_html text
+);
+
+-- Index for appointment lookups
+create index if not exists inspection_agreements_appointment_id_idx on public.inspection_agreements (appointment_id);
+
+-- Add agreement_id column to appointments table
+alter table public.appointments
+  add column agreement_id uuid references public.inspection_agreements(id);


### PR DESCRIPTION
## Summary
- create inspection_agreements table and link to appointments
- expose new agreement types via supabase client
- add agreementsApi with helpers to manage inspection agreements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c07f58a68483338b026af0a5a20aad