### PR TITLE
feat: add route metrics to optimizer

### DIFF
--- a/src/components/maps/EnhancedRouteOptimizer.tsx
+++ b/src/components/maps/EnhancedRouteOptimizer.tsx
@@ -78,11 +78,13 @@ export function EnhancedRouteOptimizer({
     try {
       // Build addresses array starting with home base
       const addresses = [settings.home_base_formatted_address];
-      
+      const appointmentsWithLocation: Appointment[] = [];
+
       // Add appointment locations
-      appointments.forEach(apt => {
+      appointments.forEach((apt) => {
         if (apt.location) {
           addresses.push(apt.location);
+          appointmentsWithLocation.push(apt);
         }
       });
 
@@ -93,17 +95,18 @@ export function EnhancedRouteOptimizer({
 
       // Get optimized route from Google Maps
       const route = await getOptimizedRoute(addresses);
-      
-      // Calculate total distance and duration (mock calculation for now)
-      const totalDistance = Math.random() * 50 + 20; // Mock: 20-70 miles
-      const totalDuration = Math.random() * 180 + 60; // Mock: 60-240 minutes
+      const totalDistance = route.totalDistanceMiles;
+      const totalDuration = route.totalDurationMinutes;
       const estimatedCost = totalDistance * (settings.mileage_rate || 0.67);
+      const optimizedOrder = route.waypointOrder.map(
+        (i) => appointmentsWithLocation[i].id
+      );
 
       // Save route to database
       const dailyRoute = await routeOptimizationApi.createOrUpdateDailyRoute({
         user_id: '', // Will be set by RLS
         route_date: selectedDate,
-        optimized_order: appointments.map(apt => apt.id),
+        optimized_order: optimizedOrder,
         total_distance_miles: totalDistance,
         total_duration_minutes: totalDuration,
         estimated_fuel_cost: estimatedCost,

--- a/src/components/maps/routeOptimizer.ts
+++ b/src/components/maps/routeOptimizer.ts
@@ -4,6 +4,9 @@ import { toast } from "@/hooks/use-toast";
 export interface OptimizedRoute {
   googleMapsUrl: string;
   wazeUrl: string;
+  totalDistanceMiles: number;
+  totalDurationMinutes: number;
+  waypointOrder: number[];
 }
 
 /**
@@ -55,7 +58,25 @@ export async function getOptimizedRoute(addresses: string[]): Promise<OptimizedR
       .map((c) => `&to=${c}`)
       .join("")}&navigate=yes`;
 
-    return { googleMapsUrl, wazeUrl };
+    const legs = result.routes[0].legs;
+    const totalDistanceMeters = legs.reduce(
+      (sum, leg) => sum + (leg.distance?.value || 0),
+      0
+    );
+    const totalDurationSeconds = legs.reduce(
+      (sum, leg) => sum + (leg.duration?.value || 0),
+      0
+    );
+    const totalDistanceMiles = totalDistanceMeters / 1609.344;
+    const totalDurationMinutes = totalDurationSeconds / 60;
+
+    return {
+      googleMapsUrl,
+      wazeUrl,
+      totalDistanceMiles,
+      totalDurationMinutes,
+      waypointOrder: order,
+    };
   } catch (error) {
     console.error("Error optimizing route:", error);
     toast({


### PR DESCRIPTION
## Summary
- extend Google Maps route optimizer to return distance, duration, and waypoint order
- persist real route metrics instead of random values in route optimizer and calendar auto-optimization

## Testing
- `npm run lint` (fails: Unexpected any and require import errors)
- `npm test` (fails: Module did not self-register: canvas.node)

------
https://chatgpt.com/codex/tasks/task_e_68c0c6c6c7d88333b0fcb0fb01783a55