### PR TITLE
feat: link reports with appointments

### DIFF
--- a/src/pages/CaWildfireNew.tsx
+++ b/src/pages/CaWildfireNew.tsx
@@ -31,6 +31,7 @@ const CaWildfireNew: React.FC = () => {
   const { user } = useAuth();
   const [searchParams] = useSearchParams();
   const contactId = searchParams.get("contactId");
+  const appointmentId = searchParams.get("appointmentId");
 
   const { data: contacts = [] } = useQuery({
     queryKey: ["contacts", user?.id],
@@ -77,6 +78,7 @@ const CaWildfireNew: React.FC = () => {
             inspectionDate: values.inspectionDate,
             contact_id: values.contactId,
             reportType: "ca_wildfire_defensible_space",
+            appointment_id: appointmentId || undefined,
           },
           user.id,
           organization?.id

--- a/src/pages/FlFourPointNew.tsx
+++ b/src/pages/FlFourPointNew.tsx
@@ -31,6 +31,7 @@ const FlFourPointNew: React.FC = () => {
   const { user } = useAuth();
   const [searchParams] = useSearchParams();
   const contactId = searchParams.get("contactId");
+  const appointmentId = searchParams.get("appointmentId");
 
   const { data: contacts = [] } = useQuery({
     queryKey: ["contacts", user?.id],
@@ -77,6 +78,7 @@ const FlFourPointNew: React.FC = () => {
             inspectionDate: values.inspectionDate,
             contact_id: values.contactId,
             reportType: "fl_four_point_citizens",
+            appointment_id: appointmentId || undefined,
           },
           user.id,
           organization?.id

--- a/src/pages/GenericReportNew.tsx
+++ b/src/pages/GenericReportNew.tsx
@@ -39,6 +39,7 @@ const GenericReportNew: React.FC = () => {
   const { user } = useAuth();
   const [searchParams] = useSearchParams();
   const contactId = searchParams.get("contactId");
+  const appointmentId = searchParams.get("appointmentId");
 
   const { data: contacts = [] } = useQuery({
     queryKey: ["contacts", user?.id],
@@ -87,6 +88,7 @@ const GenericReportNew: React.FC = () => {
             contactIds: values.contactIds || [],
             reportType: type,
             tags: values.tags || [],
+            appointment_id: appointmentId || undefined,
           },
           user.id,
           organization?.id

--- a/src/pages/HomeInspectionNew.tsx
+++ b/src/pages/HomeInspectionNew.tsx
@@ -37,6 +37,7 @@ const HomeInspectionNew: React.FC = () => {
   const { user } = useAuth();
   const [searchParams] = useSearchParams();
   const contactId = searchParams.get("contactId");
+  const appointmentId = searchParams.get("appointmentId");
   const [selectedContacts, setSelectedContacts] = useState<Contact[]>([]);
   const { templates } = useReportTemplates("home_inspection");
   const reportTemplate = templates.find(t => t.is_default) || templates[0] || null;
@@ -108,6 +109,7 @@ const HomeInspectionNew: React.FC = () => {
             includeStandardsOfPractice: values.includeStandardsOfPractice,
             tags: values.tags || [],
             template: reportTemplate,
+            appointment_id: appointmentId || undefined,
           },
           user.id,
           organization?.id

--- a/src/pages/ManufacturedHomeNew.tsx
+++ b/src/pages/ManufacturedHomeNew.tsx
@@ -31,6 +31,7 @@ const ManufacturedHomeNew: React.FC = () => {
   const { user } = useAuth();
   const [searchParams] = useSearchParams();
   const contactId = searchParams.get("contactId");
+  const appointmentId = searchParams.get("appointmentId");
 
   const { data: contacts = [] } = useQuery({
     queryKey: ["contacts", user?.id],
@@ -77,6 +78,7 @@ const ManufacturedHomeNew: React.FC = () => {
             inspectionDate: values.inspectionDate,
             contact_id: values.contactId,
             reportType: "manufactured_home_insurance_prep",
+            appointment_id: appointmentId || undefined,
           },
           user.id,
           organization?.id

--- a/src/pages/ReportNew.tsx
+++ b/src/pages/ReportNew.tsx
@@ -37,6 +37,7 @@ const ReportNew: React.FC = () => {
   const { user } = useAuth();
   const [searchParams] = useSearchParams();
   const contactId = searchParams.get("contactId");
+  const appointmentId = searchParams.get("appointmentId");
 
   // Get all contacts for lookup
   const { data: contacts = [] } = useQuery({
@@ -86,6 +87,7 @@ const ReportNew: React.FC = () => {
             inspectionDate: values.inspectionDate,
             contact_id: values.contactId,
             reportType: "home_inspection",
+            appointment_id: appointmentId || undefined,
           },
           user.id,
           organization?.id

--- a/src/pages/RoofCertificationNew.tsx
+++ b/src/pages/RoofCertificationNew.tsx
@@ -31,6 +31,7 @@ const RoofCertificationNew: React.FC = () => {
   const { user } = useAuth();
   const [searchParams] = useSearchParams();
   const contactId = searchParams.get("contactId");
+  const appointmentId = searchParams.get("appointmentId");
 
   const { data: contacts = [] } = useQuery({
     queryKey: ["contacts", user?.id],
@@ -77,6 +78,7 @@ const RoofCertificationNew: React.FC = () => {
             inspectionDate: values.inspectionDate,
             contact_id: values.contactId,
             reportType: "roof_certification_nationwide",
+            appointment_id: appointmentId || undefined,
           },
           user.id,
           organization?.id

--- a/src/pages/TxWindstormNew.tsx
+++ b/src/pages/TxWindstormNew.tsx
@@ -31,6 +31,7 @@ const TxWindstormNew: React.FC = () => {
   const { user } = useAuth();
   const [searchParams] = useSearchParams();
   const contactId = searchParams.get("contactId");
+  const appointmentId = searchParams.get("appointmentId");
 
   const { data: contacts = [] } = useQuery({
     queryKey: ["contacts", user?.id],
@@ -77,6 +78,7 @@ const TxWindstormNew: React.FC = () => {
             inspectionDate: values.inspectionDate,
             contact_id: values.contactId,
             reportType: "tx_coastal_windstorm_mitigation",
+            appointment_id: appointmentId || undefined,
           },
           user.id,
           organization?.id

--- a/src/pages/WindMitigationNew.tsx
+++ b/src/pages/WindMitigationNew.tsx
@@ -39,6 +39,7 @@ const WindMitigationNew: React.FC = () => {
   const { user } = useAuth();
   const [searchParams] = useSearchParams();
   const contactId = searchParams.get("contactId");
+  const appointmentId = searchParams.get("appointmentId");
 
   // Get all contacts for lookup
   const { data: contacts = [] } = useQuery({
@@ -117,6 +118,7 @@ const WindMitigationNew: React.FC = () => {
             insuranceCompany: values.insuranceCompany,
             policyNumber: values.policyNumber,
             email: values.email,
+            appointment_id: appointmentId || undefined,
           },
           user.id,
           organization?.id


### PR DESCRIPTION
## Summary
- include `appointment_id` in report payloads and parsing
- attach reports to appointments after creation
- allow report creators to pass appointment IDs

## Testing
- `npm run lint` *(fails: Unexpected any, require import)*
- `npm test` *(fails: Module did not self-register: canvas.node)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a0926f4c8333b0a1010031128f10