### PR TITLE
Add appointment linking to new report pages

### DIFF
--- a/src/pages/FlFourPointNew.tsx
+++ b/src/pages/FlFourPointNew.tsx
@@ -13,7 +13,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { toast } from "@/components/ui/use-toast";
 import { useAuth } from "@/contexts/AuthContext";
 import { dbCreateReport } from "@/integrations/supabase/reportsApi";
-import { contactsApi } from "@/integrations/supabase/crmApi";
+import { appointmentsApi, contactsApi } from "@/integrations/supabase/crmApi";
 import { getMyOrganization } from "@/integrations/supabase/organizationsApi";
 
 const schema = z.object({
@@ -22,6 +22,7 @@ const schema = z.object({
   address: z.string().min(1, "Address is required"),
   inspectionDate: z.string().min(1, "Required"),
   contactId: z.string().optional(),
+  appointmentId: z.string().optional(),
 });
 
 type Values = z.infer<typeof schema>;
@@ -39,6 +40,12 @@ const FlFourPointNew: React.FC = () => {
     enabled: !!user,
   });
 
+  const { data: appointments = [] } = useQuery({
+    queryKey: ["appointments", user?.id],
+    queryFn: () => appointmentsApi.getUpcoming(user!.id, 50),
+    enabled: !!user,
+  });
+
   const { data: contact } = useQuery({
     queryKey: ["contact", contactId],
     queryFn: () => contactsApi.get(contactId!),
@@ -53,6 +60,7 @@ const FlFourPointNew: React.FC = () => {
       address: "",
       inspectionDate: new Date().toISOString().slice(0, 10),
       contactId: contactId || "",
+      appointmentId: appointmentId || "",
     },
   });
 
@@ -70,6 +78,17 @@ const FlFourPointNew: React.FC = () => {
     try {
       if (user) {
         const organization = await getMyOrganization();
+        let apptId = values.appointmentId;
+        if (!apptId) {
+          const appointment = await appointmentsApi.create({
+            user_id: user.id,
+            title: values.title,
+            appointment_date: new Date(values.inspectionDate).toISOString(),
+            address: values.address,
+            contact_id: values.contactId || undefined,
+          });
+          apptId = appointment.id;
+        }
         const report = await dbCreateReport(
           {
             title: values.title,
@@ -78,11 +97,12 @@ const FlFourPointNew: React.FC = () => {
             inspectionDate: values.inspectionDate,
             contact_id: values.contactId,
             reportType: "fl_four_point_citizens",
-            appointment_id: appointmentId || undefined,
+            appointment_id: apptId,
           },
           user.id,
           organization?.id
         );
+        await appointmentsApi.update(apptId, { report_id: report.id });
         toast({ title: "FL 4-Point report created" });
         nav(`/reports/${report.id}`);
       } else {
@@ -145,6 +165,30 @@ const FlFourPointNew: React.FC = () => {
                           <SelectItem key={c.id} value={c.id}>
                             {c.first_name} {c.last_name}
                             {c.email && <span className="text-muted-foreground ml-2">({c.email})</span>}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="appointmentId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Appointment</FormLabel>
+                  <FormControl>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select an appointment..." />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {appointments.map((a) => (
+                          <SelectItem key={a.id} value={a.id}>
+                            {a.title} - {new Date(a.appointment_date).toLocaleDateString()}
                           </SelectItem>
                         ))}
                       </SelectContent>

--- a/src/pages/ManufacturedHomeNew.tsx
+++ b/src/pages/ManufacturedHomeNew.tsx
@@ -13,7 +13,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { toast } from "@/components/ui/use-toast";
 import { useAuth } from "@/contexts/AuthContext";
 import { dbCreateReport } from "@/integrations/supabase/reportsApi";
-import { contactsApi } from "@/integrations/supabase/crmApi";
+import { appointmentsApi, contactsApi } from "@/integrations/supabase/crmApi";
 import { getMyOrganization } from "@/integrations/supabase/organizationsApi";
 
 const schema = z.object({
@@ -22,6 +22,7 @@ const schema = z.object({
   address: z.string().min(1, "Address is required"),
   inspectionDate: z.string().min(1, "Required"),
   contactId: z.string().optional(),
+  appointmentId: z.string().optional(),
 });
 
 type Values = z.infer<typeof schema>;
@@ -39,6 +40,12 @@ const ManufacturedHomeNew: React.FC = () => {
     enabled: !!user,
   });
 
+  const { data: appointments = [] } = useQuery({
+    queryKey: ["appointments", user?.id],
+    queryFn: () => appointmentsApi.getUpcoming(user!.id, 50),
+    enabled: !!user,
+  });
+
   const { data: contact } = useQuery({
     queryKey: ["contact", contactId],
     queryFn: () => contactsApi.get(contactId!),
@@ -53,6 +60,7 @@ const ManufacturedHomeNew: React.FC = () => {
       address: "",
       inspectionDate: new Date().toISOString().slice(0, 10),
       contactId: contactId || "",
+      appointmentId: appointmentId || "",
     },
   });
 
@@ -70,6 +78,17 @@ const ManufacturedHomeNew: React.FC = () => {
     try {
       if (user) {
         const organization = await getMyOrganization();
+        let apptId = values.appointmentId;
+        if (!apptId) {
+          const appointment = await appointmentsApi.create({
+            user_id: user.id,
+            title: values.title,
+            appointment_date: new Date(values.inspectionDate).toISOString(),
+            address: values.address,
+            contact_id: values.contactId || undefined,
+          });
+          apptId = appointment.id;
+        }
         const report = await dbCreateReport(
           {
             title: values.title,
@@ -78,11 +97,12 @@ const ManufacturedHomeNew: React.FC = () => {
             inspectionDate: values.inspectionDate,
             contact_id: values.contactId,
             reportType: "manufactured_home_insurance_prep",
-            appointment_id: appointmentId || undefined,
+            appointment_id: apptId,
           },
           user.id,
           organization?.id
         );
+        await appointmentsApi.update(apptId, { report_id: report.id });
         toast({ title: "Manufactured home report created" });
         nav(`/reports/${report.id}`);
       } else {
@@ -145,6 +165,30 @@ const ManufacturedHomeNew: React.FC = () => {
                           <SelectItem key={c.id} value={c.id}>
                             {c.first_name} {c.last_name}
                             {c.email && <span className="text-muted-foreground ml-2">({c.email})</span>}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="appointmentId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Appointment</FormLabel>
+                  <FormControl>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select an appointment..." />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {appointments.map((a) => (
+                          <SelectItem key={a.id} value={a.id}>
+                            {a.title} - {new Date(a.appointment_date).toLocaleDateString()}
                           </SelectItem>
                         ))}
                       </SelectContent>

--- a/src/pages/RoofCertificationNew.tsx
+++ b/src/pages/RoofCertificationNew.tsx
@@ -13,7 +13,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { toast } from "@/components/ui/use-toast";
 import { useAuth } from "@/contexts/AuthContext";
 import { dbCreateReport } from "@/integrations/supabase/reportsApi";
-import { contactsApi } from "@/integrations/supabase/crmApi";
+import { appointmentsApi, contactsApi } from "@/integrations/supabase/crmApi";
 import { getMyOrganization } from "@/integrations/supabase/organizationsApi";
 
 const schema = z.object({
@@ -22,6 +22,7 @@ const schema = z.object({
   address: z.string().min(1, "Address is required"),
   inspectionDate: z.string().min(1, "Required"),
   contactId: z.string().optional(),
+  appointmentId: z.string().optional(),
 });
 
 type Values = z.infer<typeof schema>;
@@ -39,6 +40,12 @@ const RoofCertificationNew: React.FC = () => {
     enabled: !!user,
   });
 
+  const { data: appointments = [] } = useQuery({
+    queryKey: ["appointments", user?.id],
+    queryFn: () => appointmentsApi.getUpcoming(user!.id, 50),
+    enabled: !!user,
+  });
+
   const { data: contact } = useQuery({
     queryKey: ["contact", contactId],
     queryFn: () => contactsApi.get(contactId!),
@@ -53,6 +60,7 @@ const RoofCertificationNew: React.FC = () => {
       address: "",
       inspectionDate: new Date().toISOString().slice(0, 10),
       contactId: contactId || "",
+      appointmentId: appointmentId || "",
     },
   });
 
@@ -70,6 +78,17 @@ const RoofCertificationNew: React.FC = () => {
     try {
       if (user) {
         const organization = await getMyOrganization();
+        let apptId = values.appointmentId;
+        if (!apptId) {
+          const appointment = await appointmentsApi.create({
+            user_id: user.id,
+            title: values.title,
+            appointment_date: new Date(values.inspectionDate).toISOString(),
+            address: values.address,
+            contact_id: values.contactId || undefined,
+          });
+          apptId = appointment.id;
+        }
         const report = await dbCreateReport(
           {
             title: values.title,
@@ -78,11 +97,12 @@ const RoofCertificationNew: React.FC = () => {
             inspectionDate: values.inspectionDate,
             contact_id: values.contactId,
             reportType: "roof_certification_nationwide",
-            appointment_id: appointmentId || undefined,
+            appointment_id: apptId,
           },
           user.id,
           organization?.id
         );
+        await appointmentsApi.update(apptId, { report_id: report.id });
         toast({ title: "Roof certification report created" });
         nav(`/reports/${report.id}`);
       } else {
@@ -145,6 +165,30 @@ const RoofCertificationNew: React.FC = () => {
                           <SelectItem key={c.id} value={c.id}>
                             {c.first_name} {c.last_name}
                             {c.email && <span className="text-muted-foreground ml-2">({c.email})</span>}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="appointmentId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Appointment</FormLabel>
+                  <FormControl>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select an appointment..." />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {appointments.map((a) => (
+                          <SelectItem key={a.id} value={a.id}>
+                            {a.title} - {new Date(a.appointment_date).toLocaleDateString()}
                           </SelectItem>
                         ))}
                       </SelectContent>

--- a/src/pages/TxWindstormNew.tsx
+++ b/src/pages/TxWindstormNew.tsx
@@ -13,7 +13,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { toast } from "@/components/ui/use-toast";
 import { useAuth } from "@/contexts/AuthContext";
 import { dbCreateReport } from "@/integrations/supabase/reportsApi";
-import { contactsApi } from "@/integrations/supabase/crmApi";
+import { appointmentsApi, contactsApi } from "@/integrations/supabase/crmApi";
 import { getMyOrganization } from "@/integrations/supabase/organizationsApi";
 
 const schema = z.object({
@@ -22,6 +22,7 @@ const schema = z.object({
   address: z.string().min(1, "Address is required"),
   inspectionDate: z.string().min(1, "Required"),
   contactId: z.string().optional(),
+  appointmentId: z.string().optional(),
 });
 
 type Values = z.infer<typeof schema>;
@@ -39,6 +40,12 @@ const TxWindstormNew: React.FC = () => {
     enabled: !!user,
   });
 
+  const { data: appointments = [] } = useQuery({
+    queryKey: ["appointments", user?.id],
+    queryFn: () => appointmentsApi.getUpcoming(user!.id, 50),
+    enabled: !!user,
+  });
+
   const { data: contact } = useQuery({
     queryKey: ["contact", contactId],
     queryFn: () => contactsApi.get(contactId!),
@@ -53,6 +60,7 @@ const TxWindstormNew: React.FC = () => {
       address: "",
       inspectionDate: new Date().toISOString().slice(0, 10),
       contactId: contactId || "",
+      appointmentId: appointmentId || "",
     },
   });
 
@@ -70,6 +78,17 @@ const TxWindstormNew: React.FC = () => {
     try {
       if (user) {
         const organization = await getMyOrganization();
+        let apptId = values.appointmentId;
+        if (!apptId) {
+          const appointment = await appointmentsApi.create({
+            user_id: user.id,
+            title: values.title,
+            appointment_date: new Date(values.inspectionDate).toISOString(),
+            address: values.address,
+            contact_id: values.contactId || undefined,
+          });
+          apptId = appointment.id;
+        }
         const report = await dbCreateReport(
           {
             title: values.title,
@@ -78,11 +97,12 @@ const TxWindstormNew: React.FC = () => {
             inspectionDate: values.inspectionDate,
             contact_id: values.contactId,
             reportType: "tx_coastal_windstorm_mitigation",
-            appointment_id: appointmentId || undefined,
+            appointment_id: apptId,
           },
           user.id,
           organization?.id
         );
+        await appointmentsApi.update(apptId, { report_id: report.id });
         toast({ title: "TX windstorm report created" });
         nav(`/reports/${report.id}`);
       } else {
@@ -145,6 +165,30 @@ const TxWindstormNew: React.FC = () => {
                           <SelectItem key={c.id} value={c.id}>
                             {c.first_name} {c.last_name}
                             {c.email && <span className="text-muted-foreground ml-2">({c.email})</span>}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="appointmentId"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Appointment</FormLabel>
+                  <FormControl>
+                    <Select value={field.value} onValueChange={field.onChange}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select an appointment..." />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {appointments.map((a) => (
+                          <SelectItem key={a.id} value={a.id}>
+                            {a.title} - {new Date(a.appointment_date).toLocaleDateString()}
                           </SelectItem>
                         ))}
                       </SelectContent>


### PR DESCRIPTION
## Summary
- load upcoming appointments in new report forms and add appointment selector
- link selected or newly created appointment to generated report

## Testing
- `npm test` *(fails: Module did not self-register: '/workspace/your-next-web-adventure/node_modules/canvas/build/Release/canvas.node')*


------
https://chatgpt.com/codex/tasks/task_e_68c0a3729a508333a4f422e96d13148a