### PR TITLE
Add chatbot integration using react-query

### DIFF
--- a/src/integrations/chatbot.ts
+++ b/src/integrations/chatbot.ts
@@ -1,0 +1,37 @@
+import { QueryClient } from "@tanstack/react-query";
+import { supabase, SUPABASE_URL } from "@/integrations/supabase/client";
+
+export type ChatMessage = {
+  role: string;
+  content: string;
+};
+
+const queryClient = new QueryClient();
+
+export async function sendMessage(
+  messages: ChatMessage[],
+): Promise<ReadableStream<Uint8Array>> {
+  return queryClient.fetchQuery<ReadableStream<Uint8Array>>({
+    queryKey: ["chatbot", messages],
+    queryFn: async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      const res = await fetch(`${SUPABASE_URL}/functions/v1/chatbot`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session?.access_token}`,
+        },
+        body: JSON.stringify({ messages }),
+      });
+      if (!res.ok || !res.body) {
+        throw new Error("Chatbot request failed");
+      }
+      return res.body;
+    },
+    retry: 3,
+  });
+}
+
+export default { sendMessage };


### PR DESCRIPTION
## Summary
- add chatbot integration with sendMessage using React Query caching and retries
- include Supabase JWT in chatbot requests

## Testing
- `npm test` (errors: Module did not self-register: 'canvas')
- `npm run lint` (errors: 450 problems)

------
https://chatgpt.com/codex/tasks/task_e_68c0ebd1ffbc83338009aca217be47cb