### PR TITLE
fix: invalidate contacts by user

### DIFF
--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -148,7 +148,7 @@ const Calendar: React.FC = () => {
     const createContactMutation = useMutation({
         mutationFn: contactsApi.create,
         onSuccess: (newContact) => {
-            queryClient.invalidateQueries({queryKey: ["contacts"]});
+            queryClient.invalidateQueries({queryKey: ["contacts", user!.id]});
             toast.success("Contact created successfully");
             setIsContactDialogOpen(false);
             contactForm.reset();


### PR DESCRIPTION
## Summary
- ensure contact creation invalidates query cache for the specific user

## Testing
- `npm test` *(fails: Module did not self-register: '/workspace/your-next-web-adventure/node_modules/canvas/build/Release/canvas.node')*
- `npm run lint` *(fails: 445 problems (398 errors, 47 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68c0b19abd408333b931eccc8f18280d