### PR TITLE
Add lazy-loaded ChatWidget for authenticated pages

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,17 +1,29 @@
 import React from "react";
+import { useAuth } from "@/contexts/AuthContext";
+
+const ChatWidget = React.lazy(() => import("@/components/chat/ChatWidget"));
 
 const Footer: React.FC = () => {
+  const { user } = useAuth();
+
   return (
-    <footer className="border-t">
-      <div className="max-w-7xl mx-auto px-4 py-8 text-sm text-muted-foreground flex flex-col md:flex-row items-center justify-between gap-4">
-        <p>© {new Date().getFullYear()} Home Report Pro. All rights reserved.</p>
-        <nav className="flex items-center gap-4">
-          <a href="#features" className="hover:text-foreground">Features</a>
-          <a href="/documentation" className="hover:text-foreground">Documentation</a>
-          <a href="/support" className="hover:text-foreground">Support</a>
-        </nav>
-      </div>
-    </footer>
+    <>
+      <footer className="border-t">
+        <div className="max-w-7xl mx-auto px-4 py-8 text-sm text-muted-foreground flex flex-col md:flex-row items-center justify-between gap-4">
+          <p>© {new Date().getFullYear()} Home Report Pro. All rights reserved.</p>
+          <nav className="flex items-center gap-4">
+            <a href="#features" className="hover:text-foreground">Features</a>
+            <a href="/documentation" className="hover:text-foreground">Documentation</a>
+            <a href="/support" className="hover:text-foreground">Support</a>
+          </nav>
+        </div>
+      </footer>
+      {user && (
+        <React.Suspense fallback={null}>
+          <ChatWidget />
+        </React.Suspense>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- lazy load ChatWidget so it doesn't block critical rendering
- render ChatWidget in footer for signed-in users only

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm test` *(fails: Module did not self-register: canvas.node)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ee8bb18483339b92b5376953899d