### PR TITLE
Add appointment link to reports

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -292,7 +292,7 @@ export type Database = {
           {
             foreignKeyName: "fk_appointments_report"
             columns: ["report_id"]
-            isOneToOne: false
+            isOneToOne: true
             referencedRelation: "reports"
             referencedColumns: ["id"]
           },
@@ -1232,6 +1232,7 @@ export type Database = {
       reports: {
         Row: {
           address: string
+          appointment_id: string | null
           archived: boolean
           client_name: string
           color_scheme: string | null
@@ -1267,6 +1268,7 @@ export type Database = {
         }
         Insert: {
           address: string
+          appointment_id?: string | null
           archived?: boolean
           client_name: string
           color_scheme?: string | null
@@ -1302,6 +1304,7 @@ export type Database = {
         }
         Update: {
           address?: string
+          appointment_id?: string | null
           archived?: boolean
           client_name?: string
           color_scheme?: string | null
@@ -1336,6 +1339,13 @@ export type Database = {
           user_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "reports_appointment_id_fkey"
+            columns: ["appointment_id"]
+            isOneToOne: true
+            referencedRelation: "appointments"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "reports_contact_id_fkey"
             columns: ["contact_id"]

--- a/src/lib/reportSchemas.ts
+++ b/src/lib/reportSchemas.ts
@@ -59,6 +59,7 @@ export const BaseReportSchema = z.object({
     finalComments: z.string().optional().default(""),
     termsHtml: z.string().optional(),
     agreementId: z.string().optional(),
+    appointmentId: z.string().optional(),
     includeStandardsOfPractice: z.boolean().default(true),
     coverImage: z.string().optional().default(""),
     coverTemplate: z

--- a/supabase/migrations/20250926000000_add_appointment_id_to_reports.sql
+++ b/supabase/migrations/20250926000000_add_appointment_id_to_reports.sql
@@ -1,0 +1,11 @@
+-- Add appointment_id column to reports table and enforce 1-to-1 relationship with appointments
+ALTER TABLE public.reports
+  ADD COLUMN IF NOT EXISTS appointment_id uuid REFERENCES public.appointments(id) ON DELETE SET NULL;
+
+-- Each appointment can be linked to at most one report
+ALTER TABLE public.reports
+  ADD CONSTRAINT IF NOT EXISTS reports_appointment_id_key UNIQUE (appointment_id);
+
+-- Each report can be linked to at most one appointment
+ALTER TABLE public.appointments
+  ADD CONSTRAINT IF NOT EXISTS appointments_report_id_key UNIQUE (report_id);


### PR DESCRIPTION
## Summary
- add migration linking reports to appointments with one-to-one constraints
- update Supabase types with `appointment_id` and unique report relationship
- expose optional `appointmentId` in BaseReportSchema

## Testing
- `npx supabase gen types typescript --local` *(fails: Cannot connect to the Docker daemon)*
- `npx supabase gen types typescript --project-id qnrqwapbxnplypdirdiq` *(fails: Access token not provided)*
- `npm test` *(fails: Module did not self-register: canvas.node)*
- `npm run lint` *(fails: 389 errors, 42 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c09d5edf948333b041b8cde19d3f35