### PR TITLE
feat: add report navigation to appointment preview

### DIFF
--- a/src/components/calendar/AppointmentPreviewDialog.tsx
+++ b/src/components/calendar/AppointmentPreviewDialog.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
+import { Button } from "@/components/ui/button";
 import { format } from "date-fns";
 import { CalendarIcon, Clock, MapPin, User, FileText, Phone, Mail, Building2, Hash, Calendar } from "lucide-react";
 import { type Appointment } from "@/lib/crmSchemas";
@@ -10,13 +11,14 @@ interface AppointmentPreviewDialogProps {
   appointment: Appointment | null;
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
-  contact?: { 
+  contact?: {
     first_name: string; 
     last_name: string;
     email?: string;
     phone?: string;
     company?: string;
   } | null;
+  onNavigate: (path: string) => void;
 }
 
 const AppointmentPreviewDialog: React.FC<AppointmentPreviewDialogProps> = ({
@@ -24,6 +26,7 @@ const AppointmentPreviewDialog: React.FC<AppointmentPreviewDialogProps> = ({
   isOpen,
   onOpenChange,
   contact,
+  onNavigate,
 }) => {
   if (!appointment) return null;
 
@@ -206,6 +209,19 @@ const AppointmentPreviewDialog: React.FC<AppointmentPreviewDialogProps> = ({
               </div>
             </>
           )}
+
+          <Separator />
+          <div className="flex justify-end">
+            {appointment.report_id ? (
+              <Button onClick={() => onNavigate(`/reports/${appointment.report_id}`)}>
+                View Report
+              </Button>
+            ) : (
+              <Button onClick={() => onNavigate(`/reports/new/home-inspection?appointmentId=${appointment.id}`)}>
+                Create Report
+              </Button>
+            )}
+          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -40,10 +40,12 @@ import * as appleCalendar from "@/integrations/appleCalendar";
 import {syncExternalEvents} from "@/integrations/syncExternalEvents";
 import { getOptimizedRoute } from "@/components/maps/routeOptimizer";
 import RouteChoiceDialog from "@/components/maps/RouteChoiceDialog";
+import { useNavigate } from "react-router-dom";
 
 const Calendar: React.FC = () => {
     const {user} = useAuth();
     const queryClient = useQueryClient();
+    const navigate = useNavigate();
     const [selectedDate, setSelectedDate] = useState(new Date());
     const [isDialogOpen, setIsDialogOpen] = useState(false);
     const [editingAppointment, setEditingAppointment] = useState<Appointment | null>(null);
@@ -907,6 +909,7 @@ const Calendar: React.FC = () => {
                         isOpen={!!previewAppointment}
                         onOpenChange={(open) => !open && setPreviewAppointment(null)}
                         contact={(previewAppointment as any)?.contacts || (previewAppointment as any)?.contact}
+                        onNavigate={navigate}
                     />
 
                     {/* Delete Confirmation Dialog */}


### PR DESCRIPTION
## Summary
- show Create/View Report button in appointment preview dialog
- pass navigate callback from calendar page to handle report links

## Testing
- `npm test` *(fails: Module did not self-register: '/workspace/your-next-web-adventure/node_modules/canvas/build/Release/canvas.node')*
- `npm run lint` *(fails: 446 problems (400 errors, 46 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68c0a1f775648333b53a005c82e40485