### PR TITLE
feat: enforce tool invocation in chatbot system prompt

### DIFF
--- a/supabase/functions/chatbot/index.ts
+++ b/supabase/functions/chatbot/index.ts
@@ -350,7 +350,7 @@ serve(async (req) => {
       "- create_report: create a new report\n" +
       "- create_task: create a new task\n" +
       "- create_appointment: create a new appointment\n\n" +
-      "When a user requests any of these actions, call the corresponding tool with the required arguments.";
+      "Always invoke the matching tool. If required fields are missing, call the tool with placeholders and then ask for the missing data.";
     const userPrompt = `Context:\n${fallbackContext}\n\nQuestion: ${question}`;
     const userMessageContent = image
       ? [


### PR DESCRIPTION
## Summary
- direct the chatbot system prompt to always invoke the matching tool
- instruct using placeholders when required fields are missing and then request the data

## Testing
- `npm test` (fails: Unable to find a label for upload image)
- `npm run lint` (fails: 480 problems)

------
https://chatgpt.com/codex/tasks/task_e_68c17e4b053083339a2fca0d3b20b515