### PR TITLE
Ensure appointment API receives ISO-formatted dates

### DIFF
--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -220,6 +220,7 @@ const Calendar: React.FC = () => {
     const onSubmit = (data: any) => {
         const appointmentData = {
             ...data,
+            appointment_date: new Date(data.appointment_date).toISOString(),
             user_id: user!.id,
             contact_id: data.contact_id || null,
         };
@@ -326,7 +327,7 @@ const Calendar: React.FC = () => {
         const appointmentData = {
             title: appointment.title,
             description: appointment.description,
-            appointment_date: finalDate.toISOString(),
+            appointment_date: new Date(finalDate).toISOString(),
             duration_minutes: appointment.duration_minutes,
             location: appointment.location,
             contact_id: appointment.contact_id,


### PR DESCRIPTION
## Summary
- Convert `appointment_date` to ISO string before creating or updating appointments
- Apply the same conversion when confirming time changes so updates use ISO strings

## Testing
- `npm test` *(fails: Module did not self-register: '/workspace/your-next-web-adventure/node_modules/canvas/build/Release/canvas.node')*
- `npm run lint` *(fails: 445 problems including `@typescript-eslint/no-explicit-any` errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b469648883338f5a96c248dd1dba