### PR TITLE
Prefill report terms from appointment agreement

### DIFF
--- a/src/lib/reportSchemas.ts
+++ b/src/lib/reportSchemas.ts
@@ -58,6 +58,7 @@ export const BaseReportSchema = z.object({
     tags: z.array(z.string()).default([]),
     finalComments: z.string().optional().default(""),
     termsHtml: z.string().optional(),
+    agreementId: z.string().optional(),
     includeStandardsOfPractice: z.boolean().default(true),
     coverImage: z.string().optional().default(""),
     coverTemplate: z

--- a/src/pages/ReportPreview.tsx
+++ b/src/pages/ReportPreview.tsx
@@ -426,6 +426,10 @@ const ReportPreview: React.FC = () => {
 
     React.useEffect(() => {
         if (!organization || !report) return;
+        if (report.termsHtml) {
+            setTermsHtml(report.termsHtml);
+            return;
+        }
         (async () => {
             try {
                 const terms = await getTermsConditions(organization.id);


### PR DESCRIPTION
## Summary
- pull agreement HTML when creating a report from an appointment and persist agreement_id
- read stored terms_html directly when fetching reports
- use report.termsHtml in preview with fallback to organization terms

## Testing
- `bun test` *(fails: ReferenceError: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c097de10648333ba57484bade21ed5