### PR TITLE
feat: document chatbot tools and enable auto tool calls

### DIFF
--- a/supabase/functions/chatbot/index.test.ts
+++ b/supabase/functions/chatbot/index.test.ts
@@ -1,0 +1,66 @@
+import { ReadableStream } from 'stream/web'
+
+describe('chatbot tool call streaming', () => {
+  const createSSEStream = (toolName: string) => {
+    const encoder = new TextEncoder()
+    const chunks = [
+      `data: ${JSON.stringify({ choices: [{ delta: { tool_calls: [{ id: 'tool_1', type: 'function', function: { name: toolName, arguments: '{}' } }] }, index: 0, finish_reason: null }] })}\n`,
+      `data: ${JSON.stringify({ choices: [{ delta: {}, index: 0, finish_reason: 'tool_calls' }] })}\n`,
+      'data: [DONE]\n',
+    ]
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const c of chunks) {
+          controller.enqueue(encoder.encode(c))
+        }
+        controller.close()
+      },
+    })
+  }
+
+  const extractToolCall = async (stream: ReadableStream<Uint8Array>) => {
+    const reader = stream.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+    let tool: string | null = null
+    outer: while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split('\n')
+      buffer = lines.pop() || ''
+      for (const line of lines) {
+        if (line.startsWith('data: ')) {
+          const data = line.slice(6)
+          if (data === '[DONE]') continue
+          const parsed = JSON.parse(data)
+          const delta = parsed.choices?.[0]?.delta
+          if (delta?.tool_calls) {
+            tool = delta.tool_calls[0]?.function?.name || null
+          }
+          const finish = parsed.choices?.[0]?.finish_reason
+          if (finish === 'tool_calls') {
+            break outer
+          }
+        }
+      }
+    }
+    return tool
+  }
+
+  const tools = [
+    'create_account',
+    'create_contact',
+    'create_report',
+    'create_task',
+    'create_appointment',
+  ] as const
+
+  for (const tool of tools) {
+    it(`detects ${tool} tool call`, async () => {
+      const stream = createSSEStream(tool)
+      const found = await extractToolCall(stream)
+      expect(found).toBe(tool)
+    })
+  }
+})

--- a/supabase/functions/chatbot/index.ts
+++ b/supabase/functions/chatbot/index.ts
@@ -343,7 +343,14 @@ serve(async (req) => {
       "You are a HomeReportPro support assistant. This is a home inspection reporting platform that helps inspectors create professional reports, manage appointments, and organize contacts.";
 
     const systemPrompt =
-      "You are a helpful support assistant for HomeReportPro. Answer using the provided context. If you're uncertain about something, mention it in your response. Use Markdown formatting (lists, tables, code blocks) whenever it improves clarity.";
+      "You are a helpful support assistant for HomeReportPro. Answer using the provided context. If you're uncertain about something, mention it in your response. Use Markdown formatting (lists, tables, code blocks) whenever it improves clarity.\n\n" +
+      "Available tools:\n" +
+      "- create_account: create a new account record\n" +
+      "- create_contact: create a new contact\n" +
+      "- create_report: create a new report\n" +
+      "- create_task: create a new task\n" +
+      "- create_appointment: create a new appointment\n\n" +
+      "When a user requests any of these actions, call the corresponding tool with the required arguments.";
     const userPrompt = `Context:\n${fallbackContext}\n\nQuestion: ${question}`;
     const userMessageContent = image
       ? [
@@ -368,6 +375,7 @@ serve(async (req) => {
         max_tokens: 1500,
         stream: true,
         tools,
+        tool_choice: "auto",
         response_format: "markdown",
       }),
     });


### PR DESCRIPTION
## Summary
- expand system prompt with instructions for create_account/contact/report/task/appointment tools
- allow OpenAI to invoke tools automatically with `tool_choice: "auto"`
- add tests verifying tool calls appear in streamed responses for each create action

## Testing
- `npm test` *(fails: TestingLibraryElementError: Unable to find a label with the text of: /upload image/i)*
- `npx vitest run supabase/functions/chatbot/index.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c1716f12f083338fbe30761cf82d8d