### PR TITLE
fix: remove duplicated date-fns imports in calendar grids

### DIFF
--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -1,9 +1,25 @@
 import React from "react";
-import { format, startOfMonth, endOfMonth, startOfWeek, endOfWeek, addDays, isSameMonth, isSameDay, isToday, startOfDay, endOfDay, addWeeks, startOfWeek as getWeekStart, endOfWeek as getWeekEnd } from "date-fns";
+import {
+  format,
+  startOfMonth,
+  endOfMonth,
+  startOfWeek,
+  endOfWeek,
+  addDays,
+  isSameMonth,
+  isSameDay,
+  isToday,
+  startOfDay,
+  endOfDay,
+  addWeeks,
+} from "date-fns";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { ChevronLeft, ChevronRight, Calendar, CalendarDays, Clock } from "lucide-react";
 import type { Appointment } from "@/lib/crmSchemas";
+
+const getWeekStart = startOfWeek;
+const getWeekEnd = endOfWeek;
 
 type ViewMode = "day" | "week" | "month";
 

--- a/src/components/calendar/DraggableCalendarGrid.tsx
+++ b/src/components/calendar/DraggableCalendarGrid.tsx
@@ -1,11 +1,27 @@
 import React from "react";
-import { format, startOfMonth, endOfMonth, startOfWeek, endOfWeek, addDays, isSameMonth, isSameDay, isToday, startOfDay, endOfDay, addWeeks, startOfWeek as getWeekStart, endOfWeek as getWeekEnd } from "date-fns";
+import {
+  format,
+  startOfMonth,
+  endOfMonth,
+  startOfWeek,
+  endOfWeek,
+  addDays,
+  isSameMonth,
+  isSameDay,
+  isToday,
+  startOfDay,
+  endOfDay,
+  addWeeks,
+} from "date-fns";
 import { DragDropContext, Droppable, Draggable, DropResult } from "@hello-pangea/dnd";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { ChevronLeft, ChevronRight, Calendar, CalendarDays, Clock } from "lucide-react";
 import type { Appointment, Contact } from "@/lib/crmSchemas";
 import type { CalendarSettings } from "./CalendarSettingsDialog";
+
+const getWeekStart = startOfWeek;
+const getWeekEnd = endOfWeek;
 
 type ViewMode = "day" | "week" | "month";
 


### PR DESCRIPTION
## Summary
- remove duplicate `startOfWeek` and `endOfWeek` imports
- define `getWeekStart` and `getWeekEnd` local aliases

## Testing
- `npm run lint` *(fails: Unexpected any, require import forbidden)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0be3b7f1083339bb7dfe34d03f0e4