### PR TITLE
feat: show placeholder when no calendar appointments

### DIFF
--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -762,14 +762,23 @@ const Calendar: React.FC = () => {
                                 </CardTitle>
                             </CardHeader>
                             <CardContent>
-                <DraggableCalendarGrid
-                    appointments={appointments}
-                    selectedDate={selectedDate}
-                    onDateSelect={setSelectedDate}
-                    onAppointmentDrop={handleAppointmentDrop}
-                    calendarSettings={calendarSettings}
-                    contacts={contacts}
-                />
+                                {appointments.length === 0 ? (
+                                    <div className="flex flex-col items-center justify-center py-8 text-center">
+                                        <p className="text-muted-foreground mb-4">
+                                            Your calendar is intentionally empty. Click refresh to sync the latest appointments.
+                                        </p>
+                                        <Button onClick={handleSync}>Refresh</Button>
+                                    </div>
+                                ) : (
+                                    <DraggableCalendarGrid
+                                        appointments={appointments}
+                                        selectedDate={selectedDate}
+                                        onDateSelect={setSelectedDate}
+                                        onAppointmentDrop={handleAppointmentDrop}
+                                        calendarSettings={calendarSettings}
+                                        contacts={contacts}
+                                    />
+                                )}
                             </CardContent>
                         </Card>
 


### PR DESCRIPTION
## Summary
- show an empty state in Calendar view with guidance and refresh button when no appointments are loaded

## Testing
- `npm test` (fails: Module did not self-register: canvas.node)
- `npm run lint` (fails: Unexpected any, A require() style import is forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c0b7d13f18833399c142dff46a9a93