### PR TITLE
Use plural contacts alias in appointments API

### DIFF
--- a/src/integrations/supabase/crmApi.ts
+++ b/src/integrations/supabase/crmApi.ts
@@ -105,7 +105,7 @@ export const appointmentsApi = {
       .from('appointments')
       .select(`
         *,
-        contact:contacts(first_name, last_name, email, phone),
+        contacts:contacts(first_name, last_name, email, phone),
         report:reports(title, status)
       `)
       .eq('user_id', userId)

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -853,9 +853,9 @@ const Calendar: React.FC = () => {
                                                                 {format(new Date(appointment.appointment_date), "MMM d, yyyy 'at' h:mm a")}
                                                                 {appointment.location && ` • ${appointment.location}`}
                                                             </p>
-                                                            {(appointment as any).contact && (
+                                                            {(appointment as any).contacts && (
                                                                 <p className="text-sm text-muted-foreground">
-                                                                    {(appointment as any).contact.first_name} {(appointment as any).contact.last_name}
+                                                                    {(appointment as any).contacts.first_name} {(appointment as any).contacts.last_name}
                                                                 </p>
                                                             )}
                                                             {appointment.description && (
@@ -921,7 +921,7 @@ const Calendar: React.FC = () => {
                         appointment={previewAppointment}
                         isOpen={!!previewAppointment}
                         onOpenChange={(open) => !open && setPreviewAppointment(null)}
-                        contact={(previewAppointment as any)?.contacts || (previewAppointment as any)?.contact}
+                        contact={(previewAppointment as any)?.contacts}
                         onNavigate={navigate}
                     />
 


### PR DESCRIPTION
## Summary
- use `contacts` alias when listing appointments from Supabase
- update Calendar page to reference `appointment.contacts` consistently

## Testing
- `npm test` *(fails: Module did not self-register: canvas.node)*
- `npm run lint` *(fails: 398 errors, 47 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c0adea274883339f4662bf7cc9ed2a