### PR TITLE
refactor: handle null daily routes

### DIFF
--- a/src/components/maps/EnhancedRouteOptimizer.tsx
+++ b/src/components/maps/EnhancedRouteOptimizer.tsx
@@ -48,7 +48,7 @@ export function EnhancedRouteOptimizer({
   const loadExistingRoute = async () => {
     try {
       const route = await routeOptimizationApi.getDailyRoute(selectedDate);
-      setExistingRoute(route);
+      setExistingRoute(route ?? null);
     } catch (error) {
       console.error('Error loading existing route:', error);
     }

--- a/src/integrations/supabase/routeOptimizationApi.ts
+++ b/src/integrations/supabase/routeOptimizationApi.ts
@@ -78,9 +78,9 @@ export const routeOptimizationApi = {
       .from('daily_routes')
       .select('*')
       .eq('route_date', date)
-      .single();
+      .maybeSingle();
 
-    if (error && error.code !== 'PGRST116') throw error;
+    if (error) throw error;
     return data;
   },
 

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -81,7 +81,7 @@ const Calendar: React.FC = () => {
                 const route = await routeOptimizationApi.getDailyRoute(
                     format(selectedDate, "yyyy-MM-dd")
                 );
-                setDailyRoute(route);
+                setDailyRoute(route ?? null);
             } catch (error) {
                 console.error("Failed to load daily route", error);
             }
@@ -396,25 +396,25 @@ const Calendar: React.FC = () => {
             const route = await routeOptimizationApi.getDailyRoute(
                 format(selectedDate, "yyyy-MM-dd")
             );
+            if (!route) {
+                toast.error("No route data available");
+                return;
+            }
 
-            if (route) {
-                setDailyRoute(route);
+            setDailyRoute(route);
 
-                const googleMapsUrl = route.google_maps_url;
-                const wazeUrl = route.waze_url;
+            const googleMapsUrl = route.google_maps_url;
+            const wazeUrl = route.waze_url;
 
-                if (googleMapsUrl || wazeUrl) {
-                    setRouteUrls({
-                        googleMapsUrl,
-                        wazeUrl,
-                        totalDistanceMiles: route.total_distance_miles,
-                        totalDurationMinutes: route.total_duration_minutes,
-                        estimatedFuelCost: route.estimated_fuel_cost,
-                    });
-                    setIsRouteDialogOpen(true);
-                } else {
-                    toast.error("No route data available");
-                }
+            if (googleMapsUrl || wazeUrl) {
+                setRouteUrls({
+                    googleMapsUrl,
+                    wazeUrl,
+                    totalDistanceMiles: route.total_distance_miles,
+                    totalDurationMinutes: route.total_duration_minutes,
+                    estimatedFuelCost: route.estimated_fuel_cost,
+                });
+                setIsRouteDialogOpen(true);
             } else {
                 toast.error("No route data available");
             }


### PR DESCRIPTION
## Summary
- use `maybeSingle` when fetching daily routes to avoid errors on missing records
- handle nullable route results in Calendar and EnhancedRouteOptimizer components

## Testing
- `npm test` *(fails: Module did not self-register: '/workspace/your-next-web-adventure/node_modules/canvas/build/Release/canvas.node')*
- `npm run lint` *(fails: 445 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d7886da48333aeea5e1673cdb296